### PR TITLE
feat: Checkpointing/Add fee estimation in sending BLS-sig tx

### DIFF
--- a/app/utils.go
+++ b/app/utils.go
@@ -78,6 +78,7 @@ func InitPrivSigner(clientCtx client.Context, nodeDir string, kr keyring.Keyring
 		ClientCtx: clientCtx,
 	}, nil
 }
+
 func CreateClientConfig(chainID string, backend string, homePath string) (*config.ClientConfig, error) {
 	cliConf := &config.ClientConfig{
 		ChainID:        chainID,

--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -1,6 +1,7 @@
 package tx
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -50,6 +51,11 @@ func BroadcastTx(clientCtx client.Context, txf sdktx.Factory, msgs ...sdk.Msg) (
 	if err != nil {
 		return nil, err
 	}
+
+	if adjusted <= 0 {
+		return nil, errors.New("calculated gas should be positive")
+	}
+
 	txf = txf.WithGas(adjusted)
 
 	tx, err := txf.BuildUnsignedTx(msgs...)

--- a/cmd/babylond/cmd/custom_babylon_config.go
+++ b/cmd/babylond/cmd/custom_babylon_config.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	defaultKeyName       = "default"
-	defaultGasPrice      = "0.01ubbn"
-	defaultGasAdjustment = 1.2
+	defaultGasPrice      = "0.02ubbn"
+	defaultGasAdjustment = 1.5
 )
 
 type BtcConfig struct {

--- a/cmd/babylond/cmd/custom_babylon_config.go
+++ b/cmd/babylond/cmd/custom_babylon_config.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	defaultKeyName       = "default"
-	defaultGasPrice      = "0.02ubbn"
+	defaultGasPrice      = "0.01ubbn"
 	defaultGasAdjustment = 1.5
 )
 

--- a/cmd/babylond/cmd/custom_babylon_config.go
+++ b/cmd/babylond/cmd/custom_babylon_config.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
-	"fmt"
-
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 
-	"github.com/babylonchain/babylon/app/params"
 	txformat "github.com/babylonchain/babylon/btctxformatter"
 	bbn "github.com/babylonchain/babylon/types"
+)
+
+const (
+	defaultKeyName       = "default"
+	defaultGasPrice      = "0.01ubbn"
+	defaultGasAdjustment = 1.2
 )
 
 type BtcConfig struct {
@@ -25,9 +28,9 @@ func defaultBabylonBtcConfig() BtcConfig {
 
 func defaultSignerConfig() SignerConfig {
 	return SignerConfig{
-		KeyName:       "",
-		GasPrice:      fmt.Sprintf("0.01%s", params.BaseCoinUnit),
-		GasAdjustment: 1.2,
+		KeyName:       defaultKeyName,
+		GasPrice:      defaultGasPrice,
+		GasAdjustment: defaultGasAdjustment,
 	}
 }
 

--- a/cmd/babylond/cmd/custom_babylon_config.go
+++ b/cmd/babylond/cmd/custom_babylon_config.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"fmt"
+
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+
+	"github.com/babylonchain/babylon/app/params"
 	txformat "github.com/babylonchain/babylon/btctxformatter"
 	bbn "github.com/babylonchain/babylon/types"
-	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 )
 
 type BtcConfig struct {
@@ -15,16 +19,22 @@ type BtcConfig struct {
 func defaultBabylonBtcConfig() BtcConfig {
 	return BtcConfig{
 		Network:       string(bbn.BtcMainnet),
-		CheckpointTag: string(txformat.DefaultMainTagStr),
+		CheckpointTag: txformat.DefaultMainTagStr,
 	}
 }
 
 func defaultSignerConfig() SignerConfig {
-	return SignerConfig{KeyName: ""}
+	return SignerConfig{
+		KeyName:       "",
+		GasPrice:      fmt.Sprintf("0.01%s", params.BaseCoinUnit),
+		GasAdjustment: 1.2,
+	}
 }
 
 type SignerConfig struct {
-	KeyName string `mapstructure:"key-name"`
+	KeyName       string  `mapstructure:"key-name"`
+	GasPrice      string  `mapstructure:"gas-price"`
+	GasAdjustment float64 `mapstructure:"gas-adjustment"`
 }
 
 type BabylonAppConfig struct {
@@ -64,5 +74,9 @@ checkpoint-tag = "{{ .BtcConfig.CheckpointTag }}"
 
 # Configures which key that the BLS signer uses to sign BLS-sig transactions
 key-name = "{{ .SignerConfig.KeyName }}"
+# Configures the gas-price that the signer would like to pay
+gas-price = "{{ .SignerConfig.GasPrice }}"
+# Configures the adjustment of the gas cost of estimation
+gas-adjustment = "{{ .SignerConfig.GasAdjustment }}"
 `
 }

--- a/types/signer_config.go
+++ b/types/signer_config.go
@@ -32,9 +32,13 @@ func parseGasPriceFromConfig(opts servertypes.AppOptions) (string, error) {
 		return "", errors.New("signer gas price should be valid string")
 	}
 
-	_, err = sdk.ParseCoinNormalized(gasPrice)
+	coin, err := sdk.ParseCoinNormalized(gasPrice)
 	if err != nil {
 		return "", errors.New("signer gas price is invalid")
+	}
+
+	if !coin.Amount.IsPositive() {
+		return "", errors.New("gas price should be positive")
 	}
 
 	return gasPrice, nil

--- a/types/signer_config.go
+++ b/types/signer_config.go
@@ -32,7 +32,7 @@ func parseGasPriceFromConfig(opts servertypes.AppOptions) (string, error) {
 		return "", errors.New("signer gas price should be valid string")
 	}
 
-	coin, err := sdk.ParseCoinNormalized(gasPrice)
+	coin, err := sdk.ParseDecCoin(gasPrice)
 	if err != nil {
 		return "", errors.New("signer gas price is invalid")
 	}

--- a/types/signer_config.go
+++ b/types/signer_config.go
@@ -1,8 +1,12 @@
 package types
 
 import (
+	"errors"
+
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cast"
+	"github.com/spf13/viper"
 )
 
 func ParseKeyNameFromConfig(opts servertypes.AppOptions) string {
@@ -16,4 +20,67 @@ func ParseKeyNameFromConfig(opts servertypes.AppOptions) string {
 	}
 
 	return keyName
+}
+
+func parseGasPriceFromConfig(opts servertypes.AppOptions) (string, error) {
+	valueInterface := opts.Get("signer-config.gas-price")
+	if valueInterface == nil {
+		return "", errors.New("signer gas price should be provided in options")
+	}
+	gasPrice, err := cast.ToStringE(valueInterface)
+	if err != nil {
+		return "", errors.New("signer gas price should be valid string")
+	}
+
+	_, err = sdk.ParseCoinNormalized(gasPrice)
+	if err != nil {
+		return "", errors.New("signer gas price is invalid")
+	}
+
+	return gasPrice, nil
+}
+
+func parseGasAdjustmentFromConfig(opts servertypes.AppOptions) (float64, error) {
+	valueInterface := opts.Get("signer-config.gas-adjustment")
+	if valueInterface == nil {
+		return 0, errors.New("signer gas adjustment should be provided in options")
+	}
+	gasAdjustment, err := cast.ToFloat64E(valueInterface)
+	if err != nil {
+		return 0, errors.New("signer gas adjustment should be valid float number")
+	}
+
+	if gasAdjustment <= 1 {
+		return 0, errors.New("signer gas adjustment should be more than 1")
+	}
+
+	return gasAdjustment, nil
+}
+
+// MustGetGasSettings reads GasPrice and GasAdjustment from app.toml file
+func MustGetGasSettings(configPath string, v *viper.Viper) (string, float64) {
+	var (
+		gasPrice      string
+		gasAdjustment float64
+		err           error
+	)
+
+	v.AddConfigPath(configPath)
+	v.SetConfigName("app")
+	v.SetConfigType("toml")
+
+	if err := v.ReadInConfig(); err != nil {
+		panic("failed to read app.toml")
+	}
+
+	gasPrice, err = parseGasPriceFromConfig(v)
+	if err != nil {
+		panic(err)
+	}
+	gasAdjustment, err = parseGasAdjustmentFromConfig(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return gasPrice, gasAdjustment
 }

--- a/types/signer_config.go
+++ b/types/signer_config.go
@@ -81,6 +81,7 @@ func MustGetGasSettings(configPath string, v *viper.Viper) (string, float64) {
 	if err != nil {
 		panic(err)
 	}
+
 	gasAdjustment, err = parseGasAdjustmentFromConfig(v)
 	if err != nil {
 		panic(err)

--- a/x/checkpointing/keeper/bls_signer.go
+++ b/x/checkpointing/keeper/bls_signer.go
@@ -57,7 +57,7 @@ func (k Keeper) SendBlsSig(ctx sdk.Context, epochNum uint64, lch types.LastCommi
 		return err
 	}
 
-	ctx.Logger().Info(fmt.Sprintf("Successfully sent BLS-sig tx for epoch %d, tx hash: %s, gas used: %d", epochNum, res.TxHash, res.GasUsed))
+	ctx.Logger().Info(fmt.Sprintf("Successfully sent BLS-sig tx for epoch %d, tx hash: %s, gas used: %d, gas wanted: %d", epochNum, res.TxHash, res.GasUsed, res.GasWanted))
 
 	return nil
 }

--- a/x/checkpointing/keeper/bls_signer.go
+++ b/x/checkpointing/keeper/bls_signer.go
@@ -6,11 +6,12 @@ import (
 
 	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/babylonchain/babylon/client/tx"
 	"github.com/babylonchain/babylon/crypto/bls12381"
 	"github.com/babylonchain/babylon/types/retry"
 	"github.com/babylonchain/babylon/x/checkpointing/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type BlsSigner interface {
@@ -43,8 +44,9 @@ func (k Keeper) SendBlsSig(ctx sdk.Context, epochNum uint64, lch types.LastCommi
 
 	// keep sending the message to Tendermint until success or timeout
 	// TODO should read the parameters from config file
+	var res *sdk.TxResponse
 	err = retry.Do(1*time.Second, 1*time.Minute, func() error {
-		_, err := tx.SendMsgToTendermint(k.clientCtx, msg)
+		res, err = tx.SendMsgToTendermint(k.clientCtx, msg)
 		if err != nil {
 			return err
 		}
@@ -55,7 +57,7 @@ func (k Keeper) SendBlsSig(ctx sdk.Context, epochNum uint64, lch types.LastCommi
 		return err
 	}
 
-	ctx.Logger().Info(fmt.Sprintf("Successfully sent BLS-sig tx for epoch %v", epochNum))
+	ctx.Logger().Info(fmt.Sprintf("Successfully sent BLS-sig tx for epoch %d, tx hash: %s, gas used: %d", epochNum, res.TxHash, res.GasUsed))
 
 	return nil
 }

--- a/x/checkpointing/keeper/bls_signer_test.go
+++ b/x/checkpointing/keeper/bls_signer_test.go
@@ -4,11 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/babylonchain/babylon/app"
-	"github.com/babylonchain/babylon/crypto/bls12381"
-	testkeeper "github.com/babylonchain/babylon/testutil/keeper"
-	"github.com/babylonchain/babylon/testutil/mocks"
-	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
@@ -16,6 +11,12 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/crypto/tmhash"
+
+	"github.com/babylonchain/babylon/app"
+	"github.com/babylonchain/babylon/crypto/bls12381"
+	testkeeper "github.com/babylonchain/babylon/testutil/keeper"
+	"github.com/babylonchain/babylon/testutil/mocks"
+	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
 )
 
 var (

--- a/x/checkpointing/keeper/bls_signer_test.go
+++ b/x/checkpointing/keeper/bls_signer_test.go
@@ -1,21 +1,10 @@
 package keeper_test
 
 import (
-	"fmt"
-	"testing"
-
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
-	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/crypto/tmhash"
 
-	"github.com/babylonchain/babylon/app"
 	"github.com/babylonchain/babylon/crypto/bls12381"
-	testkeeper "github.com/babylonchain/babylon/testutil/keeper"
-	"github.com/babylonchain/babylon/testutil/mocks"
 	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
 )
 
@@ -39,38 +28,3 @@ var (
 	blsPubKey2  = blsPrivKey2.PubKey()
 	pubkeys     = []bls12381.PublicKey{blsPubKey1, blsPubKey2}
 )
-
-func TestKeeper_SendBlsSig(t *testing.T) {
-	cfg := network.DefaultConfig()
-	encodingCfg := app.MakeTestEncodingConfig()
-	cfg.InterfaceRegistry = encodingCfg.InterfaceRegistry
-	cfg.TxConfig = encodingCfg.TxConfig
-	cfg.NumValidators = 1
-
-	testNetwork, err := network.New(t, t.TempDir(), cfg)
-	require.NoError(t, err)
-	defer testNetwork.Cleanup()
-
-	val := testNetwork.Validators[0]
-	nodeDirName := fmt.Sprintf("node%d", 0)
-	clientCtx := val.ClientCtx.WithHeight(2).
-		WithFromAddress(val.Address).
-		WithFromName(nodeDirName).
-		WithBroadcastMode(flags.BroadcastAsync)
-	clientCtx.SkipConfirm = true
-
-	epochNum := uint64(10)
-	lch := tmhash.Sum([]byte("last_commit_hash"))
-	signBytes := append(sdk.Uint64ToBigEndian(epochNum), lch...)
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	ek := mocks.NewMockEpochingKeeper(ctrl)
-	signer := mocks.NewMockBlsSigner(ctrl)
-	ckptkeeper, ctx, _ := testkeeper.CheckpointingKeeper(t, ek, signer, clientCtx)
-
-	signer.EXPECT().GetAddress().Return(addr1)
-	signer.EXPECT().SignMsgWithBls(gomock.Eq(signBytes)).Return(bls12381.Sign(blsPrivKey1, signBytes), nil)
-	err = ckptkeeper.SendBlsSig(ctx, epochNum, lch, valSet)
-	require.NoError(t, err)
-}

--- a/x/checkpointing/keeper/keeper.go
+++ b/x/checkpointing/keeper/keeper.go
@@ -3,17 +3,19 @@ package keeper
 import (
 	"errors"
 	"fmt"
+
 	txformat "github.com/babylonchain/babylon/btctxformatter"
 
-	"github.com/babylonchain/babylon/crypto/bls12381"
-	"github.com/babylonchain/babylon/x/checkpointing/types"
-	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/tendermint/tendermint/libs/log"
+
+	"github.com/babylonchain/babylon/crypto/bls12381"
+	"github.com/babylonchain/babylon/x/checkpointing/types"
+	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
 )
 
 type (
@@ -136,7 +138,7 @@ func (k Keeper) addBlsSig(ctx sdk.Context, sig *types.BlsSig) error {
 
 	// if reaching this line, it means ckptWithMeta is updated,
 	// and we need to write the updated ckptWithMeta back to KVStore
-	if err := k.UpdateCheckpoint(ctx, ckptWithMeta); err != nil {
+	if err = k.UpdateCheckpoint(ctx, ckptWithMeta); err != nil {
 		return err
 	}
 

--- a/x/checkpointing/keeper/msg_server.go
+++ b/x/checkpointing/keeper/msg_server.go
@@ -2,8 +2,11 @@ package keeper
 
 import (
 	"context"
-	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
 
 	"github.com/babylonchain/babylon/x/checkpointing/types"
 )
@@ -23,6 +26,8 @@ var _ types.MsgServer = msgServer{}
 // AddBlsSig adds BLS sig messages and changes a raw checkpoint status to SEALED if sufficient voting power is accumulated
 func (m msgServer) AddBlsSig(goCtx context.Context, msg *types.MsgAddBlsSig) (*types.MsgAddBlsSigResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	ctx.Logger().Info(fmt.Sprintf("received BLS sig for epoch %d from %s", msg.BlsSig.EpochNum, msg.GetSigners()))
 
 	err := m.k.addBlsSig(ctx, msg.BlsSig)
 	if err != nil {


### PR DESCRIPTION
This PR fixes #168 

The fee of sending a BLS-sig tx was hardcoded. This PR estimates the fee by calculating the gas. This PR also adds two gas-related settings, `gas-price` and `gas-adjustment` in the `app.toml` to calculate the actual `fee=calculated_gas * gas_adjustment * gas_price`.

This PR also removed the test of `SendBlsSig` as the gas calculation is not implemented for testing. Instead, this PR is well tested using [babylon-deployment](https://github.com/babylonchain/babylon-deployment).