### PR TITLE
prepare-genesis cmd: Add flags related to inflation

### DIFF
--- a/cmd/babylond/cmd/flags.go
+++ b/cmd/babylond/cmd/flags.go
@@ -15,6 +15,9 @@ const (
 	flagBaseBtcHeaderHex       = "btc-base-header"
 	flagBaseBtcHeaderHeight    = "btc-base-header-height"
 	flagGenesisTime            = "genesis-time"
+	flagInflationRateChange    = "inflation-rate-change"
+	flagInflationMax           = "inflation-max"
+	flagInflationMin           = "inflation-min"
 )
 
 type GenesisCLIArgs struct {
@@ -25,6 +28,9 @@ type GenesisCLIArgs struct {
 	EpochInterval          uint64
 	BaseBtcHeaderHex       string
 	BaseBtcHeaderHeight    uint64
+	InflationRateChange    float64
+	InflationMax           float64
+	InflationMin           float64
 	GenesisTime            time.Time
 }
 
@@ -42,6 +48,9 @@ func addGenesisFlags(cmd *cobra.Command) {
 	cmd.Flags().String(flagBaseBtcHeaderHex, "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a45068653ffff7f2002000000", "Hex of the base Bitcoin header.")
 	cmd.Flags().Uint64(flagBaseBtcHeaderHeight, 0, "Height of the base Bitcoin header.")
 	cmd.Flags().Int64(flagGenesisTime, time.Now().Unix(), "Genesis time")
+	cmd.Flags().Float64(flagInflationRateChange, 0.13, "Inflation rate change")
+	cmd.Flags().Float64(flagInflationMax, 0.2, "Maximum inflation")
+	cmd.Flags().Float64(flagInflationMin, 0.07, "Minimum inflation")
 }
 
 func parseGenesisFlags(cmd *cobra.Command) *GenesisCLIArgs {
@@ -53,6 +62,9 @@ func parseGenesisFlags(cmd *cobra.Command) *GenesisCLIArgs {
 	baseBtcHeaderHex, _ := cmd.Flags().GetString(flagBaseBtcHeaderHex)
 	baseBtcHeaderHeight, _ := cmd.Flags().GetUint64(flagBaseBtcHeaderHeight)
 	genesisTimeUnix, _ := cmd.Flags().GetInt64(flagGenesisTime)
+	inflationRateChange, _ := cmd.Flags().GetFloat64(flagInflationRateChange)
+	inflationMax, _ := cmd.Flags().GetFloat64(flagInflationMax)
+	inflationMin, _ := cmd.Flags().GetFloat64(flagInflationMin)
 
 	if chainID == "" {
 		chainID = "chain-" + tmrand.NewRand().Str(6)
@@ -69,5 +81,8 @@ func parseGenesisFlags(cmd *cobra.Command) *GenesisCLIArgs {
 		BaseBtcHeaderHeight:    baseBtcHeaderHeight,
 		BaseBtcHeaderHex:       baseBtcHeaderHex,
 		GenesisTime:            genesisTime,
+		InflationRateChange:    inflationRateChange,
+		InflationMax:           inflationMax,
+		InflationMin:           inflationMin,
 	}
 }

--- a/cmd/babylond/cmd/flags.go
+++ b/cmd/babylond/cmd/flags.go
@@ -14,10 +14,12 @@ const (
 	flagBtcFinalizationTimeout = "btc-finalization-timeout"
 	flagBaseBtcHeaderHex       = "btc-base-header"
 	flagBaseBtcHeaderHeight    = "btc-base-header-height"
-	flagGenesisTime            = "genesis-time"
 	flagInflationRateChange    = "inflation-rate-change"
 	flagInflationMax           = "inflation-max"
 	flagInflationMin           = "inflation-min"
+	flagGoalBonded             = "goal-bonded"
+	flagBlocksPerYear          = "blocks-per-year"
+	flagGenesisTime            = "genesis-time"
 )
 
 type GenesisCLIArgs struct {
@@ -31,6 +33,8 @@ type GenesisCLIArgs struct {
 	InflationRateChange    float64
 	InflationMax           float64
 	InflationMin           float64
+	GoalBonded             float64
+	BlocksPerYear          uint64
 	GenesisTime            time.Time
 }
 
@@ -47,10 +51,12 @@ func addGenesisFlags(cmd *cobra.Command) {
 	// Genesis header for the simnet
 	cmd.Flags().String(flagBaseBtcHeaderHex, "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a45068653ffff7f2002000000", "Hex of the base Bitcoin header.")
 	cmd.Flags().Uint64(flagBaseBtcHeaderHeight, 0, "Height of the base Bitcoin header.")
-	cmd.Flags().Int64(flagGenesisTime, time.Now().Unix(), "Genesis time")
 	cmd.Flags().Float64(flagInflationRateChange, 0.13, "Inflation rate change")
 	cmd.Flags().Float64(flagInflationMax, 0.2, "Maximum inflation")
 	cmd.Flags().Float64(flagInflationMin, 0.07, "Minimum inflation")
+	cmd.Flags().Float64(flagGoalBonded, 0.67, "Bonded tokens goal")
+	cmd.Flags().Uint64(flagBlocksPerYear, 6311520, "Blocks per year")
+	cmd.Flags().Int64(flagGenesisTime, time.Now().Unix(), "Genesis time")
 }
 
 func parseGenesisFlags(cmd *cobra.Command) *GenesisCLIArgs {
@@ -65,6 +71,8 @@ func parseGenesisFlags(cmd *cobra.Command) *GenesisCLIArgs {
 	inflationRateChange, _ := cmd.Flags().GetFloat64(flagInflationRateChange)
 	inflationMax, _ := cmd.Flags().GetFloat64(flagInflationMax)
 	inflationMin, _ := cmd.Flags().GetFloat64(flagInflationMin)
+	goalBonded, _ := cmd.Flags().GetFloat64(flagGoalBonded)
+	blocksPerYear, _ := cmd.Flags().GetUint64(flagBlocksPerYear)
 
 	if chainID == "" {
 		chainID = "chain-" + tmrand.NewRand().Str(6)
@@ -84,5 +92,7 @@ func parseGenesisFlags(cmd *cobra.Command) *GenesisCLIArgs {
 		InflationRateChange:    inflationRateChange,
 		InflationMax:           inflationMax,
 		InflationMin:           inflationMin,
+		GoalBonded:             goalBonded,
+		BlocksPerYear:          blocksPerYear,
 	}
 }

--- a/cmd/babylond/cmd/genesis.go
+++ b/cmd/babylond/cmd/genesis.go
@@ -65,7 +65,8 @@ Example:
 					genesisCliArgs.BtcConfirmationDepth, genesisCliArgs.BtcFinalizationTimeout,
 					genesisCliArgs.EpochInterval, genesisCliArgs.BaseBtcHeaderHex,
 					genesisCliArgs.BaseBtcHeaderHeight, genesisCliArgs.InflationRateChange,
-					genesisCliArgs.InflationMin, genesisCliArgs.InflationMax, genesisCliArgs.GenesisTime)
+					genesisCliArgs.InflationMin, genesisCliArgs.InflationMax, genesisCliArgs.GoalBonded,
+					genesisCliArgs.BlocksPerYear, genesisCliArgs.GenesisTime)
 			} else if network == "mainnet" {
 				// TODO: mainnet genesis params
 				panic("Mainnet params not implemented.")
@@ -193,7 +194,8 @@ type GenesisParams struct {
 func TestnetGenesisParams(maxActiveValidators uint32, btcConfirmationDepth uint64,
 	btcFinalizationTimeout uint64, epochInterval uint64, baseBtcHeaderHex string,
 	baseBtcHeaderHeight uint64, inflationRateChange float64,
-	inflationMin float64, inflationMax float64, genesisTime time.Time) GenesisParams {
+	inflationMin float64, inflationMax float64, goalBonded float64,
+	blocksPerYear uint64, genesisTime time.Time) GenesisParams {
 
 	genParams := GenesisParams{}
 
@@ -228,10 +230,12 @@ func TestnetGenesisParams(maxActiveValidators uint32, btcConfirmationDepth uint6
 
 	genParams.MintParams = minttypes.DefaultParams()
 	genParams.MintParams.MintDenom = genParams.NativeCoinMetadatas[0].Base
+	genParams.MintParams.BlocksPerYear = blocksPerYear
 	// This should always work as inflation rate is already a float64
 	genParams.MintParams.InflationRateChange = sdk.MustNewDecFromStr(fmt.Sprintf("%f", inflationRateChange))
 	genParams.MintParams.InflationMin = sdk.MustNewDecFromStr(fmt.Sprintf("%f", inflationMin))
 	genParams.MintParams.InflationMax = sdk.MustNewDecFromStr(fmt.Sprintf("%f", inflationMax))
+	genParams.MintParams.GoalBonded = sdk.MustNewDecFromStr(fmt.Sprintf("%f", goalBonded))
 
 	genParams.GovParams = govv1.DefaultParams()
 	genParams.GovParams.DepositParams.MinDeposit = sdk.NewCoins(sdk.NewCoin(

--- a/cmd/babylond/cmd/genesis.go
+++ b/cmd/babylond/cmd/genesis.go
@@ -64,7 +64,8 @@ Example:
 				genesisParams = TestnetGenesisParams(genesisCliArgs.MaxActiveValidators,
 					genesisCliArgs.BtcConfirmationDepth, genesisCliArgs.BtcFinalizationTimeout,
 					genesisCliArgs.EpochInterval, genesisCliArgs.BaseBtcHeaderHex,
-					genesisCliArgs.BaseBtcHeaderHeight, genesisCliArgs.GenesisTime)
+					genesisCliArgs.BaseBtcHeaderHeight, genesisCliArgs.InflationRateChange,
+					genesisCliArgs.InflationMin, genesisCliArgs.InflationMax, genesisCliArgs.GenesisTime)
 			} else if network == "mainnet" {
 				// TODO: mainnet genesis params
 				panic("Mainnet params not implemented.")
@@ -191,7 +192,8 @@ type GenesisParams struct {
 
 func TestnetGenesisParams(maxActiveValidators uint32, btcConfirmationDepth uint64,
 	btcFinalizationTimeout uint64, epochInterval uint64, baseBtcHeaderHex string,
-	baseBtcHeaderHeight uint64, genesisTime time.Time) GenesisParams {
+	baseBtcHeaderHeight uint64, inflationRateChange float64,
+	inflationMin float64, inflationMax float64, genesisTime time.Time) GenesisParams {
 
 	genParams := GenesisParams{}
 
@@ -226,6 +228,10 @@ func TestnetGenesisParams(maxActiveValidators uint32, btcConfirmationDepth uint6
 
 	genParams.MintParams = minttypes.DefaultParams()
 	genParams.MintParams.MintDenom = genParams.NativeCoinMetadatas[0].Base
+	// This should always work as inflation rate is already a float64
+	genParams.MintParams.InflationRateChange = sdk.MustNewDecFromStr(fmt.Sprintf("%f", inflationRateChange))
+	genParams.MintParams.InflationMin = sdk.MustNewDecFromStr(fmt.Sprintf("%f", inflationMin))
+	genParams.MintParams.InflationMax = sdk.MustNewDecFromStr(fmt.Sprintf("%f", inflationMax))
 
 	genParams.GovParams = govv1.DefaultParams()
 	genParams.GovParams.DepositParams.MinDeposit = sdk.NewCoins(sdk.NewCoin(

--- a/cmd/babylond/cmd/testnet.go
+++ b/cmd/babylond/cmd/testnet.go
@@ -98,7 +98,8 @@ Example:
 			genesisParams := TestnetGenesisParams(genesisCliArgs.MaxActiveValidators,
 				genesisCliArgs.BtcConfirmationDepth, genesisCliArgs.BtcFinalizationTimeout,
 				genesisCliArgs.EpochInterval, genesisCliArgs.BaseBtcHeaderHex,
-				genesisCliArgs.BaseBtcHeaderHeight, genesisCliArgs.GenesisTime)
+				genesisCliArgs.BaseBtcHeaderHeight, genesisCliArgs.InflationRateChange,
+				genesisCliArgs.InflationMin, genesisCliArgs.InflationMax, genesisCliArgs.GenesisTime)
 
 			return InitTestnet(
 				clientCtx, cmd, config, mbm, genBalIterator, outputDir, genesisCliArgs.ChainID, minGasPrices,

--- a/cmd/babylond/cmd/testnet.go
+++ b/cmd/babylond/cmd/testnet.go
@@ -99,7 +99,8 @@ Example:
 				genesisCliArgs.BtcConfirmationDepth, genesisCliArgs.BtcFinalizationTimeout,
 				genesisCliArgs.EpochInterval, genesisCliArgs.BaseBtcHeaderHex,
 				genesisCliArgs.BaseBtcHeaderHeight, genesisCliArgs.InflationRateChange,
-				genesisCliArgs.InflationMin, genesisCliArgs.InflationMax, genesisCliArgs.GenesisTime)
+				genesisCliArgs.InflationMin, genesisCliArgs.InflationMax, genesisCliArgs.GoalBonded,
+				genesisCliArgs.BlocksPerYear, genesisCliArgs.GenesisTime)
 
 			return InitTestnet(
 				clientCtx, cmd, config, mbm, genBalIterator, outputDir, genesisCliArgs.ChainID, minGasPrices,


### PR DESCRIPTION
These flags will help us control the inflation rate when we create a genesis file for testnet purposes.