### PR TITLE
chore: Add balance check before inserting MsgWrappedCreateValidator into the epoch message queue

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -10,7 +10,6 @@ import (
 
 	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 
-	bbn "github.com/babylonchain/babylon/types"
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"
@@ -19,7 +18,8 @@ import (
 	tmos "github.com/tendermint/tendermint/libs/os"
 	dbm "github.com/tendermint/tm-db"
 
-	appparams "github.com/babylonchain/babylon/app/params"
+	bbn "github.com/babylonchain/babylon/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
@@ -87,8 +87,15 @@ import (
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	appparams "github.com/babylonchain/babylon/app/params"
+
 	// unnamed import of statik for swagger UI support
 	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
 	"github.com/babylonchain/babylon/x/btccheckpoint"
 	btccheckpointkeeper "github.com/babylonchain/babylon/x/btccheckpoint/keeper"
@@ -105,16 +112,8 @@ import (
 	"github.com/babylonchain/babylon/x/monitor"
 	monitorkeeper "github.com/babylonchain/babylon/x/monitor/keeper"
 	monitortypes "github.com/babylonchain/babylon/x/monitor/types"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
-	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
-	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
-	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
-	// IBC-related
-	"github.com/babylonchain/babylon/x/zoneconcierge"
-	zckeeper "github.com/babylonchain/babylon/x/zoneconcierge/keeper"
-	zctypes "github.com/babylonchain/babylon/x/zoneconcierge/types"
-	transfer "github.com/cosmos/ibc-go/v5/modules/apps/transfer"
+	"github.com/cosmos/ibc-go/v5/modules/apps/transfer"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v5/modules/apps/transfer/keeper"
 	ibctransfertypes "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v5/modules/core"
@@ -122,6 +121,11 @@ import (
 	porttypes "github.com/cosmos/ibc-go/v5/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v5/modules/core/24-host" // ibc module puts types under `ibchost` rather than `ibctypes`
 	ibckeeper "github.com/cosmos/ibc-go/v5/modules/core/keeper"
+
+	// IBC-related
+	"github.com/babylonchain/babylon/x/zoneconcierge"
+	zckeeper "github.com/babylonchain/babylon/x/zoneconcierge/keeper"
+	zctypes "github.com/babylonchain/babylon/x/zoneconcierge/types"
 )
 
 const (
@@ -346,7 +350,7 @@ func NewBabylonApp(
 
 	// NOTE: the epoching module has to be set before the chekpointing module, as the checkpointing module will have access to the epoching module
 	epochingKeeper := epochingkeeper.NewKeeper(
-		appCodec, keys[epochingtypes.StoreKey], keys[epochingtypes.StoreKey], app.GetSubspace(epochingtypes.ModuleName), &app.StakingKeeper,
+		appCodec, keys[epochingtypes.StoreKey], keys[epochingtypes.StoreKey], app.GetSubspace(epochingtypes.ModuleName), app.BankKeeper, &app.StakingKeeper,
 	)
 
 	app.MintKeeper = mintkeeper.NewKeeper(

--- a/testutil/keeper/epoching.go
+++ b/testutil/keeper/epoching.go
@@ -3,8 +3,6 @@ package keeper
 import (
 	"testing"
 
-	"github.com/babylonchain/babylon/x/epoching/keeper"
-	"github.com/babylonchain/babylon/x/epoching/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store"
@@ -15,6 +13,9 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmdb "github.com/tendermint/tm-db"
+
+	"github.com/babylonchain/babylon/x/epoching/keeper"
+	"github.com/babylonchain/babylon/x/epoching/types"
 )
 
 func EpochingKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
@@ -42,6 +43,7 @@ func EpochingKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 		memStoreKey,
 		paramsSubspace,
 		// TODO: make this compile at the moment, will fix for integrated testing
+		nil,
 		nil,
 	)
 

--- a/x/epoching/keeper/keeper.go
+++ b/x/epoching/keeper/keeper.go
@@ -3,13 +3,14 @@ package keeper
 import (
 	"fmt"
 
-	"github.com/babylonchain/babylon/x/epoching/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/tendermint/tendermint/libs/log"
+
+	"github.com/babylonchain/babylon/x/epoching/types"
 )
 
 type (
@@ -19,6 +20,7 @@ type (
 		memKey     storetypes.StoreKey
 		hooks      types.EpochingHooks
 		paramstore paramtypes.Subspace
+		bk         types.BankKeeper
 		stk        types.StakingKeeper
 		router     *baseapp.MsgServiceRouter
 	}
@@ -29,6 +31,7 @@ func NewKeeper(
 	storeKey,
 	memKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
+	bk types.BankKeeper,
 	stk types.StakingKeeper,
 ) Keeper {
 	// set KeyTable if it has not already been set
@@ -42,6 +45,7 @@ func NewKeeper(
 		memKey:     memKey,
 		paramstore: ps,
 		hooks:      nil,
+		bk:         bk,
 		stk:        stk,
 	}
 }

--- a/x/epoching/keeper/staking_functions.go
+++ b/x/epoching/keeper/staking_functions.go
@@ -5,6 +5,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/babylonchain/babylon/x/epoching/types"
 )
 
 // CheckMsgCreateValidator performs stateless checks on a given `MsgCreateValidator` message
@@ -89,8 +91,14 @@ func (k Keeper) CheckMsgCreateValidator(ctx sdk.Context, msg *stakingtypes.MsgCr
 	}
 
 	// sanity check on delegator address
-	if _, err := sdk.AccAddressFromBech32(msg.DelegatorAddress); err != nil {
+	delegatorAddr, err := sdk.AccAddressFromBech32(msg.DelegatorAddress)
+	if err != nil {
 		return err
+	}
+
+	balance := k.bk.GetBalance(ctx, delegatorAddr, msg.Value.GetDenom())
+	if msg.Value.IsGTE(balance) {
+		return types.ErrInsufficientBalance
 	}
 
 	return nil

--- a/x/epoching/keeper/staking_functions.go
+++ b/x/epoching/keeper/staking_functions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/babylonchain/babylon/x/epoching/types"
 )
 
-// CheckMsgCreateValidator performs stateless checks on a given `MsgCreateValidator` message
+// CheckMsgCreateValidator performs checks on a given `MsgCreateValidator` message
 // The checkpointing module will use this function to verify the `MsgCreateValidator` message
 // inside a `MsgWrappedCreateValidator` message.
 // (adapted from https://github.com/cosmos/cosmos-sdk/blob/v0.46.10/x/staking/keeper/msg_server.go#L34-L108)

--- a/x/epoching/types/errors.go
+++ b/x/epoching/types/errors.go
@@ -21,4 +21,5 @@ var (
 	ErrZeroEpochMsg              = sdkerrors.Register(ModuleName, 11, "the 0-th epoch does not handle messages")
 	ErrInvalidEpoch              = sdkerrors.Register(ModuleName, 12, "the epoch is invalid")
 	ErrInvalidHeight             = sdkerrors.Register(ModuleName, 13, "the height is invalid")
+	ErrInsufficientBalance       = sdkerrors.Register(ModuleName, 14, "the delegator has insufficient balance to perform delegate")
 )


### PR DESCRIPTION
This PR fixed #317 and added relevant fuzz tests. To support the check of delegator balance, this PR added the `BankKeeper` to the epoching module