### PR TITLE
fix gas cost of insert header

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -298,7 +298,8 @@ func NewBabylonApp(
 		ibctransfertypes.StoreKey,
 		zctypes.StoreKey,
 	)
-	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
+	tkeys := sdk.NewTransientStoreKeys(
+		paramstypes.TStoreKey, btccheckpointtypes.TStoreKey)
 	// NOTE: The testingkey is just mounted for testing purposes. Actual applications should
 	// not include this key.
 	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, "testingkey")
@@ -518,6 +519,7 @@ func NewBabylonApp(
 		btccheckpointkeeper.NewKeeper(
 			appCodec,
 			keys[btccheckpointtypes.StoreKey],
+			tkeys[btccheckpointtypes.TStoreKey],
 			keys[btccheckpointtypes.MemStoreKey],
 			app.GetSubspace(btccheckpointtypes.ModuleName),
 			&btclightclientKeeper,

--- a/testutil/keeper/btccheckpoint.go
+++ b/testutil/keeper/btccheckpoint.go
@@ -26,6 +26,7 @@ func NewBTCCheckpointKeeper(
 	ek btcctypes.CheckpointingKeeper,
 	powLimit *big.Int) (*keeper.Keeper, sdk.Context) {
 	storeKey := sdk.NewKVStoreKey(btcctypes.StoreKey)
+	tstoreKey := sdk.NewTransientStoreKey(btcctypes.TStoreKey)
 	memStoreKey := storetypes.NewMemoryStoreKey(btcctypes.MemStoreKey)
 
 	db := tmdb.NewMemDB()
@@ -47,6 +48,7 @@ func NewBTCCheckpointKeeper(
 	k := keeper.NewKeeper(
 		cdc,
 		storeKey,
+		tstoreKey,
 		memStoreKey,
 		paramsSubspace,
 		lk,

--- a/x/btccheckpoint/abci.go
+++ b/x/btccheckpoint/abci.go
@@ -1,0 +1,16 @@
+package btccheckpoint
+
+import (
+	"github.com/babylonchain/babylon/x/btccheckpoint/keeper"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// EndBlocker checks if during block execution btc light client head had been
+// updated. If the head had been updated, status of all available checkpoints
+// is checked to determine if any of them became confirmed/finalized/abandonded.
+func EndBlocker(ctx sdk.Context, k keeper.Keeper, req abci.RequestEndBlock) {
+	if k.BtcLightClientUpdated(ctx) {
+		k.OnTipChange(ctx)
+	}
+}

--- a/x/btccheckpoint/keeper/hooks.go
+++ b/x/btccheckpoint/keeper/hooks.go
@@ -21,11 +21,11 @@ var _ HandledHooks = Hooks{}
 func (k Keeper) Hooks() Hooks { return Hooks{k} }
 
 func (h Hooks) AfterBTCRollBack(ctx sdk.Context, headerInfo *ltypes.BTCHeaderInfo) {
-	h.k.OnTipChange(ctx)
+	h.k.setBtcLightClientUpdated(ctx)
 }
 
 func (h Hooks) AfterBTCRollForward(ctx sdk.Context, headerInfo *ltypes.BTCHeaderInfo) {
-	h.k.OnTipChange(ctx)
+	h.k.setBtcLightClientUpdated(ctx)
 }
 
 func (h Hooks) AfterBTCHeaderInserted(ctx sdk.Context, headerInfo *ltypes.BTCHeaderInfo) {}

--- a/x/btccheckpoint/keeper/keeper.go
+++ b/x/btccheckpoint/keeper/keeper.go
@@ -352,7 +352,7 @@ func (k Keeper) OnTipChange(ctx sdk.Context) {
 
 func (k Keeper) setBtcLightClientUpdated(ctx sdk.Context) {
 	store := ctx.TransientStore(k.tstoreKey)
-	store.Set(types.GetBtcLigtClientUpdatedKey(), []byte{1})
+	store.Set(types.GetBtcLightClientUpdatedKey(), []byte{1})
 }
 
 // BtcLightClientUpdated checks if btc light client was updated during block execution
@@ -361,7 +361,7 @@ func (k Keeper) BtcLightClientUpdated(ctx sdk.Context) bool {
 	// BtcLightClientKey is set, it means setBtcLightClientUpdated was called during
 	// current block execution
 	store := ctx.TransientStore(k.tstoreKey)
-	lcUpdated := store.Get(types.GetBtcLigtClientUpdatedKey())
+	lcUpdated := store.Get(types.GetBtcLightClientUpdatedKey())
 	return len(lcUpdated) > 0
 }
 

--- a/x/btccheckpoint/module.go
+++ b/x/btccheckpoint/module.go
@@ -172,6 +172,7 @@ func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
 // returns no validator updates.
-func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.ValidatorUpdate {
+	EndBlocker(ctx, am.keeper, req)
 	return []abci.ValidatorUpdate{}
 }

--- a/x/btccheckpoint/types/keys.go
+++ b/x/btccheckpoint/types/keys.go
@@ -25,14 +25,14 @@ const (
 
 	LatestFinalizedEpochKey = "latestFinalizedEpoch"
 
-	btcLighClientUpdated = "btcLightClientUpdated"
+	btcLightClientUpdated = "btcLightClientUpdated"
 )
 
 var (
 	SubmisionKeyPrefix       = []byte{3}
 	EpochDataPrefix          = []byte{4}
 	LastFinalizedEpochKey    = append([]byte{5}, []byte(LatestFinalizedEpochKey)...)
-	BtcLightClientUpdatedKey = append([]byte{6}, []byte(btcLighClientUpdated)...)
+	BtcLightClientUpdatedKey = append([]byte{6}, []byte(btcLightClientUpdated)...)
 )
 
 func KeyPrefix(p string) []byte {
@@ -51,6 +51,6 @@ func GetLatestFinalizedEpochKey() []byte {
 	return LastFinalizedEpochKey
 }
 
-func GetBtcLigtClientUpdatedKey() []byte {
+func GetBtcLightClientUpdatedKey() []byte {
 	return BtcLightClientUpdatedKey
 }

--- a/x/btccheckpoint/types/keys.go
+++ b/x/btccheckpoint/types/keys.go
@@ -18,16 +18,21 @@ const (
 	// QuerierRoute defines the module's query routing key
 	QuerierRoute = ModuleName
 
+	TStoreKey = "transient_btccheckpoint"
+
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_btccheckpoint"
 
 	LatestFinalizedEpochKey = "latestFinalizedEpoch"
+
+	btcLighClientUpdated = "btcLightClientUpdated"
 )
 
 var (
-	SubmisionKeyPrefix    = []byte{3}
-	EpochDataPrefix       = []byte{4}
-	LastFinalizedEpochKey = append([]byte{5}, []byte(LatestFinalizedEpochKey)...)
+	SubmisionKeyPrefix       = []byte{3}
+	EpochDataPrefix          = []byte{4}
+	LastFinalizedEpochKey    = append([]byte{5}, []byte(LatestFinalizedEpochKey)...)
+	BtcLightClientUpdatedKey = append([]byte{6}, []byte(btcLighClientUpdated)...)
 )
 
 func KeyPrefix(p string) []byte {
@@ -44,4 +49,8 @@ func GetEpochIndexKey(e uint64) []byte {
 
 func GetLatestFinalizedEpochKey() []byte {
 	return LastFinalizedEpochKey
+}
+
+func GetBtcLigtClientUpdatedKey() []byte {
+	return BtcLightClientUpdatedKey
 }


### PR DESCRIPTION
Currently most costly babylon msg is Insert Header msg from btc light client. The difference is in order of magnitude range. The main reason is that btclightclient exposes hooks for header events to which btccheckpoint subscribes. With each header update it check status of every checkpoint of every non finalized epoch. This mean that gas cost of this operation is around O(numberOfNonFinlizedEpochs * numberOfCheckpointsInEachNonFinalizedEpoch) (+ some some cost of light client itself).

This pr proposes to move all checking logic into EndBlock callback and to use local transient store to check if btc light client have been updated during current block execution.

This:
- reduces gas cost of inserting btc header to only the gas costs of btc light client itself (operations on transient store are super cheap)
- reduces gas cost of transactions which have multiple Insert Header messages i.e if one inserts 50 btc headers at once, ultimately what matters is the state at the end of Babylon block.

Gas cost of inserting headers in e2e tests have been reduced almost two times.
