### PR TITLE
Hostname template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.testnet
+.testnets

--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ localnet-build-dlv:
 
 localnet-build-nodes:
 	$(DOCKER) run --rm -v $(CURDIR)/.testnets:/data babylonchain/babylond \
-			  testnet init-files --v 4 -o /data --starting-ip-address babylonnode{i} --keyring-backend=test
+			  testnet init-files --v 4 -o /data --starting-ip-address 192.168.10.2 --keyring-backend=test
 	docker-compose up -d
 
 localnet-stop:

--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ localnet-build-dlv:
 
 localnet-build-nodes:
 	$(DOCKER) run --rm -v $(CURDIR)/.testnets:/data babylonchain/babylond \
-			  testnet init-files --v 4 -o /data --starting-ip-address 192.168.10.2 --keyring-backend=test
+			  testnet init-files --v 4 -o /data --starting-ip-address babylonnode{i} --keyring-backend=test
 	docker-compose up -d
 
 localnet-stop:

--- a/contrib/images/Makefile
+++ b/contrib/images/Makefile
@@ -13,7 +13,7 @@ babylond-rmi:
 
 bitcoinsim:
 	docker build --tag babylonchain/bitcoinsim -f bitcoinsim/Dockerfile \
-        	$(shell git rev-parse --show-toplevel)
+        	$(shell git rev-parse --show-toplevel)/contrib/images/bitcoinsim
 
 bitcoinsim-rmi:
 	docker rmi babylonchain/bitcoinsim 2>/dev/null; true

--- a/contrib/images/bitcoinsim/Dockerfile
+++ b/contrib/images/bitcoinsim/Dockerfile
@@ -18,8 +18,8 @@ RUN apk add bash expect expect-dev
 WORKDIR /bitcoinsim
 
 COPY --from=build /go/bin/* /usr/bin/
-COPY contrib/images/bitcoinsim/wrapper.sh /bitcoinsim/wrapper.sh
-COPY contrib/images/bitcoinsim/btcwallet_create.exp /bitcoinsim/btcwallet_create.exp
+COPY wrapper.sh /bitcoinsim/wrapper.sh
+COPY btcwallet_create.exp /bitcoinsim/btcwallet_create.exp
 
 ENV RPCUSER=rpcuser
 ENV RPCPASS=rpcpass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,8 +91,8 @@ services:
 
   bitcoinsim:
     build:
-      context: ./
-      dockerfile: ./contrib/images/bitcoinsim/Dockerfile
+      context: ./contrib/images/bitcoinsim/
+      dockerfile: ./Dockerfile
     image: babylonchain/bitcoinsim:latest
     container_name: bitcoinsim
     ports:


### PR DESCRIPTION
This PR allows the `testnet` command that set up `-v` number of nodes to use a hostname template in `--starting-ip-address` rather than an IP address. The template only works for `{i}` and replaces it with `0, 1, 2, ...`. 

This is so that we can use predictable hostnames when deploying to AWS, when we don't know the IP addresses up front. 

The IP/hostname becomes part of the `memo` field of the transaction that creates the validator and is signed, so it can't be modified later. The `genutil` module of the Cosmos SDK [collects](https://github.com/cosmos/cosmos-sdk/blob/3e492d4bcae76b715bed89215c70fad13aa9f20a/x/genutil/collect.go#L38) these [memos](https://github.com/cosmos/cosmos-sdk/blob/3e492d4bcae76b715bed89215c70fad13aa9f20a/x/genutil/collect.go#L129) and puts them in the `persistent_peers` of `.testnets/node0/babylond/config/config.toml`, and for `node1` etc.

Although, for provisioning a network, it should also be possible to just edit the `config.toml` files and modify the seed and/or persistent node list, surely they don't have to match the transaction memos. They are probably there as a convenience mechanism conjured up by the Cosmos developers.