### PR TITLE
proto: fix proto-linter comments for epoching/zoneconcierge

### DIFF
--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -108,27 +108,24 @@ paths:
                             description: >-
                               TODO: this could probably be better typed
 
-                              Address of the checkpoint submitter, extracted
-                              from the checkpoint itself.
+                              submitter is the address of the checkpoint
+                              submitter to BTC, extracted from
+
+                              the checkpoint itself.
                           reporter:
                             type: string
                             format: byte
                             title: >-
-                              Address of the reporter which reported the
-                              submissions, calculated from
+                              reporter is the address of the reporter who
+                              reported the submissions,
 
-                              submission message MsgInsertBTCSpvProof itself
+                              calculated from submission message
+                              MsgInsertBTCSpvProof itself
                         title: >-
                           CheckpointAddresses contains the addresses of the
                           submitter and reporter of a
 
-                          given checkpoint submitter is the address of the
-                          submitter of the checkpoint
-
-                          to BTC reporter is the address of the submitter of the
-                          MsgInsertBTCSpvProof
-
-                          message to Babylon
+                          given checkpoint
                       title: list of vigilantes' addresses
                   description: >-
                     BTCCheckpointInfo contains all checkpoint related data
@@ -416,27 +413,24 @@ paths:
                           description: >-
                             TODO: this could probably be better typed
 
-                            Address of the checkpoint submitter, extracted from
+                            submitter is the address of the checkpoint submitter
+                            to BTC, extracted from
+
                             the checkpoint itself.
                         reporter:
                           type: string
                           format: byte
                           title: >-
-                            Address of the reporter which reported the
-                            submissions, calculated from
+                            reporter is the address of the reporter who reported
+                            the submissions,
 
-                            submission message MsgInsertBTCSpvProof itself
+                            calculated from submission message
+                            MsgInsertBTCSpvProof itself
                       title: >-
                         CheckpointAddresses contains the addresses of the
                         submitter and reporter of a
 
-                        given checkpoint submitter is the address of the
-                        submitter of the checkpoint
-
-                        to BTC reporter is the address of the submitter of the
-                        MsgInsertBTCSpvProof
-
-                        message to Babylon
+                        given checkpoint
                     title: list of vigilantes' addresses
                 description: >-
                   BTCCheckpointInfo contains all checkpoint related data
@@ -10404,27 +10398,23 @@ definitions:
               description: >-
                 TODO: this could probably be better typed
 
-                Address of the checkpoint submitter, extracted from the
-                checkpoint itself.
+                submitter is the address of the checkpoint submitter to BTC,
+                extracted from
+
+                the checkpoint itself.
             reporter:
               type: string
               format: byte
               title: >-
-                Address of the reporter which reported the submissions,
-                calculated from
+                reporter is the address of the reporter who reported the
+                submissions,
 
-                submission message MsgInsertBTCSpvProof itself
+                calculated from submission message MsgInsertBTCSpvProof itself
           title: >-
             CheckpointAddresses contains the addresses of the submitter and
             reporter of a
 
-            given checkpoint submitter is the address of the submitter of the
-            checkpoint
-
-            to BTC reporter is the address of the submitter of the
-            MsgInsertBTCSpvProof
-
-            message to Babylon
+            given checkpoint
         title: list of vigilantes' addresses
     description: |-
       BTCCheckpointInfo contains all checkpoint related data expected in a query
@@ -10438,27 +10428,21 @@ definitions:
         description: >-
           TODO: this could probably be better typed
 
-          Address of the checkpoint submitter, extracted from the checkpoint
-          itself.
+          submitter is the address of the checkpoint submitter to BTC, extracted
+          from
+
+          the checkpoint itself.
       reporter:
         type: string
         format: byte
-        title: >-
-          Address of the reporter which reported the submissions, calculated
-          from
-
-          submission message MsgInsertBTCSpvProof itself
+        title: |-
+          reporter is the address of the reporter who reported the submissions,
+          calculated from submission message MsgInsertBTCSpvProof itself
     title: >-
       CheckpointAddresses contains the addresses of the submitter and reporter
       of a
 
-      given checkpoint submitter is the address of the submitter of the
-      checkpoint
-
-      to BTC reporter is the address of the submitter of the
-      MsgInsertBTCSpvProof
-
-      message to Babylon
+      given checkpoint
   babylon.btccheckpoint.v1.Params:
     type: object
     properties:
@@ -10583,27 +10567,24 @@ definitions:
                   description: >-
                     TODO: this could probably be better typed
 
-                    Address of the checkpoint submitter, extracted from the
-                    checkpoint itself.
+                    submitter is the address of the checkpoint submitter to BTC,
+                    extracted from
+
+                    the checkpoint itself.
                 reporter:
                   type: string
                   format: byte
                   title: >-
-                    Address of the reporter which reported the submissions,
-                    calculated from
+                    reporter is the address of the reporter who reported the
+                    submissions,
 
-                    submission message MsgInsertBTCSpvProof itself
+                    calculated from submission message MsgInsertBTCSpvProof
+                    itself
               title: >-
                 CheckpointAddresses contains the addresses of the submitter and
                 reporter of a
 
-                given checkpoint submitter is the address of the submitter of
-                the checkpoint
-
-                to BTC reporter is the address of the submitter of the
-                MsgInsertBTCSpvProof
-
-                message to Babylon
+                given checkpoint
             title: list of vigilantes' addresses
         description: >-
           BTCCheckpointInfo contains all checkpoint related data expected in a
@@ -10707,27 +10688,24 @@ definitions:
                     description: >-
                       TODO: this could probably be better typed
 
-                      Address of the checkpoint submitter, extracted from the
-                      checkpoint itself.
+                      submitter is the address of the checkpoint submitter to
+                      BTC, extracted from
+
+                      the checkpoint itself.
                   reporter:
                     type: string
                     format: byte
                     title: >-
-                      Address of the reporter which reported the submissions,
-                      calculated from
+                      reporter is the address of the reporter who reported the
+                      submissions,
 
-                      submission message MsgInsertBTCSpvProof itself
+                      calculated from submission message MsgInsertBTCSpvProof
+                      itself
                 title: >-
                   CheckpointAddresses contains the addresses of the submitter
                   and reporter of a
 
-                  given checkpoint submitter is the address of the submitter of
-                  the checkpoint
-
-                  to BTC reporter is the address of the submitter of the
-                  MsgInsertBTCSpvProof
-
-                  message to Babylon
+                  given checkpoint
               title: list of vigilantes' addresses
           description: >-
             BTCCheckpointInfo contains all checkpoint related data expected in a

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -118,7 +118,19 @@ paths:
                               submissions, calculated from
 
                               submission message MsgInsertBTCSpvProof itself
+                        title: >-
+                          CheckpointAddresses contains the addresses of the
+                          submitter and reporter of a given checkpoint
+
+                          submitter is the address of the submitter of the
+                          checkpoint to BTC
+
+                          reporter is the address of the submitter of the
+                          MsgInsertBTCSpvProof message to Babylon
                       title: list of vigilantes' addresses
+                  description: >-
+                    BTCCheckpointInfo contains all checkpoint related data
+                    expected in a query response.
               pagination:
                 title: pagination defines the pagination in the response
                 type: object
@@ -410,7 +422,19 @@ paths:
                             submissions, calculated from
 
                             submission message MsgInsertBTCSpvProof itself
+                      title: >-
+                        CheckpointAddresses contains the addresses of the
+                        submitter and reporter of a given checkpoint
+
+                        submitter is the address of the submitter of the
+                        checkpoint to BTC
+
+                        reporter is the address of the submitter of the
+                        MsgInsertBTCSpvProof message to Babylon
                     title: list of vigilantes' addresses
+                description: >-
+                  BTCCheckpointInfo contains all checkpoint related data
+                  expected in a query response.
             title: |-
               QueryBtcCheckpointInfoResponse is response type for the
               Query/BtcCheckpointInfo RPC method
@@ -449,6 +473,7 @@ paths:
         - Query
   /babylon/btccheckpoint/v1/{epoch_num}/submissions:
     get:
+      summary: EpochSubmissions returns all submissions for a given epoch
       operationId: EpochSubmissions
       responses:
         '200':
@@ -527,6 +552,9 @@ paths:
                            repeated Bar results = 1;
                            PageResponse page = 2;
                    }
+            title: >-
+              QueryEpochSubmissionsResponse defines a response to get all
+              submissions in given epoch (QueryEpochSubmissionsRequest)
         default:
           description: An unexpected error response.
           schema:
@@ -616,6 +644,9 @@ paths:
         - Query
   /babylon/btclightclient/v1/baseheader:
     get:
+      summary: >-
+        BaseHeader returns the base BTC header of the chain. This header is
+        defined on genesis.
       operationId: BaseHeader
       responses:
         '200':
@@ -638,6 +669,17 @@ paths:
                   work:
                     type: string
                     format: byte
+                description: >-
+                  BTCHeaderInfo is a structure that contains all relevant
+                  information about a BTC header
+                   - Full header bytes
+                   - Header hash for easy retrieval
+                   - Height of the header in the BTC chain
+                   - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+                     and the total work of the header.
+            description: >-
+              QueryBaseHeaderResponse is the response type for the
+              Query/BaseHeader RPC method.
         default:
           description: An unexpected error response.
           schema:
@@ -912,6 +954,14 @@ paths:
                     work:
                       type: string
                       format: byte
+                  description: >-
+                    BTCHeaderInfo is a structure that contains all relevant
+                    information about a BTC header
+                     - Full header bytes
+                     - Header hash for easy retrieval
+                     - Height of the header in the BTC chain
+                     - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+                       and the total work of the header.
               pagination:
                 type: object
                 properties:
@@ -1089,6 +1139,17 @@ paths:
                   work:
                     type: string
                     format: byte
+                description: >-
+                  BTCHeaderInfo is a structure that contains all relevant
+                  information about a BTC header
+                   - Full header bytes
+                   - Header hash for easy retrieval
+                   - Height of the header in the BTC chain
+                   - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+                     and the total work of the header.
+            description: >-
+              QueryTipResponse is the response type for the Query/Tip RPC
+              method.
         default:
           description: An unexpected error response.
           schema:
@@ -1775,9 +1836,7 @@ paths:
                         proposer_address:
                           type: string
                           format: byte
-                      description: >-
-                        Header defines the structure of a Tendermint block
-                        header.
+                      description: Header defines the structure of a block header.
               pagination:
                 title: pagination defines the pagination in the response
                 type: object
@@ -2260,7 +2319,7 @@ paths:
                       proposer_address:
                         type: string
                         format: byte
-                    description: Header defines the structure of a Tendermint block header.
+                    description: Header defines the structure of a block header.
         default:
           description: An unexpected error response.
           schema:
@@ -4759,7 +4818,7 @@ paths:
                   - CKPT_STATUS_FINALIZED
                 default: CKPT_STATUS_ACCUMULATING
                 description: |-
-                  CkptStatus is the status of a checkpoint.
+                  CheckpointStatus is the status of a checkpoint.
 
                    - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                    - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -4908,6 +4967,9 @@ paths:
 
                       sigs
                 title: RawCheckpoint wraps the BLS multi sig with meta data
+            description: |-
+              QueryLastCheckpointWithStatusResponse is the response type for the
+              Query/LastCheckpointWithStatus RPC method.
         default:
           description: An unexpected error response.
           schema:
@@ -5038,7 +5100,7 @@ paths:
                       - CKPT_STATUS_FINALIZED
                     default: CKPT_STATUS_ACCUMULATING
                     description: |-
-                      CkptStatus is the status of a checkpoint.
+                      CheckpointStatus is the status of a checkpoint.
 
                        - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                        - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -5071,7 +5133,7 @@ paths:
                             - CKPT_STATUS_FINALIZED
                           default: CKPT_STATUS_ACCUMULATING
                           description: |-
-                            CkptStatus is the status of a checkpoint.
+                            CheckpointStatus is the status of a checkpoint.
 
                              - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                              - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -5097,6 +5159,9 @@ paths:
                             that triggers the state
 
                             update
+                      description: >-
+                        CheckpointStateUpdate defines a state transition on the
+                        checkpoint.
                     description: >-
                       lifecycle defines the lifecycle of this checkpoint, i.e.,
                       each state
@@ -5199,7 +5264,7 @@ paths:
                         - CKPT_STATUS_FINALIZED
                       default: CKPT_STATUS_ACCUMULATING
                       description: |-
-                        CkptStatus is the status of a checkpoint.
+                        CheckpointStatus is the status of a checkpoint.
 
                          - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                          - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -5232,7 +5297,7 @@ paths:
                               - CKPT_STATUS_FINALIZED
                             default: CKPT_STATUS_ACCUMULATING
                             description: |-
-                              CkptStatus is the status of a checkpoint.
+                              CheckpointStatus is the status of a checkpoint.
 
                                - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                                - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -5258,6 +5323,9 @@ paths:
                               that triggers the state
 
                               update
+                        description: >-
+                          CheckpointStateUpdate defines a state transition on
+                          the checkpoint.
                       description: >-
                         lifecycle defines the lifecycle of this checkpoint,
                         i.e., each state
@@ -5503,9 +5571,7 @@ paths:
                           proposer_address:
                             type: string
                             format: byte
-                        description: >-
-                          Header defines the structure of a Tendermint block
-                          header.
+                        description: Header defines the structure of a block header.
                       babylon_epoch:
                         type: string
                         format: uint64
@@ -5634,9 +5700,7 @@ paths:
                                 proposer_address:
                                   type: string
                                   format: byte
-                              description: >-
-                                Header defines the structure of a Tendermint
-                                block header.
+                              description: Header defines the structure of a block header.
                             babylon_epoch:
                               type: string
                               format: uint64
@@ -6017,9 +6081,7 @@ paths:
                           proposer_address:
                             type: string
                             format: byte
-                        description: >-
-                          Header defines the structure of a Tendermint block
-                          header.
+                        description: Header defines the structure of a block header.
                       babylon_epoch:
                         type: string
                         format: uint64
@@ -6148,9 +6210,7 @@ paths:
                                 proposer_address:
                                   type: string
                                   format: byte
-                              description: >-
-                                Header defines the structure of a Tendermint
-                                block header.
+                              description: Header defines the structure of a block header.
                             babylon_epoch:
                               type: string
                               format: uint64
@@ -6528,7 +6588,7 @@ paths:
                       proposer_address:
                         type: string
                         format: byte
-                    description: Header defines the structure of a Tendermint block header.
+                    description: Header defines the structure of a block header.
                   babylon_epoch:
                     type: string
                     format: uint64
@@ -6649,9 +6709,7 @@ paths:
                             proposer_address:
                               type: string
                               format: byte
-                          description: >-
-                            Header defines the structure of a Tendermint block
-                            header.
+                          description: Header defines the structure of a block header.
                         babylon_epoch:
                           type: string
                           format: uint64
@@ -7328,9 +7386,7 @@ paths:
                           proposer_address:
                             type: string
                             format: byte
-                        description: >-
-                          Header defines the structure of a Tendermint block
-                          header.
+                        description: Header defines the structure of a block header.
                       babylon_epoch:
                         type: string
                         format: uint64
@@ -7459,9 +7515,7 @@ paths:
                                 proposer_address:
                                   type: string
                                   format: byte
-                              description: >-
-                                Header defines the structure of a Tendermint
-                                block header.
+                              description: Header defines the structure of a block header.
                             babylon_epoch:
                               type: string
                               format: uint64
@@ -7716,7 +7770,7 @@ paths:
                       proposer_address:
                         type: string
                         format: byte
-                    description: Header defines the structure of a Tendermint block header.
+                    description: Header defines the structure of a block header.
               raw_checkpoint:
                 title: raw_checkpoint is the raw checkpoint of this epoch
                 type: object
@@ -8321,9 +8375,7 @@ paths:
                           proposer_address:
                             type: string
                             format: byte
-                        description: >-
-                          Header defines the structure of a Tendermint block
-                          header.
+                        description: Header defines the structure of a block header.
                       babylon_epoch:
                         type: string
                         format: uint64
@@ -8452,9 +8504,7 @@ paths:
                                 proposer_address:
                                   type: string
                                   format: byte
-                              description: >-
-                                Header defines the structure of a Tendermint
-                                block header.
+                              description: Header defines the structure of a block header.
                             babylon_epoch:
                               type: string
                               format: uint64
@@ -8709,7 +8759,7 @@ paths:
                       proposer_address:
                         type: string
                         format: byte
-                    description: Header defines the structure of a Tendermint block header.
+                    description: Header defines the structure of a block header.
               raw_checkpoint:
                 title: raw_checkpoint is the raw checkpoint of this epoch
                 type: object
@@ -9320,9 +9370,7 @@ paths:
                         proposer_address:
                           type: string
                           format: byte
-                      description: >-
-                        Header defines the structure of a Tendermint block
-                        header.
+                      description: Header defines the structure of a block header.
                     babylon_epoch:
                       type: string
                       format: uint64
@@ -9743,9 +9791,7 @@ paths:
                         proposer_address:
                           type: string
                           format: byte
-                      description: >-
-                        Header defines the structure of a Tendermint block
-                        header.
+                      description: Header defines the structure of a block header.
                     babylon_epoch:
                       type: string
                       format: uint64
@@ -10282,7 +10328,18 @@ definitions:
                 calculated from
 
                 submission message MsgInsertBTCSpvProof itself
+          title: >-
+            CheckpointAddresses contains the addresses of the submitter and
+            reporter of a given checkpoint
+
+            submitter is the address of the submitter of the checkpoint to BTC
+
+            reporter is the address of the submitter of the MsgInsertBTCSpvProof
+            message to Babylon
         title: list of vigilantes' addresses
+    description: >-
+      BTCCheckpointInfo contains all checkpoint related data expected in a query
+      response.
   babylon.btccheckpoint.v1.CheckpointAddresses:
     type: object
     properties:
@@ -10302,6 +10359,14 @@ definitions:
           from
 
           submission message MsgInsertBTCSpvProof itself
+    title: >-
+      CheckpointAddresses contains the addresses of the submitter and reporter
+      of a given checkpoint
+
+      submitter is the address of the submitter of the checkpoint to BTC
+
+      reporter is the address of the submitter of the MsgInsertBTCSpvProof
+      message to Babylon
   babylon.btccheckpoint.v1.Params:
     type: object
     properties:
@@ -10436,7 +10501,19 @@ definitions:
                     calculated from
 
                     submission message MsgInsertBTCSpvProof itself
+              title: >-
+                CheckpointAddresses contains the addresses of the submitter and
+                reporter of a given checkpoint
+
+                submitter is the address of the submitter of the checkpoint to
+                BTC
+
+                reporter is the address of the submitter of the
+                MsgInsertBTCSpvProof message to Babylon
             title: list of vigilantes' addresses
+        description: >-
+          BTCCheckpointInfo contains all checkpoint related data expected in a
+          query response.
     title: |-
       QueryBtcCheckpointInfoResponse is response type for the
       Query/BtcCheckpointInfo RPC method
@@ -10544,7 +10621,19 @@ definitions:
                       calculated from
 
                       submission message MsgInsertBTCSpvProof itself
+                title: >-
+                  CheckpointAddresses contains the addresses of the submitter
+                  and reporter of a given checkpoint
+
+                  submitter is the address of the submitter of the checkpoint to
+                  BTC
+
+                  reporter is the address of the submitter of the
+                  MsgInsertBTCSpvProof message to Babylon
               title: list of vigilantes' addresses
+          description: >-
+            BTCCheckpointInfo contains all checkpoint related data expected in a
+            query response.
       pagination:
         title: pagination defines the pagination in the response
         type: object
@@ -10645,6 +10734,9 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
+    title: >-
+      QueryEpochSubmissionsResponse defines a response to get all submissions in
+      given epoch (QueryEpochSubmissionsRequest)
   babylon.btccheckpoint.v1.QueryParamsResponse:
     type: object
     properties:
@@ -11200,6 +11292,14 @@ definitions:
       work:
         type: string
         format: byte
+    description: >-
+      BTCHeaderInfo is a structure that contains all relevant information about
+      a BTC header
+       - Full header bytes
+       - Header hash for easy retrieval
+       - Height of the header in the BTC chain
+       - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+         and the total work of the header.
   babylon.btclightclient.v1.Params:
     type: object
     description: Params defines the parameters for the module.
@@ -11221,6 +11321,17 @@ definitions:
           work:
             type: string
             format: byte
+        description: >-
+          BTCHeaderInfo is a structure that contains all relevant information
+          about a BTC header
+           - Full header bytes
+           - Header hash for easy retrieval
+           - Height of the header in the BTC chain
+           - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+             and the total work of the header.
+    description: >-
+      QueryBaseHeaderResponse is the response type for the Query/BaseHeader RPC
+      method.
   babylon.btclightclient.v1.QueryContainsBytesResponse:
     type: object
     properties:
@@ -11292,6 +11403,14 @@ definitions:
             work:
               type: string
               format: byte
+          description: >-
+            BTCHeaderInfo is a structure that contains all relevant information
+            about a BTC header
+             - Full header bytes
+             - Header hash for easy retrieval
+             - Height of the header in the BTC chain
+             - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+               and the total work of the header.
       pagination:
         type: object
         properties:
@@ -11346,6 +11465,15 @@ definitions:
           work:
             type: string
             format: byte
+        description: >-
+          BTCHeaderInfo is a structure that contains all relevant information
+          about a BTC header
+           - Full header bytes
+           - Header hash for easy retrieval
+           - Height of the header in the BTC chain
+           - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+             and the total work of the header.
+    description: QueryTipResponse is the response type for the Query/Tip RPC method.
   babylon.epoching.v1.BondState:
     type: string
     enum:
@@ -11590,7 +11718,7 @@ definitions:
           proposer_address:
             type: string
             format: byte
-        description: Header defines the structure of a Tendermint block header.
+        description: Header defines the structure of a block header.
   babylon.epoching.v1.Params:
     type: object
     properties:
@@ -11838,7 +11966,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
   babylon.epoching.v1.QueryEpochMsgsResponse:
     type: object
     properties:
@@ -12477,7 +12605,7 @@ definitions:
                 proposer_address:
                   type: string
                   format: byte
-              description: Header defines the structure of a Tendermint block header.
+              description: Header defines the structure of a block header.
       pagination:
         title: pagination defines the pagination in the response
         type: object
@@ -14171,7 +14299,7 @@ definitions:
       proposer_address:
         type: string
         format: byte
-    description: Header defines the structure of a Tendermint block header.
+    description: Header defines the structure of a block header.
   tendermint.types.PartSetHeader:
     type: object
     properties:
@@ -14212,7 +14340,7 @@ definitions:
           - CKPT_STATUS_FINALIZED
         default: CKPT_STATUS_ACCUMULATING
         description: |-
-          CkptStatus is the status of a checkpoint.
+          CheckpointStatus is the status of a checkpoint.
 
            - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
            - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14236,6 +14364,7 @@ definitions:
           state
 
           update
+    description: CheckpointStateUpdate defines a state transition on the checkpoint.
   babylon.checkpointing.v1.CheckpointStatus:
     type: string
     enum:
@@ -14246,7 +14375,7 @@ definitions:
       - CKPT_STATUS_FINALIZED
     default: CKPT_STATUS_ACCUMULATING
     description: |-
-      CkptStatus is the status of a checkpoint.
+      CheckpointStatus is the status of a checkpoint.
 
        - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
        - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14312,7 +14441,7 @@ definitions:
           - CKPT_STATUS_FINALIZED
         default: CKPT_STATUS_ACCUMULATING
         description: |-
-          CkptStatus is the status of a checkpoint.
+          CheckpointStatus is the status of a checkpoint.
 
            - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
            - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14355,6 +14484,9 @@ definitions:
 
               sigs
         title: RawCheckpoint wraps the BLS multi sig with meta data
+    description: |-
+      QueryLastCheckpointWithStatusResponse is the response type for the
+      Query/LastCheckpointWithStatus RPC method.
   babylon.checkpointing.v1.QueryParamsResponse:
     type: object
     properties:
@@ -14410,7 +14542,7 @@ definitions:
                 - CKPT_STATUS_FINALIZED
               default: CKPT_STATUS_ACCUMULATING
               description: |-
-                CkptStatus is the status of a checkpoint.
+                CheckpointStatus is the status of a checkpoint.
 
                  - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                  - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14443,7 +14575,7 @@ definitions:
                       - CKPT_STATUS_FINALIZED
                     default: CKPT_STATUS_ACCUMULATING
                     description: |-
-                      CkptStatus is the status of a checkpoint.
+                      CheckpointStatus is the status of a checkpoint.
 
                        - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                        - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14469,6 +14601,9 @@ definitions:
                       triggers the state
 
                       update
+                description: >-
+                  CheckpointStateUpdate defines a state transition on the
+                  checkpoint.
               description: >-
                 lifecycle defines the lifecycle of this checkpoint, i.e., each
                 state
@@ -14547,7 +14682,7 @@ definitions:
               - CKPT_STATUS_FINALIZED
             default: CKPT_STATUS_ACCUMULATING
             description: |-
-              CkptStatus is the status of a checkpoint.
+              CheckpointStatus is the status of a checkpoint.
 
                - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14578,7 +14713,7 @@ definitions:
                     - CKPT_STATUS_FINALIZED
                   default: CKPT_STATUS_ACCUMULATING
                   description: |-
-                    CkptStatus is the status of a checkpoint.
+                    CheckpointStatus is the status of a checkpoint.
 
                      - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                      - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14604,6 +14739,9 @@ definitions:
                     triggers the state
 
                     update
+              description: >-
+                CheckpointStateUpdate defines a state transition on the
+                checkpoint.
             description: >-
               lifecycle defines the lifecycle of this checkpoint, i.e., each
               state
@@ -14708,7 +14846,7 @@ definitions:
           - CKPT_STATUS_FINALIZED
         default: CKPT_STATUS_ACCUMULATING
         description: |-
-          CkptStatus is the status of a checkpoint.
+          CheckpointStatus is the status of a checkpoint.
 
            - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
            - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14739,7 +14877,7 @@ definitions:
                 - CKPT_STATUS_FINALIZED
               default: CKPT_STATUS_ACCUMULATING
               description: |-
-                CkptStatus is the status of a checkpoint.
+                CheckpointStatus is the status of a checkpoint.
 
                  - CKPT_STATUS_ACCUMULATING: ACCUMULATING defines a checkpoint that is awaiting for BLS signatures.
                  - CKPT_STATUS_SEALED: SEALED defines a checkpoint that has accumulated sufficient BLS signatures.
@@ -14763,6 +14901,7 @@ definitions:
                 the state
 
                 update
+          description: CheckpointStateUpdate defines a state transition on the checkpoint.
         description: |-
           lifecycle defines the lifecycle of this checkpoint, i.e., each state
           transition and the time (in both timestamp and block height) of this
@@ -14888,7 +15027,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
           babylon_epoch:
             type: string
             format: uint64
@@ -15012,7 +15151,7 @@ definitions:
                     proposer_address:
                       type: string
                       format: byte
-                  description: Header defines the structure of a Tendermint block header.
+                  description: Header defines the structure of a block header.
                 babylon_epoch:
                   type: string
                   format: uint64
@@ -15170,7 +15309,7 @@ definitions:
                 proposer_address:
                   type: string
                   format: byte
-              description: Header defines the structure of a Tendermint block header.
+              description: Header defines the structure of a block header.
             babylon_epoch:
               type: string
               format: uint64
@@ -15312,7 +15451,7 @@ definitions:
           proposer_address:
             type: string
             format: byte
-        description: Header defines the structure of a Tendermint block header.
+        description: Header defines the structure of a block header.
       babylon_epoch:
         type: string
         format: uint64
@@ -15755,7 +15894,7 @@ definitions:
                   proposer_address:
                     type: string
                     format: byte
-                description: Header defines the structure of a Tendermint block header.
+                description: Header defines the structure of a block header.
               babylon_epoch:
                 type: string
                 format: uint64
@@ -15880,9 +16019,7 @@ definitions:
                         proposer_address:
                           type: string
                           format: byte
-                      description: >-
-                        Header defines the structure of a Tendermint block
-                        header.
+                      description: Header defines the structure of a block header.
                     babylon_epoch:
                       type: string
                       format: uint64
@@ -16092,7 +16229,7 @@ definitions:
                   proposer_address:
                     type: string
                     format: byte
-                description: Header defines the structure of a Tendermint block header.
+                description: Header defines the structure of a block header.
               babylon_epoch:
                 type: string
                 format: uint64
@@ -16217,9 +16354,7 @@ definitions:
                         proposer_address:
                           type: string
                           format: byte
-                      description: >-
-                        Header defines the structure of a Tendermint block
-                        header.
+                      description: Header defines the structure of a block header.
                     babylon_epoch:
                       type: string
                       format: uint64
@@ -16395,7 +16530,7 @@ definitions:
                   proposer_address:
                     type: string
                     format: byte
-                description: Header defines the structure of a Tendermint block header.
+                description: Header defines the structure of a block header.
               babylon_epoch:
                 type: string
                 format: uint64
@@ -16520,9 +16655,7 @@ definitions:
                         proposer_address:
                           type: string
                           format: byte
-                      description: >-
-                        Header defines the structure of a Tendermint block
-                        header.
+                      description: Header defines the structure of a block header.
                     babylon_epoch:
                       type: string
                       format: uint64
@@ -16774,7 +16907,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
       raw_checkpoint:
         title: raw_checkpoint is the raw checkpoint of this epoch
         type: object
@@ -17158,7 +17291,7 @@ definitions:
                   proposer_address:
                     type: string
                     format: byte
-                description: Header defines the structure of a Tendermint block header.
+                description: Header defines the structure of a block header.
               babylon_epoch:
                 type: string
                 format: uint64
@@ -17283,9 +17416,7 @@ definitions:
                         proposer_address:
                           type: string
                           format: byte
-                      description: >-
-                        Header defines the structure of a Tendermint block
-                        header.
+                      description: Header defines the structure of a block header.
                     babylon_epoch:
                       type: string
                       format: uint64
@@ -17537,7 +17668,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
       raw_checkpoint:
         title: raw_checkpoint is the raw checkpoint of this epoch
         type: object
@@ -17913,7 +18044,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
           babylon_epoch:
             type: string
             format: uint64
@@ -18033,7 +18164,7 @@ definitions:
                     proposer_address:
                       type: string
                       format: byte
-                  description: Header defines the structure of a Tendermint block header.
+                  description: Header defines the structure of a block header.
                 babylon_epoch:
                   type: string
                   format: uint64
@@ -18185,7 +18316,7 @@ definitions:
                 proposer_address:
                   type: string
                   format: byte
-              description: Header defines the structure of a Tendermint block header.
+              description: Header defines the structure of a block header.
             babylon_epoch:
               type: string
               format: uint64
@@ -18311,7 +18442,7 @@ definitions:
                 proposer_address:
                   type: string
                   format: byte
-              description: Header defines the structure of a Tendermint block header.
+              description: Header defines the structure of a block header.
             babylon_epoch:
               type: string
               format: uint64

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -120,17 +120,21 @@ paths:
                               submission message MsgInsertBTCSpvProof itself
                         title: >-
                           CheckpointAddresses contains the addresses of the
-                          submitter and reporter of a given checkpoint
+                          submitter and reporter of a
 
-                          submitter is the address of the submitter of the
-                          checkpoint to BTC
+                          given checkpoint submitter is the address of the
+                          submitter of the checkpoint
 
-                          reporter is the address of the submitter of the
-                          MsgInsertBTCSpvProof message to Babylon
+                          to BTC reporter is the address of the submitter of the
+                          MsgInsertBTCSpvProof
+
+                          message to Babylon
                       title: list of vigilantes' addresses
                   description: >-
                     BTCCheckpointInfo contains all checkpoint related data
-                    expected in a query response.
+                    expected in a query
+
+                    response.
               pagination:
                 title: pagination defines the pagination in the response
                 type: object
@@ -424,17 +428,21 @@ paths:
                             submission message MsgInsertBTCSpvProof itself
                       title: >-
                         CheckpointAddresses contains the addresses of the
-                        submitter and reporter of a given checkpoint
+                        submitter and reporter of a
 
-                        submitter is the address of the submitter of the
-                        checkpoint to BTC
+                        given checkpoint submitter is the address of the
+                        submitter of the checkpoint
 
-                        reporter is the address of the submitter of the
-                        MsgInsertBTCSpvProof message to Babylon
+                        to BTC reporter is the address of the submitter of the
+                        MsgInsertBTCSpvProof
+
+                        message to Babylon
                     title: list of vigilantes' addresses
                 description: >-
                   BTCCheckpointInfo contains all checkpoint related data
-                  expected in a query response.
+                  expected in a query
+
+                  response.
             title: |-
               QueryBtcCheckpointInfoResponse is response type for the
               Query/BtcCheckpointInfo RPC method
@@ -554,7 +562,9 @@ paths:
                    }
             title: >-
               QueryEpochSubmissionsResponse defines a response to get all
-              submissions in given epoch (QueryEpochSubmissionsRequest)
+              submissions in
+
+              given epoch (QueryEpochSubmissionsRequest)
         default:
           description: An unexpected error response.
           schema:
@@ -646,7 +656,9 @@ paths:
     get:
       summary: >-
         BaseHeader returns the base BTC header of the chain. This header is
-        defined on genesis.
+        defined
+
+        on genesis.
       operationId: BaseHeader
       responses:
         '200':
@@ -671,15 +683,20 @@ paths:
                     format: byte
                 description: >-
                   BTCHeaderInfo is a structure that contains all relevant
-                  information about a BTC header
+                  information about a
+
+                  BTC header
                    - Full header bytes
                    - Header hash for easy retrieval
                    - Height of the header in the BTC chain
-                   - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+                   - Total work spent on the header. This is the sum of the work corresponding
+                   to the header Bits field
                      and the total work of the header.
             description: >-
               QueryBaseHeaderResponse is the response type for the
-              Query/BaseHeader RPC method.
+              Query/BaseHeader RPC
+
+              method.
         default:
           description: An unexpected error response.
           schema:
@@ -956,11 +973,14 @@ paths:
                       format: byte
                   description: >-
                     BTCHeaderInfo is a structure that contains all relevant
-                    information about a BTC header
+                    information about a
+
+                    BTC header
                      - Full header bytes
                      - Header hash for easy retrieval
                      - Height of the header in the BTC chain
-                     - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+                     - Total work spent on the header. This is the sum of the work corresponding
+                     to the header Bits field
                        and the total work of the header.
               pagination:
                 type: object
@@ -1141,11 +1161,14 @@ paths:
                     format: byte
                 description: >-
                   BTCHeaderInfo is a structure that contains all relevant
-                  information about a BTC header
+                  information about a
+
+                  BTC header
                    - Full header bytes
                    - Header hash for easy retrieval
                    - Height of the header in the BTC chain
-                   - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+                   - Total work spent on the header. This is the sum of the work corresponding
+                   to the header Bits field
                      and the total work of the header.
             description: >-
               QueryTipResponse is the response type for the Query/Tip RPC
@@ -1419,6 +1442,16 @@ paths:
                             - UNBONDED
                             - REMOVED
                           default: CREATED
+                          description: >-
+                            - CREATED: CREATED is when the validator/delegation
+                            has been created
+                             - BONDED: CREATED is when the validator/delegation has become bonded
+                             - UNBONDING: CREATED is when the validator/delegation has become unbonding
+                             - UNBONDED: CREATED is when the validator/delegation has become unbonded
+                             - REMOVED: CREATED is when the validator/delegation has been removed
+                          title: >-
+                            BondState is the bond state of a validator or
+                            delegation
                         val_addr:
                           type: string
                         block_height:
@@ -1427,6 +1460,19 @@ paths:
                         block_time:
                           type: string
                           format: date-time
+                      title: >-
+                        DelegationStateUpdate is the message that records a
+                        state update of a
+
+                        delegation
+                title: >-
+                  ValidatorLifecycle is a message that records records the
+                  lifecycle of
+
+                  a delegation
+            title: |-
+              QueryDelegationLifecycleRequest is the response type for the
+              Query/DelegationLifecycle RPC method
         default:
           description: An unexpected error response.
           schema:
@@ -1837,6 +1883,7 @@ paths:
                           type: string
                           format: byte
                       description: Header defines the structure of a block header.
+                  title: Epoch is a structure that contains the metadata of an epoch
               pagination:
                 title: pagination defines the pagination in the response
                 type: object
@@ -1866,6 +1913,9 @@ paths:
                            repeated Bar results = 1;
                            PageResponse page = 2;
                    }
+            title: >-
+              QueryEpochsInfoResponse is the response type for the
+              Query/EpochInfos method
         default:
           description: An unexpected error response.
           schema:
@@ -2320,6 +2370,10 @@ paths:
                         type: string
                         format: byte
                     description: Header defines the structure of a block header.
+                title: Epoch is a structure that contains the metadata of an epoch
+            title: >-
+              QueryEpochInfoRequest is the response type for the Query/EpochInfo
+              method
         default:
           description: An unexpected error response.
           schema:
@@ -3219,6 +3273,7 @@ paths:
                       type: string
                       format: int64
                       title: power is the validator's voting power
+                  title: Validator is a message that denotes a validator
               total_voting_power:
                 type: string
                 format: int64
@@ -3250,6 +3305,11 @@ paths:
                            repeated Bar results = 1;
                            PageResponse page = 2;
                    }
+            title: >-
+              QueryEpochValSetRequest is the response type for the
+              Query/EpochValSet RPC
+
+              method
         default:
           description: An unexpected error response.
           schema:
@@ -3910,6 +3970,11 @@ paths:
                           validator set and is delayed
 
                           to the epoch boundary
+                  title: >-
+                    QueuedMessageList is a message that contains a list of
+                    staking-related
+
+                    messages queued for an epoch
                 title: >-
                   epoch_msg_map is a list of QueuedMessageList
 
@@ -4453,12 +4518,33 @@ paths:
                             - UNBONDED
                             - REMOVED
                           default: CREATED
+                          description: >-
+                            - CREATED: CREATED is when the validator/delegation
+                            has been created
+                             - BONDED: CREATED is when the validator/delegation has become bonded
+                             - UNBONDING: CREATED is when the validator/delegation has become unbonding
+                             - UNBONDED: CREATED is when the validator/delegation has become unbonded
+                             - REMOVED: CREATED is when the validator/delegation has been removed
+                          title: >-
+                            BondState is the bond state of a validator or
+                            delegation
                         block_height:
                           type: string
                           format: uint64
                         block_time:
                           type: string
                           format: date-time
+                      title: >-
+                        ValStateUpdate is a messages that records a state update
+                        of a validator
+                title: >-
+                  ValidatorLifecycle is a message that records records the
+                  lifecycle of
+
+                  a validator
+            title: |-
+              QueryValidatorLifecycleResponse is the response type for the
+              Query/ValidatorLifecycle RPC method
         default:
           description: An unexpected error response.
           schema:
@@ -10330,14 +10416,17 @@ definitions:
                 submission message MsgInsertBTCSpvProof itself
           title: >-
             CheckpointAddresses contains the addresses of the submitter and
-            reporter of a given checkpoint
+            reporter of a
 
-            submitter is the address of the submitter of the checkpoint to BTC
+            given checkpoint submitter is the address of the submitter of the
+            checkpoint
 
-            reporter is the address of the submitter of the MsgInsertBTCSpvProof
+            to BTC reporter is the address of the submitter of the
+            MsgInsertBTCSpvProof
+
             message to Babylon
         title: list of vigilantes' addresses
-    description: >-
+    description: |-
       BTCCheckpointInfo contains all checkpoint related data expected in a query
       response.
   babylon.btccheckpoint.v1.CheckpointAddresses:
@@ -10361,11 +10450,14 @@ definitions:
           submission message MsgInsertBTCSpvProof itself
     title: >-
       CheckpointAddresses contains the addresses of the submitter and reporter
-      of a given checkpoint
+      of a
 
-      submitter is the address of the submitter of the checkpoint to BTC
+      given checkpoint submitter is the address of the submitter of the
+      checkpoint
 
-      reporter is the address of the submitter of the MsgInsertBTCSpvProof
+      to BTC reporter is the address of the submitter of the
+      MsgInsertBTCSpvProof
+
       message to Babylon
   babylon.btccheckpoint.v1.Params:
     type: object
@@ -10503,17 +10595,21 @@ definitions:
                     submission message MsgInsertBTCSpvProof itself
               title: >-
                 CheckpointAddresses contains the addresses of the submitter and
-                reporter of a given checkpoint
+                reporter of a
 
-                submitter is the address of the submitter of the checkpoint to
-                BTC
+                given checkpoint submitter is the address of the submitter of
+                the checkpoint
 
-                reporter is the address of the submitter of the
-                MsgInsertBTCSpvProof message to Babylon
+                to BTC reporter is the address of the submitter of the
+                MsgInsertBTCSpvProof
+
+                message to Babylon
             title: list of vigilantes' addresses
         description: >-
           BTCCheckpointInfo contains all checkpoint related data expected in a
-          query response.
+          query
+
+          response.
     title: |-
       QueryBtcCheckpointInfoResponse is response type for the
       Query/BtcCheckpointInfo RPC method
@@ -10623,17 +10719,21 @@ definitions:
                       submission message MsgInsertBTCSpvProof itself
                 title: >-
                   CheckpointAddresses contains the addresses of the submitter
-                  and reporter of a given checkpoint
+                  and reporter of a
 
-                  submitter is the address of the submitter of the checkpoint to
-                  BTC
+                  given checkpoint submitter is the address of the submitter of
+                  the checkpoint
 
-                  reporter is the address of the submitter of the
-                  MsgInsertBTCSpvProof message to Babylon
+                  to BTC reporter is the address of the submitter of the
+                  MsgInsertBTCSpvProof
+
+                  message to Babylon
               title: list of vigilantes' addresses
           description: >-
             BTCCheckpointInfo contains all checkpoint related data expected in a
-            query response.
+            query
+
+            response.
       pagination:
         title: pagination defines the pagination in the response
         type: object
@@ -10734,7 +10834,7 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
-    title: >-
+    title: |-
       QueryEpochSubmissionsResponse defines a response to get all submissions in
       given epoch (QueryEpochSubmissionsRequest)
   babylon.btccheckpoint.v1.QueryParamsResponse:
@@ -11294,11 +11394,14 @@ definitions:
         format: byte
     description: >-
       BTCHeaderInfo is a structure that contains all relevant information about
-      a BTC header
+      a
+
+      BTC header
        - Full header bytes
        - Header hash for easy retrieval
        - Height of the header in the BTC chain
-       - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+       - Total work spent on the header. This is the sum of the work corresponding
+       to the header Bits field
          and the total work of the header.
   babylon.btclightclient.v1.Params:
     type: object
@@ -11323,13 +11426,16 @@ definitions:
             format: byte
         description: >-
           BTCHeaderInfo is a structure that contains all relevant information
-          about a BTC header
+          about a
+
+          BTC header
            - Full header bytes
            - Header hash for easy retrieval
            - Height of the header in the BTC chain
-           - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+           - Total work spent on the header. This is the sum of the work corresponding
+           to the header Bits field
              and the total work of the header.
-    description: >-
+    description: |-
       QueryBaseHeaderResponse is the response type for the Query/BaseHeader RPC
       method.
   babylon.btclightclient.v1.QueryContainsBytesResponse:
@@ -11405,11 +11511,14 @@ definitions:
               format: byte
           description: >-
             BTCHeaderInfo is a structure that contains all relevant information
-            about a BTC header
+            about a
+
+            BTC header
              - Full header bytes
              - Header hash for easy retrieval
              - Height of the header in the BTC chain
-             - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+             - Total work spent on the header. This is the sum of the work corresponding
+             to the header Bits field
                and the total work of the header.
       pagination:
         type: object
@@ -11467,11 +11576,14 @@ definitions:
             format: byte
         description: >-
           BTCHeaderInfo is a structure that contains all relevant information
-          about a BTC header
+          about a
+
+          BTC header
            - Full header bytes
            - Header hash for easy retrieval
            - Height of the header in the BTC chain
-           - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+           - Total work spent on the header. This is the sum of the work corresponding
+           to the header Bits field
              and the total work of the header.
     description: QueryTipResponse is the response type for the Query/Tip RPC method.
   babylon.epoching.v1.BondState:
@@ -11483,6 +11595,13 @@ definitions:
       - UNBONDED
       - REMOVED
     default: CREATED
+    description: |-
+      - CREATED: CREATED is when the validator/delegation has been created
+       - BONDED: CREATED is when the validator/delegation has become bonded
+       - UNBONDING: CREATED is when the validator/delegation has become unbonding
+       - UNBONDED: CREATED is when the validator/delegation has become unbonded
+       - REMOVED: CREATED is when the validator/delegation has been removed
+    title: BondState is the bond state of a validator or delegation
   babylon.epoching.v1.DelegationLifecycle:
     type: object
     properties:
@@ -11502,6 +11621,14 @@ definitions:
                 - UNBONDED
                 - REMOVED
               default: CREATED
+              description: >-
+                - CREATED: CREATED is when the validator/delegation has been
+                created
+                 - BONDED: CREATED is when the validator/delegation has become bonded
+                 - UNBONDING: CREATED is when the validator/delegation has become unbonding
+                 - UNBONDED: CREATED is when the validator/delegation has become unbonded
+                 - REMOVED: CREATED is when the validator/delegation has been removed
+              title: BondState is the bond state of a validator or delegation
             val_addr:
               type: string
             block_height:
@@ -11510,6 +11637,14 @@ definitions:
             block_time:
               type: string
               format: date-time
+          title: >-
+            DelegationStateUpdate is the message that records a state update of
+            a
+
+            delegation
+    title: |-
+      ValidatorLifecycle is a message that records records the lifecycle of
+      a delegation
   babylon.epoching.v1.DelegationStateUpdate:
     type: object
     properties:
@@ -11522,6 +11657,13 @@ definitions:
           - UNBONDED
           - REMOVED
         default: CREATED
+        description: |-
+          - CREATED: CREATED is when the validator/delegation has been created
+           - BONDED: CREATED is when the validator/delegation has become bonded
+           - UNBONDING: CREATED is when the validator/delegation has become unbonding
+           - UNBONDED: CREATED is when the validator/delegation has become unbonded
+           - REMOVED: CREATED is when the validator/delegation has been removed
+        title: BondState is the bond state of a validator or delegation
       val_addr:
         type: string
       block_height:
@@ -11530,6 +11672,9 @@ definitions:
       block_time:
         type: string
         format: date-time
+    title: |-
+      DelegationStateUpdate is the message that records a state update of a
+      delegation
   babylon.epoching.v1.Epoch:
     type: object
     properties:
@@ -11719,6 +11864,7 @@ definitions:
             type: string
             format: byte
         description: Header defines the structure of a block header.
+    title: Epoch is a structure that contains the metadata of an epoch
   babylon.epoching.v1.Params:
     type: object
     properties:
@@ -11765,6 +11911,14 @@ definitions:
                     - UNBONDED
                     - REMOVED
                   default: CREATED
+                  description: >-
+                    - CREATED: CREATED is when the validator/delegation has been
+                    created
+                     - BONDED: CREATED is when the validator/delegation has become bonded
+                     - UNBONDING: CREATED is when the validator/delegation has become unbonding
+                     - UNBONDED: CREATED is when the validator/delegation has become unbonded
+                     - REMOVED: CREATED is when the validator/delegation has been removed
+                  title: BondState is the bond state of a validator or delegation
                 val_addr:
                   type: string
                 block_height:
@@ -11773,6 +11927,17 @@ definitions:
                 block_time:
                   type: string
                   format: date-time
+              title: >-
+                DelegationStateUpdate is the message that records a state update
+                of a
+
+                delegation
+        title: |-
+          ValidatorLifecycle is a message that records records the lifecycle of
+          a delegation
+    title: |-
+      QueryDelegationLifecycleRequest is the response type for the
+      Query/DelegationLifecycle RPC method
   babylon.epoching.v1.QueryEpochInfoResponse:
     type: object
     properties:
@@ -11967,6 +12132,8 @@ definitions:
                 type: string
                 format: byte
             description: Header defines the structure of a block header.
+        title: Epoch is a structure that contains the metadata of an epoch
+    title: QueryEpochInfoRequest is the response type for the Query/EpochInfo method
   babylon.epoching.v1.QueryEpochMsgsResponse:
     type: object
     properties:
@@ -12381,6 +12548,7 @@ definitions:
               type: string
               format: int64
               title: power is the validator's voting power
+          title: Validator is a message that denotes a validator
       total_voting_power:
         type: string
         format: int64
@@ -12410,6 +12578,9 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
+    title: |-
+      QueryEpochValSetRequest is the response type for the Query/EpochValSet RPC
+      method
   babylon.epoching.v1.QueryEpochsInfoResponse:
     type: object
     properties:
@@ -12606,6 +12777,7 @@ definitions:
                   type: string
                   format: byte
               description: Header defines the structure of a block header.
+          title: Epoch is a structure that contains the metadata of an epoch
       pagination:
         title: pagination defines the pagination in the response
         type: object
@@ -12633,6 +12805,9 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
+    title: >-
+      QueryEpochsInfoResponse is the response type for the Query/EpochInfos
+      method
   babylon.epoching.v1.QueryLatestEpochMsgsResponse:
     type: object
     properties:
@@ -13018,6 +13193,11 @@ definitions:
                   and is delayed
 
                   to the epoch boundary
+          title: >-
+            QueuedMessageList is a message that contains a list of
+            staking-related
+
+            messages queued for an epoch
         title: |-
           epoch_msg_map is a list of QueuedMessageList
           each QueuedMessageList has a field identifying the epoch number
@@ -13086,12 +13266,29 @@ definitions:
                     - UNBONDED
                     - REMOVED
                   default: CREATED
+                  description: >-
+                    - CREATED: CREATED is when the validator/delegation has been
+                    created
+                     - BONDED: CREATED is when the validator/delegation has become bonded
+                     - UNBONDING: CREATED is when the validator/delegation has become unbonding
+                     - UNBONDED: CREATED is when the validator/delegation has become unbonded
+                     - REMOVED: CREATED is when the validator/delegation has been removed
+                  title: BondState is the bond state of a validator or delegation
                 block_height:
                   type: string
                   format: uint64
                 block_time:
                   type: string
                   format: date-time
+              title: >-
+                ValStateUpdate is a messages that records a state update of a
+                validator
+        title: |-
+          ValidatorLifecycle is a message that records records the lifecycle of
+          a validator
+    title: |-
+      QueryValidatorLifecycleResponse is the response type for the
+      Query/ValidatorLifecycle RPC method
   babylon.epoching.v1.QueuedMessage:
     type: object
     properties:
@@ -13805,6 +14002,9 @@ definitions:
             delayed
 
             to the epoch boundary
+    title: |-
+      QueuedMessageList is a message that contains a list of staking-related
+      messages queued for an epoch
   babylon.epoching.v1.ValStateUpdate:
     type: object
     properties:
@@ -13817,12 +14017,20 @@ definitions:
           - UNBONDED
           - REMOVED
         default: CREATED
+        description: |-
+          - CREATED: CREATED is when the validator/delegation has been created
+           - BONDED: CREATED is when the validator/delegation has become bonded
+           - UNBONDING: CREATED is when the validator/delegation has become unbonding
+           - UNBONDED: CREATED is when the validator/delegation has become unbonded
+           - REMOVED: CREATED is when the validator/delegation has been removed
+        title: BondState is the bond state of a validator or delegation
       block_height:
         type: string
         format: uint64
       block_time:
         type: string
         format: date-time
+    title: ValStateUpdate is a messages that records a state update of a validator
   babylon.epoching.v1.Validator:
     type: object
     properties:
@@ -13834,6 +14042,7 @@ definitions:
         type: string
         format: int64
         title: power is the validator's voting power
+    title: Validator is a message that denotes a validator
   babylon.epoching.v1.ValidatorLifecycle:
     type: object
     properties:
@@ -13853,12 +14062,26 @@ definitions:
                 - UNBONDED
                 - REMOVED
               default: CREATED
+              description: >-
+                - CREATED: CREATED is when the validator/delegation has been
+                created
+                 - BONDED: CREATED is when the validator/delegation has become bonded
+                 - UNBONDING: CREATED is when the validator/delegation has become unbonding
+                 - UNBONDED: CREATED is when the validator/delegation has become unbonded
+                 - REMOVED: CREATED is when the validator/delegation has been removed
+              title: BondState is the bond state of a validator or delegation
             block_height:
               type: string
               format: uint64
             block_time:
               type: string
               format: date-time
+          title: >-
+            ValStateUpdate is a messages that records a state update of a
+            validator
+    title: |-
+      ValidatorLifecycle is a message that records records the lifecycle of
+      a validator
   cosmos.base.v1beta1.Coin:
     type: object
     properties:

--- a/proto/babylon/btccheckpoint/v1/btccheckpoint.proto
+++ b/proto/babylon/btccheckpoint/v1/btccheckpoint.proto
@@ -121,15 +121,14 @@ message EpochData {
 }
 
 // CheckpointAddresses contains the addresses of the submitter and reporter of a
-// given checkpoint submitter is the address of the submitter of the checkpoint
-// to BTC reporter is the address of the submitter of the MsgInsertBTCSpvProof
-// message to Babylon
+// given checkpoint
 message CheckpointAddresses {
   // TODO: this could probably be better typed
-  // Address of the checkpoint submitter, extracted from the checkpoint itself.
+  // submitter is the address of the checkpoint submitter to BTC, extracted from
+  // the checkpoint itself.
   bytes submitter = 1;
-  // Address of the reporter which reported the submissions, calculated from
-  // submission message MsgInsertBTCSpvProof itself
+  // reporter is the address of the reporter who reported the submissions,
+  // calculated from submission message MsgInsertBTCSpvProof itself
   bytes reporter = 2;
 }
 

--- a/proto/babylon/btccheckpoint/v1/btccheckpoint.proto
+++ b/proto/babylon/btccheckpoint/v1/btccheckpoint.proto
@@ -120,9 +120,10 @@ message EpochData {
   BtcStatus status = 2;
 }
 
-// CheckpointAddresses contains the addresses of the submitter and reporter of a given checkpoint
-// submitter is the address of the submitter of the checkpoint to BTC
-// reporter is the address of the submitter of the MsgInsertBTCSpvProof message to Babylon
+// CheckpointAddresses contains the addresses of the submitter and reporter of a
+// given checkpoint submitter is the address of the submitter of the checkpoint
+// to BTC reporter is the address of the submitter of the MsgInsertBTCSpvProof
+// message to Babylon
 message CheckpointAddresses {
   // TODO: this could probably be better typed
   // Address of the checkpoint submitter, extracted from the checkpoint itself.
@@ -132,7 +133,8 @@ message CheckpointAddresses {
   bytes reporter = 2;
 }
 
-// BTCCheckpointInfo contains all checkpoint related data expected in a query response.
+// BTCCheckpointInfo contains all checkpoint related data expected in a query
+// response.
 message BTCCheckpointInfo {
   // epoch number of this checkpoint
   uint64 epoch_number = 1;

--- a/proto/babylon/btccheckpoint/v1/query.proto
+++ b/proto/babylon/btccheckpoint/v1/query.proto
@@ -45,7 +45,8 @@ message QueryParamsResponse {
   Params params = 1 [ (gogoproto.nullable) = false ];
 }
 
-// QueryBtcCheckpointInfoRequest defines the query to get the best checkpoint for a given epoch
+// QueryBtcCheckpointInfoRequest defines the query to get the best checkpoint
+// for a given epoch
 message QueryBtcCheckpointInfoRequest {
   // Number of epoch for which the earliest checkpointing btc height is
   // requested
@@ -71,7 +72,8 @@ message QueryBtcCheckpointsInfoResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryEpochSubmissionsRequest defines a request to get all submissions in given epoch
+// QueryEpochSubmissionsRequest defines a request to get all submissions in
+// given epoch
 message QueryEpochSubmissionsRequest {
   // Number of epoch for which submissions are requested
   uint64 epoch_num = 1;
@@ -79,7 +81,8 @@ message QueryEpochSubmissionsRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QueryEpochSubmissionsResponse defines a response to get all submissions in given epoch (QueryEpochSubmissionsRequest)
+// QueryEpochSubmissionsResponse defines a response to get all submissions in
+// given epoch (QueryEpochSubmissionsRequest)
 message QueryEpochSubmissionsResponse {
   // All submissions saved during an epoch.
   repeated SubmissionKey keys = 1;

--- a/proto/babylon/btccheckpoint/v1/tx.proto
+++ b/proto/babylon/btccheckpoint/v1/tx.proto
@@ -12,11 +12,13 @@ service Msg {
       returns (MsgInsertBTCSpvProofResponse);
 }
 
-// MsgInsertBTCSpvProof defines resquest to insert a new checkpoint into the store
+// MsgInsertBTCSpvProof defines resquest to insert a new checkpoint into the
+// store
 message MsgInsertBTCSpvProof {
   string submitter = 1;
   repeated babylon.btccheckpoint.v1.BTCSpvProof proofs = 2;
 }
 
-// MsgInsertBTCSpvProofResponse defines the response for the MsgInsertBTCSpvProof message
+// MsgInsertBTCSpvProofResponse defines the response for the
+// MsgInsertBTCSpvProof message
 message MsgInsertBTCSpvProofResponse {}

--- a/proto/babylon/btclightclient/v1/btclightclient.proto
+++ b/proto/babylon/btclightclient/v1/btclightclient.proto
@@ -5,11 +5,13 @@ import "gogoproto/gogo.proto";
 
 option go_package = "github.com/babylonchain/babylon/x/btclightclient/types";
 
-// BTCHeaderInfo is a structure that contains all relevant information about a BTC header
+// BTCHeaderInfo is a structure that contains all relevant information about a
+// BTC header
 //  - Full header bytes
 //  - Header hash for easy retrieval
 //  - Height of the header in the BTC chain
-//  - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+//  - Total work spent on the header. This is the sum of the work corresponding
+//  to the header Bits field
 //    and the total work of the header.
 message BTCHeaderInfo {
   bytes header = 1

--- a/proto/babylon/btclightclient/v1/query.proto
+++ b/proto/babylon/btclightclient/v1/query.proto
@@ -45,7 +45,8 @@ service Query {
     option (google.api.http).get = "/babylon/btclightclient/v1/tip";
   }
 
-  // BaseHeader returns the base BTC header of the chain. This header is defined on genesis.
+  // BaseHeader returns the base BTC header of the chain. This header is defined
+  // on genesis.
   rpc BaseHeader(QueryBaseHeaderRequest) returns (QueryBaseHeaderResponse) {
     option (google.api.http).get = "/babylon/btclightclient/v1/baseheader";
   }
@@ -111,8 +112,10 @@ message QueryTipRequest {}
 // QueryTipResponse is the response type for the Query/Tip RPC method.
 message QueryTipResponse { BTCHeaderInfo header = 1; }
 
-// QueryBaseHeaderRequest is the request type for the Query/BaseHeader RPC method.
+// QueryBaseHeaderRequest is the request type for the Query/BaseHeader RPC
+// method.
 message QueryBaseHeaderRequest {}
 
-// QueryBaseHeaderResponse is the response type for the Query/BaseHeader RPC method.
+// QueryBaseHeaderResponse is the response type for the Query/BaseHeader RPC
+// method.
 message QueryBaseHeaderResponse { BTCHeaderInfo header = 1; }

--- a/proto/babylon/btclightclient/v1/tx.proto
+++ b/proto/babylon/btclightclient/v1/tx.proto
@@ -7,7 +7,8 @@ option go_package = "github.com/babylonchain/babylon/x/btclightclient/types";
 
 // Msg defines the Msg service.
 service Msg {
-  // InsertHeader adds a header to the BTC light client chain maintained by Babylon.
+  // InsertHeader adds a header to the BTC light client chain maintained by
+  // Babylon.
   rpc InsertHeader(MsgInsertHeader) returns (MsgInsertHeaderResponse) {};
 }
 

--- a/proto/babylon/checkpointing/v1/events.proto
+++ b/proto/babylon/checkpointing/v1/events.proto
@@ -5,25 +5,32 @@ import "babylon/checkpointing/v1/checkpoint.proto";
 
 option go_package = "github.com/babylonchain/babylon/x/checkpointing/types";
 
-// EventCheckpointAccumulating is emitted when a checkpoint reaches the `Accumulating` state.
+// EventCheckpointAccumulating is emitted when a checkpoint reaches the
+// `Accumulating` state.
 message EventCheckpointAccumulating { RawCheckpointWithMeta checkpoint = 1; }
 
-// EventCheckpointSealed is emitted when a checkpoint reaches the `Sealed` state.
+// EventCheckpointSealed is emitted when a checkpoint reaches the `Sealed`
+// state.
 message EventCheckpointSealed { RawCheckpointWithMeta checkpoint = 1; }
 
-// EventCheckpointSubmitted is emitted when a checkpoint reaches the `Submitted` state.
+// EventCheckpointSubmitted is emitted when a checkpoint reaches the `Submitted`
+// state.
 message EventCheckpointSubmitted { RawCheckpointWithMeta checkpoint = 1; }
 
-// EventCheckpointConfirmed is emitted when a checkpoint reaches the `Confirmed` state.
+// EventCheckpointConfirmed is emitted when a checkpoint reaches the `Confirmed`
+// state.
 message EventCheckpointConfirmed { RawCheckpointWithMeta checkpoint = 1; }
 
-// EventCheckpointFinalized is emitted when a checkpoint reaches the `Finalized` state.
+// EventCheckpointFinalized is emitted when a checkpoint reaches the `Finalized`
+// state.
 message EventCheckpointFinalized { RawCheckpointWithMeta checkpoint = 1; }
 
-// EventCheckpointForgotten is emitted when a checkpoint switches to a `Forgotten` state.
+// EventCheckpointForgotten is emitted when a checkpoint switches to a
+// `Forgotten` state.
 message EventCheckpointForgotten { RawCheckpointWithMeta checkpoint = 1; }
 
-// EventConflictingCheckpoint is emitted when two conflicting checkpoints are found.
+// EventConflictingCheckpoint is emitted when two conflicting checkpoints are
+// found.
 message EventConflictingCheckpoint {
   RawCheckpoint conflicting_checkpoint = 1;
   RawCheckpointWithMeta local_checkpoint = 2;

--- a/proto/babylon/epoching/v1/epoching.proto
+++ b/proto/babylon/epoching/v1/epoching.proto
@@ -8,6 +8,7 @@ import "cosmos/staking/v1beta1/tx.proto";
 
 option go_package = "github.com/babylonchain/babylon/x/epoching/types";
 
+// Epoch is a structure that contains the metadata of an epoch
 message Epoch {
   uint64 epoch_number = 1;
   uint64 current_epoch_interval = 2;
@@ -49,30 +50,43 @@ message QueuedMessage {
   }
 }
 
+// QueuedMessageList is a message that contains a list of staking-related
+// messages queued for an epoch
 message QueuedMessageList {
   uint64 epoch_number = 1;
   repeated QueuedMessage msgs = 2;
 }
 
+// BondState is the bond state of a validator or delegation
 enum BondState {
+  // CREATED is when the validator/delegation has been created
   CREATED = 0;
+  // CREATED is when the validator/delegation has become bonded
   BONDED = 1;
+  // CREATED is when the validator/delegation has become unbonding
   UNBONDING = 2;
+  // CREATED is when the validator/delegation has become unbonded
   UNBONDED = 3;
+  // CREATED is when the validator/delegation has been removed
   REMOVED = 4;
 }
 
+// ValStateUpdate is a messages that records a state update of a validator
 message ValStateUpdate {
   BondState state = 1;
   uint64 block_height = 2;
   google.protobuf.Timestamp block_time = 3 [ (gogoproto.stdtime) = true ];
 }
 
+// ValidatorLifecycle is a message that records records the lifecycle of
+// a validator
 message ValidatorLifecycle {
   string val_addr = 1;
   repeated ValStateUpdate val_life = 2;
 }
 
+// DelegationStateUpdate is the message that records a state update of a
+// delegation
 message DelegationStateUpdate {
   BondState state = 1;
   string val_addr = 2;
@@ -80,11 +94,14 @@ message DelegationStateUpdate {
   google.protobuf.Timestamp block_time = 4 [ (gogoproto.stdtime) = true ];
 }
 
+// ValidatorLifecycle is a message that records records the lifecycle of
+// a delegation
 message DelegationLifecycle {
   string del_addr = 1;
   repeated DelegationStateUpdate del_life = 2;
 }
 
+// Validator is a message that denotes a validator
 message Validator {
   // addr is the validator's address (in sdk.ValAddress)
   bytes addr = 1;

--- a/proto/babylon/epoching/v1/events.proto
+++ b/proto/babylon/epoching/v1/events.proto
@@ -5,13 +5,14 @@ import "gogoproto/gogo.proto";
 
 option go_package = "github.com/babylonchain/babylon/x/epoching/types";
 
-// EventBeginEpoch is the event that an epoch has started
+// EventBeginEpoch is the event emitted when an epoch has started
 message EventBeginEpoch { uint64 epoch_number = 1; }
 
-// EventEndEpoch is the event that an epoch has ended
+// EventEndEpoch is the event emitted when an epoch has ended
 message EventEndEpoch { uint64 epoch_number = 1; }
 
-// EventHandleQueuedMsg is the event that a queued message has been handled
+// EventHandleQueuedMsg is the event emitted when a queued message has been
+// handled
 message EventHandleQueuedMsg {
   string original_event_type = 1;
   uint64 epoch_number = 2;
@@ -24,14 +25,16 @@ message EventHandleQueuedMsg {
   string error = 7;
 }
 
-// EventSlashThreshold is the event that a set of validators have been slashed
+// EventSlashThreshold is the event emitted when a set of validators have been
+// slashed
 message EventSlashThreshold {
   int64 slashed_voting_power = 1;
   int64 total_voting_power = 2;
   repeated bytes slashed_validators = 3;
 }
 
-// EventWrappedDelegate is the event that a MsgWrappedDelegate has been queued
+// EventWrappedDelegate is the event emitted when a MsgWrappedDelegate has been
+// queued
 message EventWrappedDelegate {
   string delegator_address = 1;
   string validator_address = 2;
@@ -40,8 +43,8 @@ message EventWrappedDelegate {
   uint64 epoch_boundary = 5;
 }
 
-// EventWrappedUndelegate is the event that a MsgWrappedUndelegate has been
-// queued
+// EventWrappedUndelegate is the event emitted when a MsgWrappedUndelegate has
+// been queued
 message EventWrappedUndelegate {
   string delegator_address = 1;
   string validator_address = 2;
@@ -50,8 +53,8 @@ message EventWrappedUndelegate {
   uint64 epoch_boundary = 5;
 }
 
-// EventWrappedBeginRedelegate is the event that a MsgWrappedBeginRedelegate has
-// been queued
+// EventWrappedBeginRedelegate is the event emitted when a
+// MsgWrappedBeginRedelegate has been queued
 message EventWrappedBeginRedelegate {
   string delegator_address = 1;
   string source_validator_address = 2;

--- a/proto/babylon/epoching/v1/events.proto
+++ b/proto/babylon/epoching/v1/events.proto
@@ -5,10 +5,13 @@ import "gogoproto/gogo.proto";
 
 option go_package = "github.com/babylonchain/babylon/x/epoching/types";
 
+// EventBeginEpoch is the event that an epoch has started
 message EventBeginEpoch { uint64 epoch_number = 1; }
 
+// EventEndEpoch is the event that an epoch has ended
 message EventEndEpoch { uint64 epoch_number = 1; }
 
+// EventHandleQueuedMsg is the event that a queued message has been handled
 message EventHandleQueuedMsg {
   string original_event_type = 1;
   uint64 epoch_number = 2;
@@ -21,12 +24,14 @@ message EventHandleQueuedMsg {
   string error = 7;
 }
 
+// EventSlashThreshold is the event that a set of validators have been slashed
 message EventSlashThreshold {
   int64 slashed_voting_power = 1;
   int64 total_voting_power = 2;
   repeated bytes slashed_validators = 3;
 }
 
+// EventWrappedDelegate is the event that a MsgWrappedDelegate has been queued
 message EventWrappedDelegate {
   string delegator_address = 1;
   string validator_address = 2;
@@ -35,6 +40,8 @@ message EventWrappedDelegate {
   uint64 epoch_boundary = 5;
 }
 
+// EventWrappedUndelegate is the event that a MsgWrappedUndelegate has been
+// queued
 message EventWrappedUndelegate {
   string delegator_address = 1;
   string validator_address = 2;
@@ -43,6 +50,8 @@ message EventWrappedUndelegate {
   uint64 epoch_boundary = 5;
 }
 
+// EventWrappedBeginRedelegate is the event that a MsgWrappedBeginRedelegate has
+// been queued
 message EventWrappedBeginRedelegate {
   string delegator_address = 1;
   string source_validator_address = 2;

--- a/proto/babylon/epoching/v1/query.proto
+++ b/proto/babylon/epoching/v1/query.proto
@@ -78,15 +78,19 @@ message QueryParamsResponse {
   babylon.epoching.v1.Params params = 1 [ (gogoproto.nullable) = false ];
 }
 
+// QueryEpochInfoRequest is the request type for the Query/EpochInfo method
 message QueryEpochInfoRequest { uint64 epoch_num = 1; }
 
+// QueryEpochInfoRequest is the response type for the Query/EpochInfo method
 message QueryEpochInfoResponse { babylon.epoching.v1.Epoch epoch = 1; }
 
+// QueryEpochInfosRequest is the request type for the Query/EpochInfos method
 message QueryEpochsInfoRequest {
   // pagination defines whether to have the pagination in the request
   cosmos.base.query.v1beta1.PageRequest pagination = 1;
 }
 
+// QueryEpochsInfoResponse is the response type for the Query/EpochInfos method
 message QueryEpochsInfoResponse {
   repeated babylon.epoching.v1.Epoch epochs = 1;
 
@@ -147,19 +151,31 @@ message QueryLatestEpochMsgsResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
+// QueryValidatorLifecycleRequest is the request type for the
+// Query/ValidatorLifecycle RPC method
 message QueryValidatorLifecycleRequest { string val_addr = 1; }
 
+// QueryValidatorLifecycleResponse is the response type for the
+// Query/ValidatorLifecycle RPC method
 message QueryValidatorLifecycleResponse { ValidatorLifecycle val_life = 1; }
 
+// QueryDelegationLifecycleRequest is the request type for the
+// Query/DelegationLifecycle RPC method
 message QueryDelegationLifecycleRequest { string del_addr = 1; }
 
+// QueryDelegationLifecycleRequest is the response type for the
+// Query/DelegationLifecycle RPC method
 message QueryDelegationLifecycleResponse { DelegationLifecycle del_life = 1; }
 
+// QueryEpochValSetRequest is the request type for the Query/EpochValSet RPC
+// method
 message QueryEpochValSetRequest {
   uint64 epoch_num = 1;
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
+// QueryEpochValSetRequest is the response type for the Query/EpochValSet RPC
+// method
 message QueryEpochValSetResponse {
   repeated babylon.epoching.v1.Validator validators = 1;
   int64 total_voting_power = 2;

--- a/proto/babylon/epoching/v1/tx.proto
+++ b/proto/babylon/epoching/v1/tx.proto
@@ -23,26 +23,38 @@ service Msg {
       returns (MsgWrappedBeginRedelegateResponse);
 }
 
+// MsgWrappedDelegate is the message for delegating some stakes
 message MsgWrappedDelegate {
   option (gogoproto.equal) = false;
   option (gogoproto.goproto_getters) = false;
 
   cosmos.staking.v1beta1.MsgDelegate msg = 1;
 }
+
+// MsgWrappedDelegate is the response to the MsgWrappedDelegate message
 message MsgWrappedDelegateResponse {}
 
+// MsgWrappedUndelegate is the message for undelegating some stakes
 message MsgWrappedUndelegate {
   option (gogoproto.equal) = false;
   option (gogoproto.goproto_getters) = false;
 
   cosmos.staking.v1beta1.MsgUndelegate msg = 1;
 }
+
+// MsgWrappedUndelegateResponse is the response to the MsgWrappedUndelegate
+// message
 message MsgWrappedUndelegateResponse {}
 
+// MsgWrappedDelegate is the message for moving some bonded stakes from a
+// validator to another validator
 message MsgWrappedBeginRedelegate {
   option (gogoproto.equal) = false;
   option (gogoproto.goproto_getters) = false;
 
   cosmos.staking.v1beta1.MsgBeginRedelegate msg = 1;
 }
+
+// MsgWrappedBeginRedelegateResponse is the response to the
+// MsgWrappedBeginRedelegate message
 message MsgWrappedBeginRedelegateResponse {}

--- a/proto/babylon/epoching/v1/tx.proto
+++ b/proto/babylon/epoching/v1/tx.proto
@@ -23,7 +23,7 @@ service Msg {
       returns (MsgWrappedBeginRedelegateResponse);
 }
 
-// MsgWrappedDelegate is the message for delegating some stakes
+// MsgWrappedDelegate is the message for delegating stakes
 message MsgWrappedDelegate {
   option (gogoproto.equal) = false;
   option (gogoproto.goproto_getters) = false;
@@ -34,7 +34,7 @@ message MsgWrappedDelegate {
 // MsgWrappedDelegate is the response to the MsgWrappedDelegate message
 message MsgWrappedDelegateResponse {}
 
-// MsgWrappedUndelegate is the message for undelegating some stakes
+// MsgWrappedUndelegate is the message for undelegating stakes
 message MsgWrappedUndelegate {
   option (gogoproto.equal) = false;
   option (gogoproto.goproto_getters) = false;
@@ -46,7 +46,7 @@ message MsgWrappedUndelegate {
 // message
 message MsgWrappedUndelegateResponse {}
 
-// MsgWrappedDelegate is the message for moving some bonded stakes from a
+// MsgWrappedDelegate is the message for moving bonded stakes from a
 // validator to another validator
 message MsgWrappedBeginRedelegate {
   option (gogoproto.equal) = false;

--- a/proto/babylon/monitor/v1/query.proto
+++ b/proto/babylon/monitor/v1/query.proto
@@ -43,22 +43,22 @@ message QueryParamsResponse {
 // RPC method
 message QueryEndedEpochBtcHeightRequest { uint64 epoch_num = 1; }
 
-// QueryEndedEpochBtcHeightResponse defines a response type for EndedEpochBtcHeight
-// RPC method
+// QueryEndedEpochBtcHeightResponse defines a response type for
+// EndedEpochBtcHeight RPC method
 message QueryEndedEpochBtcHeightResponse {
   // height of btc light client when epoch ended
   uint64 btc_light_client_height = 1;
 }
 
-// QueryReportedCheckpointBtcHeightRequest defines a query type for ReportedCheckpointBtcHeight
-// RPC method
+// QueryReportedCheckpointBtcHeightRequest defines a query type for
+// ReportedCheckpointBtcHeight RPC method
 message QueryReportedCheckpointBtcHeightRequest {
   // ckpt_hash is hex encoded byte string of the hash of the checkpoint
   string ckpt_hash = 1;
 }
 
-// QueryReportedCheckpointBtcHeightResponse defines a response type for ReportedCheckpointBtcHeight
-// RPC method
+// QueryReportedCheckpointBtcHeightResponse defines a response type for
+// ReportedCheckpointBtcHeight RPC method
 message QueryReportedCheckpointBtcHeightResponse {
   // height of btc light client when checkpoint is reported
   uint64 btc_light_client_height = 1;

--- a/proto/babylon/zoneconcierge/v1/packet.proto
+++ b/proto/babylon/zoneconcierge/v1/packet.proto
@@ -3,8 +3,13 @@ package babylon.zoneconcierge.v1;
 
 option go_package = "github.com/babylonchain/babylon/x/zoneconcierge/types";
 
+// ZoneconciergePacketData is the message that defines the IBC packets of
+// ZoneConcierge
 message ZoneconciergePacketData {
+  // packet is the actual message carried in the IBC packet
   oneof packet { Heartbeat heartbeart = 1; }
 }
 
+// Heartbeat is a heartbeat message that can be carried in IBC packets of
+// ZoneConcierge
 message Heartbeat { string msg = 1; }

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -13,7 +13,6 @@ lint:
     - DEFAULT
     - COMMENTS
     - FILE_LOWER_SNAKE_CASE
-    # TODO Decide which comments we would like to enfore by linter
     - COMMENT_MESSAGE
     - COMMENT_ENUM_VALUE
     - COMMENT_ENUM

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -13,6 +13,12 @@ lint:
     - DEFAULT
     - COMMENTS
     - FILE_LOWER_SNAKE_CASE
+    # TODO Decide which comments we would like to enfore by linter
+    - COMMENT_MESSAGE
+    - COMMENT_ENUM_VALUE
+    - COMMENT_ENUM
+    - COMMENT_RPC
+    - COMMENT_ONEOF
   except:
     - UNARY_RPC
     - COMMENT_FIELD
@@ -21,9 +27,3 @@ lint:
     - RPC_REQUEST_STANDARD_NAME
     - ENUM_VALUE_PREFIX
     - ENUM_ZERO_VALUE_SUFFIX
-    # TODO Decide which comments we would like to enfore by linter
-    - COMMENT_MESSAGE
-    - COMMENT_ENUM_VALUE
-    - COMMENT_ENUM
-    - COMMENT_RPC
-    - COMMENT_ONEOF

--- a/x/btccheckpoint/types/btccheckpoint.pb.go
+++ b/x/btccheckpoint/types/btccheckpoint.pb.go
@@ -449,15 +449,14 @@ func (m *EpochData) GetStatus() BtcStatus {
 }
 
 // CheckpointAddresses contains the addresses of the submitter and reporter of a
-// given checkpoint submitter is the address of the submitter of the checkpoint
-// to BTC reporter is the address of the submitter of the MsgInsertBTCSpvProof
-// message to Babylon
+// given checkpoint
 type CheckpointAddresses struct {
 	// TODO: this could probably be better typed
-	// Address of the checkpoint submitter, extracted from the checkpoint itself.
+	// submitter is the address of the checkpoint submitter to BTC, extracted from
+	// the checkpoint itself.
 	Submitter []byte `protobuf:"bytes,1,opt,name=submitter,proto3" json:"submitter,omitempty"`
-	// Address of the reporter which reported the submissions, calculated from
-	// submission message MsgInsertBTCSpvProof itself
+	// reporter is the address of the reporter who reported the submissions,
+	// calculated from submission message MsgInsertBTCSpvProof itself
 	Reporter []byte `protobuf:"bytes,2,opt,name=reporter,proto3" json:"reporter,omitempty"`
 }
 

--- a/x/btccheckpoint/types/btccheckpoint.pb.go
+++ b/x/btccheckpoint/types/btccheckpoint.pb.go
@@ -24,6 +24,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// BtcStatus is an enum describing the current btc status of the checkpoint
 type BtcStatus int32
 
 const (
@@ -447,6 +448,9 @@ func (m *EpochData) GetStatus() BtcStatus {
 	return Submitted
 }
 
+// CheckpointAddresses contains the addresses of the submitter and reporter of a given checkpoint
+// submitter is the address of the submitter of the checkpoint to BTC
+// reporter is the address of the submitter of the MsgInsertBTCSpvProof message to Babylon
 type CheckpointAddresses struct {
 	// TODO: this could probably be better typed
 	// Address of the checkpoint submitter, extracted from the checkpoint itself.
@@ -503,6 +507,7 @@ func (m *CheckpointAddresses) GetReporter() []byte {
 	return nil
 }
 
+// BTCCheckpointInfo contains all checkpoint related data expected in a query response.
 type BTCCheckpointInfo struct {
 	// epoch number of this checkpoint
 	EpochNumber uint64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`

--- a/x/btccheckpoint/types/btccheckpoint.pb.go
+++ b/x/btccheckpoint/types/btccheckpoint.pb.go
@@ -448,9 +448,10 @@ func (m *EpochData) GetStatus() BtcStatus {
 	return Submitted
 }
 
-// CheckpointAddresses contains the addresses of the submitter and reporter of a given checkpoint
-// submitter is the address of the submitter of the checkpoint to BTC
-// reporter is the address of the submitter of the MsgInsertBTCSpvProof message to Babylon
+// CheckpointAddresses contains the addresses of the submitter and reporter of a
+// given checkpoint submitter is the address of the submitter of the checkpoint
+// to BTC reporter is the address of the submitter of the MsgInsertBTCSpvProof
+// message to Babylon
 type CheckpointAddresses struct {
 	// TODO: this could probably be better typed
 	// Address of the checkpoint submitter, extracted from the checkpoint itself.
@@ -507,7 +508,8 @@ func (m *CheckpointAddresses) GetReporter() []byte {
 	return nil
 }
 
-// BTCCheckpointInfo contains all checkpoint related data expected in a query response.
+// BTCCheckpointInfo contains all checkpoint related data expected in a query
+// response.
 type BTCCheckpointInfo struct {
 	// epoch number of this checkpoint
 	EpochNumber uint64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`

--- a/x/btccheckpoint/types/query.pb.go
+++ b/x/btccheckpoint/types/query.pb.go
@@ -113,6 +113,7 @@ func (m *QueryParamsResponse) GetParams() Params {
 	return Params{}
 }
 
+// QueryBtcCheckpointInfoRequest defines the query to get the best checkpoint for a given epoch
 type QueryBtcCheckpointInfoRequest struct {
 	// Number of epoch for which the earliest checkpointing btc height is
 	// requested
@@ -307,6 +308,7 @@ func (m *QueryBtcCheckpointsInfoResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
+// QueryEpochSubmissionsRequest defines a request to get all submissions in given epoch
 type QueryEpochSubmissionsRequest struct {
 	// Number of epoch for which submissions are requested
 	EpochNum   uint64             `protobuf:"varint,1,opt,name=epoch_num,json=epochNum,proto3" json:"epoch_num,omitempty"`
@@ -360,6 +362,7 @@ func (m *QueryEpochSubmissionsRequest) GetPagination() *query.PageRequest {
 	return nil
 }
 
+// QueryEpochSubmissionsResponse defines a response to get all submissions in given epoch (QueryEpochSubmissionsRequest)
 type QueryEpochSubmissionsResponse struct {
 	// All submissions saved during an epoch.
 	Keys       []*SubmissionKey    `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
@@ -489,6 +492,7 @@ type QueryClient interface {
 	BtcCheckpointInfo(ctx context.Context, in *QueryBtcCheckpointInfoRequest, opts ...grpc.CallOption) (*QueryBtcCheckpointInfoResponse, error)
 	// BtcCheckpointsInfo returns checkpoint info for a range of epochs
 	BtcCheckpointsInfo(ctx context.Context, in *QueryBtcCheckpointsInfoRequest, opts ...grpc.CallOption) (*QueryBtcCheckpointsInfoResponse, error)
+	// EpochSubmissions returns all submissions for a given epoch
 	EpochSubmissions(ctx context.Context, in *QueryEpochSubmissionsRequest, opts ...grpc.CallOption) (*QueryEpochSubmissionsResponse, error)
 }
 
@@ -544,6 +548,7 @@ type QueryServer interface {
 	BtcCheckpointInfo(context.Context, *QueryBtcCheckpointInfoRequest) (*QueryBtcCheckpointInfoResponse, error)
 	// BtcCheckpointsInfo returns checkpoint info for a range of epochs
 	BtcCheckpointsInfo(context.Context, *QueryBtcCheckpointsInfoRequest) (*QueryBtcCheckpointsInfoResponse, error)
+	// EpochSubmissions returns all submissions for a given epoch
 	EpochSubmissions(context.Context, *QueryEpochSubmissionsRequest) (*QueryEpochSubmissionsResponse, error)
 }
 

--- a/x/btccheckpoint/types/query.pb.go
+++ b/x/btccheckpoint/types/query.pb.go
@@ -113,7 +113,8 @@ func (m *QueryParamsResponse) GetParams() Params {
 	return Params{}
 }
 
-// QueryBtcCheckpointInfoRequest defines the query to get the best checkpoint for a given epoch
+// QueryBtcCheckpointInfoRequest defines the query to get the best checkpoint
+// for a given epoch
 type QueryBtcCheckpointInfoRequest struct {
 	// Number of epoch for which the earliest checkpointing btc height is
 	// requested
@@ -308,7 +309,8 @@ func (m *QueryBtcCheckpointsInfoResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
-// QueryEpochSubmissionsRequest defines a request to get all submissions in given epoch
+// QueryEpochSubmissionsRequest defines a request to get all submissions in
+// given epoch
 type QueryEpochSubmissionsRequest struct {
 	// Number of epoch for which submissions are requested
 	EpochNum   uint64             `protobuf:"varint,1,opt,name=epoch_num,json=epochNum,proto3" json:"epoch_num,omitempty"`
@@ -362,7 +364,8 @@ func (m *QueryEpochSubmissionsRequest) GetPagination() *query.PageRequest {
 	return nil
 }
 
-// QueryEpochSubmissionsResponse defines a response to get all submissions in given epoch (QueryEpochSubmissionsRequest)
+// QueryEpochSubmissionsResponse defines a response to get all submissions in
+// given epoch (QueryEpochSubmissionsRequest)
 type QueryEpochSubmissionsResponse struct {
 	// All submissions saved during an epoch.
 	Keys       []*SubmissionKey    `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`

--- a/x/btccheckpoint/types/tx.pb.go
+++ b/x/btccheckpoint/types/tx.pb.go
@@ -27,6 +27,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// MsgInsertBTCSpvProof defines resquest to insert a new checkpoint into the store
 type MsgInsertBTCSpvProof struct {
 	Submitter string         `protobuf:"bytes,1,opt,name=submitter,proto3" json:"submitter,omitempty"`
 	Proofs    []*BTCSpvProof `protobuf:"bytes,2,rep,name=proofs,proto3" json:"proofs,omitempty"`
@@ -79,6 +80,7 @@ func (m *MsgInsertBTCSpvProof) GetProofs() []*BTCSpvProof {
 	return nil
 }
 
+// MsgInsertBTCSpvProofResponse defines the response for the MsgInsertBTCSpvProof message
 type MsgInsertBTCSpvProofResponse struct {
 }
 
@@ -154,6 +156,7 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
+	// InsertBTCSpvProof tries to insert a new checkpoint into the store.
 	InsertBTCSpvProof(ctx context.Context, in *MsgInsertBTCSpvProof, opts ...grpc.CallOption) (*MsgInsertBTCSpvProofResponse, error)
 }
 
@@ -176,6 +179,7 @@ func (c *msgClient) InsertBTCSpvProof(ctx context.Context, in *MsgInsertBTCSpvPr
 
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
+	// InsertBTCSpvProof tries to insert a new checkpoint into the store.
 	InsertBTCSpvProof(context.Context, *MsgInsertBTCSpvProof) (*MsgInsertBTCSpvProofResponse, error)
 }
 

--- a/x/btccheckpoint/types/tx.pb.go
+++ b/x/btccheckpoint/types/tx.pb.go
@@ -27,7 +27,8 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// MsgInsertBTCSpvProof defines resquest to insert a new checkpoint into the store
+// MsgInsertBTCSpvProof defines resquest to insert a new checkpoint into the
+// store
 type MsgInsertBTCSpvProof struct {
 	Submitter string         `protobuf:"bytes,1,opt,name=submitter,proto3" json:"submitter,omitempty"`
 	Proofs    []*BTCSpvProof `protobuf:"bytes,2,rep,name=proofs,proto3" json:"proofs,omitempty"`
@@ -80,7 +81,8 @@ func (m *MsgInsertBTCSpvProof) GetProofs() []*BTCSpvProof {
 	return nil
 }
 
-// MsgInsertBTCSpvProofResponse defines the response for the MsgInsertBTCSpvProof message
+// MsgInsertBTCSpvProofResponse defines the response for the
+// MsgInsertBTCSpvProof message
 type MsgInsertBTCSpvProofResponse struct {
 }
 

--- a/x/btclightclient/types/btclightclient.pb.go
+++ b/x/btclightclient/types/btclightclient.pb.go
@@ -25,6 +25,12 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// BTCHeaderInfo is a structure that contains all relevant information about a BTC header
+//   - Full header bytes
+//   - Header hash for easy retrieval
+//   - Height of the header in the BTC chain
+//   - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+//     and the total work of the header.
 type BTCHeaderInfo struct {
 	Header *github_com_babylonchain_babylon_types.BTCHeaderBytes     `protobuf:"bytes,1,opt,name=header,proto3,customtype=github.com/babylonchain/babylon/types.BTCHeaderBytes" json:"header,omitempty"`
 	Hash   *github_com_babylonchain_babylon_types.BTCHeaderHashBytes `protobuf:"bytes,2,opt,name=hash,proto3,customtype=github.com/babylonchain/babylon/types.BTCHeaderHashBytes" json:"hash,omitempty"`

--- a/x/btclightclient/types/btclightclient.pb.go
+++ b/x/btclightclient/types/btclightclient.pb.go
@@ -25,11 +25,13 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// BTCHeaderInfo is a structure that contains all relevant information about a BTC header
+// BTCHeaderInfo is a structure that contains all relevant information about a
+// BTC header
 //   - Full header bytes
 //   - Header hash for easy retrieval
 //   - Height of the header in the BTC chain
-//   - Total work spent on the header. This is the sum of the work corresponding to the header Bits field
+//   - Total work spent on the header. This is the sum of the work corresponding
+//     to the header Bits field
 //     and the total work of the header.
 type BTCHeaderInfo struct {
 	Header *github_com_babylonchain_babylon_types.BTCHeaderBytes     `protobuf:"bytes,1,opt,name=header,proto3,customtype=github.com/babylonchain/babylon/types.BTCHeaderBytes" json:"header,omitempty"`

--- a/x/btclightclient/types/query.pb.go
+++ b/x/btclightclient/types/query.pb.go
@@ -563,7 +563,8 @@ func (m *QueryTipResponse) GetHeader() *BTCHeaderInfo {
 	return nil
 }
 
-// QueryBaseHeaderRequest is the request type for the Query/BaseHeader RPC method.
+// QueryBaseHeaderRequest is the request type for the Query/BaseHeader RPC
+// method.
 type QueryBaseHeaderRequest struct {
 }
 
@@ -600,7 +601,8 @@ func (m *QueryBaseHeaderRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryBaseHeaderRequest proto.InternalMessageInfo
 
-// QueryBaseHeaderResponse is the response type for the Query/BaseHeader RPC method.
+// QueryBaseHeaderResponse is the response type for the Query/BaseHeader RPC
+// method.
 type QueryBaseHeaderResponse struct {
 	Header *BTCHeaderInfo `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 }
@@ -745,7 +747,8 @@ type QueryClient interface {
 	MainChain(ctx context.Context, in *QueryMainChainRequest, opts ...grpc.CallOption) (*QueryMainChainResponse, error)
 	// Tip return best header on canonical chain
 	Tip(ctx context.Context, in *QueryTipRequest, opts ...grpc.CallOption) (*QueryTipResponse, error)
-	// BaseHeader returns the base BTC header of the chain. This header is defined on genesis.
+	// BaseHeader returns the base BTC header of the chain. This header is defined
+	// on genesis.
 	BaseHeader(ctx context.Context, in *QueryBaseHeaderRequest, opts ...grpc.CallOption) (*QueryBaseHeaderResponse, error)
 }
 
@@ -837,7 +840,8 @@ type QueryServer interface {
 	MainChain(context.Context, *QueryMainChainRequest) (*QueryMainChainResponse, error)
 	// Tip return best header on canonical chain
 	Tip(context.Context, *QueryTipRequest) (*QueryTipResponse, error)
-	// BaseHeader returns the base BTC header of the chain. This header is defined on genesis.
+	// BaseHeader returns the base BTC header of the chain. This header is defined
+	// on genesis.
 	BaseHeader(context.Context, *QueryBaseHeaderRequest) (*QueryBaseHeaderResponse, error)
 }
 

--- a/x/btclightclient/types/query.pb.go
+++ b/x/btclightclient/types/query.pb.go
@@ -481,6 +481,7 @@ func (m *QueryMainChainResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
+// QueryTipRequest is the request type for the Query/Tip RPC method.
 type QueryTipRequest struct {
 }
 
@@ -517,6 +518,7 @@ func (m *QueryTipRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryTipRequest proto.InternalMessageInfo
 
+// QueryTipResponse is the response type for the Query/Tip RPC method.
 type QueryTipResponse struct {
 	Header *BTCHeaderInfo `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 }
@@ -561,6 +563,7 @@ func (m *QueryTipResponse) GetHeader() *BTCHeaderInfo {
 	return nil
 }
 
+// QueryBaseHeaderRequest is the request type for the Query/BaseHeader RPC method.
 type QueryBaseHeaderRequest struct {
 }
 
@@ -597,6 +600,7 @@ func (m *QueryBaseHeaderRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryBaseHeaderRequest proto.InternalMessageInfo
 
+// QueryBaseHeaderResponse is the response type for the Query/BaseHeader RPC method.
 type QueryBaseHeaderResponse struct {
 	Header *BTCHeaderInfo `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 }
@@ -741,6 +745,7 @@ type QueryClient interface {
 	MainChain(ctx context.Context, in *QueryMainChainRequest, opts ...grpc.CallOption) (*QueryMainChainResponse, error)
 	// Tip return best header on canonical chain
 	Tip(ctx context.Context, in *QueryTipRequest, opts ...grpc.CallOption) (*QueryTipResponse, error)
+	// BaseHeader returns the base BTC header of the chain. This header is defined on genesis.
 	BaseHeader(ctx context.Context, in *QueryBaseHeaderRequest, opts ...grpc.CallOption) (*QueryBaseHeaderResponse, error)
 }
 
@@ -832,6 +837,7 @@ type QueryServer interface {
 	MainChain(context.Context, *QueryMainChainRequest) (*QueryMainChainResponse, error)
 	// Tip return best header on canonical chain
 	Tip(context.Context, *QueryTipRequest) (*QueryTipResponse, error)
+	// BaseHeader returns the base BTC header of the chain. This header is defined on genesis.
 	BaseHeader(context.Context, *QueryBaseHeaderRequest) (*QueryBaseHeaderResponse, error)
 }
 

--- a/x/btclightclient/types/tx.pb.go
+++ b/x/btclightclient/types/tx.pb.go
@@ -154,7 +154,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
-	// InsertHeader adds a header to the BTC light client chain maintained by Babylon.
+	// InsertHeader adds a header to the BTC light client chain maintained by
+	// Babylon.
 	InsertHeader(ctx context.Context, in *MsgInsertHeader, opts ...grpc.CallOption) (*MsgInsertHeaderResponse, error)
 }
 
@@ -177,7 +178,8 @@ func (c *msgClient) InsertHeader(ctx context.Context, in *MsgInsertHeader, opts 
 
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
-	// InsertHeader adds a header to the BTC light client chain maintained by Babylon.
+	// InsertHeader adds a header to the BTC light client chain maintained by
+	// Babylon.
 	InsertHeader(context.Context, *MsgInsertHeader) (*MsgInsertHeaderResponse, error)
 }
 

--- a/x/btclightclient/types/tx.pb.go
+++ b/x/btclightclient/types/tx.pb.go
@@ -75,6 +75,7 @@ func (m *MsgInsertHeader) GetSigner() string {
 	return ""
 }
 
+// MsgInsertHeaderResponse defines the response for the InsertHeader transaction
 type MsgInsertHeaderResponse struct {
 }
 
@@ -153,6 +154,7 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
+	// InsertHeader adds a header to the BTC light client chain maintained by Babylon.
 	InsertHeader(ctx context.Context, in *MsgInsertHeader, opts ...grpc.CallOption) (*MsgInsertHeaderResponse, error)
 }
 
@@ -175,6 +177,7 @@ func (c *msgClient) InsertHeader(ctx context.Context, in *MsgInsertHeader, opts 
 
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
+	// InsertHeader adds a header to the BTC light client chain maintained by Babylon.
 	InsertHeader(context.Context, *MsgInsertHeader) (*MsgInsertHeaderResponse, error)
 }
 

--- a/x/checkpointing/types/checkpoint.pb.go
+++ b/x/checkpointing/types/checkpoint.pb.go
@@ -29,7 +29,7 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// CkptStatus is the status of a checkpoint.
+// CheckpointStatus is the status of a checkpoint.
 type CheckpointStatus int32
 
 const (
@@ -206,6 +206,7 @@ func (m *RawCheckpointWithMeta) GetLifecycle() []*CheckpointStateUpdate {
 	return nil
 }
 
+// CheckpointStateUpdate defines a state transition on the checkpoint.
 type CheckpointStateUpdate struct {
 	// state defines the event of a state transition towards this state
 	State CheckpointStatus `protobuf:"varint,1,opt,name=state,proto3,enum=babylon.checkpointing.v1.CheckpointStatus" json:"state,omitempty"`

--- a/x/checkpointing/types/events.pb.go
+++ b/x/checkpointing/types/events.pb.go
@@ -22,6 +22,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// EventCheckpointAccumulating is emitted when a checkpoint reaches the `Accumulating` state.
 type EventCheckpointAccumulating struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -66,6 +67,7 @@ func (m *EventCheckpointAccumulating) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
+// EventCheckpointSealed is emitted when a checkpoint reaches the `Sealed` state.
 type EventCheckpointSealed struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -110,6 +112,7 @@ func (m *EventCheckpointSealed) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
+// EventCheckpointSubmitted is emitted when a checkpoint reaches the `Submitted` state.
 type EventCheckpointSubmitted struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -154,6 +157,7 @@ func (m *EventCheckpointSubmitted) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
+// EventCheckpointConfirmed is emitted when a checkpoint reaches the `Confirmed` state.
 type EventCheckpointConfirmed struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -198,6 +202,7 @@ func (m *EventCheckpointConfirmed) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
+// EventCheckpointFinalized is emitted when a checkpoint reaches the `Finalized` state.
 type EventCheckpointFinalized struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -242,6 +247,7 @@ func (m *EventCheckpointFinalized) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
+// EventCheckpointForgotten is emitted when a checkpoint switches to a `Forgotten` state.
 type EventCheckpointForgotten struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -286,6 +292,7 @@ func (m *EventCheckpointForgotten) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
+// EventConflictingCheckpoint is emitted when two conflicting checkpoints are found.
 type EventConflictingCheckpoint struct {
 	ConflictingCheckpoint *RawCheckpoint         `protobuf:"bytes,1,opt,name=conflicting_checkpoint,json=conflictingCheckpoint,proto3" json:"conflicting_checkpoint,omitempty"`
 	LocalCheckpoint       *RawCheckpointWithMeta `protobuf:"bytes,2,opt,name=local_checkpoint,json=localCheckpoint,proto3" json:"local_checkpoint,omitempty"`

--- a/x/checkpointing/types/events.pb.go
+++ b/x/checkpointing/types/events.pb.go
@@ -22,7 +22,8 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// EventCheckpointAccumulating is emitted when a checkpoint reaches the `Accumulating` state.
+// EventCheckpointAccumulating is emitted when a checkpoint reaches the
+// `Accumulating` state.
 type EventCheckpointAccumulating struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -67,7 +68,8 @@ func (m *EventCheckpointAccumulating) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
-// EventCheckpointSealed is emitted when a checkpoint reaches the `Sealed` state.
+// EventCheckpointSealed is emitted when a checkpoint reaches the `Sealed`
+// state.
 type EventCheckpointSealed struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -112,7 +114,8 @@ func (m *EventCheckpointSealed) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
-// EventCheckpointSubmitted is emitted when a checkpoint reaches the `Submitted` state.
+// EventCheckpointSubmitted is emitted when a checkpoint reaches the `Submitted`
+// state.
 type EventCheckpointSubmitted struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -157,7 +160,8 @@ func (m *EventCheckpointSubmitted) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
-// EventCheckpointConfirmed is emitted when a checkpoint reaches the `Confirmed` state.
+// EventCheckpointConfirmed is emitted when a checkpoint reaches the `Confirmed`
+// state.
 type EventCheckpointConfirmed struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -202,7 +206,8 @@ func (m *EventCheckpointConfirmed) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
-// EventCheckpointFinalized is emitted when a checkpoint reaches the `Finalized` state.
+// EventCheckpointFinalized is emitted when a checkpoint reaches the `Finalized`
+// state.
 type EventCheckpointFinalized struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -247,7 +252,8 @@ func (m *EventCheckpointFinalized) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
-// EventCheckpointForgotten is emitted when a checkpoint switches to a `Forgotten` state.
+// EventCheckpointForgotten is emitted when a checkpoint switches to a
+// `Forgotten` state.
 type EventCheckpointForgotten struct {
 	Checkpoint *RawCheckpointWithMeta `protobuf:"bytes,1,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 }
@@ -292,7 +298,8 @@ func (m *EventCheckpointForgotten) GetCheckpoint() *RawCheckpointWithMeta {
 	return nil
 }
 
-// EventConflictingCheckpoint is emitted when two conflicting checkpoints are found.
+// EventConflictingCheckpoint is emitted when two conflicting checkpoints are
+// found.
 type EventConflictingCheckpoint struct {
 	ConflictingCheckpoint *RawCheckpoint         `protobuf:"bytes,1,opt,name=conflicting_checkpoint,json=conflictingCheckpoint,proto3" json:"conflicting_checkpoint,omitempty"`
 	LocalCheckpoint       *RawCheckpointWithMeta `protobuf:"bytes,2,opt,name=local_checkpoint,json=localCheckpoint,proto3" json:"local_checkpoint,omitempty"`

--- a/x/checkpointing/types/genesis.pb.go
+++ b/x/checkpointing/types/genesis.pb.go
@@ -27,7 +27,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // GenesisState defines the checkpointing module's genesis state.
 type GenesisState struct {
 	// params defines all the paramaters of related to checkpointing
-	Params      Params        `protobuf:"bytes,1,opt,name=params,proto3" json:"params"`
+	Params Params `protobuf:"bytes,1,opt,name=params,proto3" json:"params"`
+	// genesis_keys defines the public keys for the genesis validators
 	GenesisKeys []*GenesisKey `protobuf:"bytes,2,rep,name=genesis_keys,json=genesisKeys,proto3" json:"genesis_keys,omitempty"`
 }
 
@@ -78,6 +79,7 @@ func (m *GenesisState) GetGenesisKeys() []*GenesisKey {
 	return nil
 }
 
+// GenesisKey defines public key information about the genesis validators
 type GenesisKey struct {
 	// validator_address is the address corresponding to a validator
 	ValidatorAddress string `protobuf:"bytes,1,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`

--- a/x/checkpointing/types/query.pb.go
+++ b/x/checkpointing/types/query.pb.go
@@ -548,6 +548,8 @@ func (m *QueryRecentEpochStatusCountResponse) GetStatusCount() map[string]uint64
 	return nil
 }
 
+// QueryLastCheckpointWithStatusRequest is the request type for the
+// Query/LastCheckpointWithStatus RPC method.
 type QueryLastCheckpointWithStatusRequest struct {
 	Status CheckpointStatus `protobuf:"varint,1,opt,name=status,proto3,enum=babylon.checkpointing.v1.CheckpointStatus" json:"status,omitempty"`
 }
@@ -592,6 +594,8 @@ func (m *QueryLastCheckpointWithStatusRequest) GetStatus() CheckpointStatus {
 	return Accumulating
 }
 
+// QueryLastCheckpointWithStatusResponse is the response type for the
+// Query/LastCheckpointWithStatus RPC method.
 type QueryLastCheckpointWithStatusResponse struct {
 	RawCheckpoint *RawCheckpoint `protobuf:"bytes,1,opt,name=raw_checkpoint,json=rawCheckpoint,proto3" json:"raw_checkpoint,omitempty"`
 }

--- a/x/epoching/types/epoching.pb.go
+++ b/x/epoching/types/epoching.pb.go
@@ -29,14 +29,20 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// BondState is the bond state of a validator or delegation
 type BondState int32
 
 const (
-	BondState_CREATED   BondState = 0
-	BondState_BONDED    BondState = 1
+	// CREATED is when the validator/delegation has been created
+	BondState_CREATED BondState = 0
+	// CREATED is when the validator/delegation has become bonded
+	BondState_BONDED BondState = 1
+	// CREATED is when the validator/delegation has become unbonding
 	BondState_UNBONDING BondState = 2
-	BondState_UNBONDED  BondState = 3
-	BondState_REMOVED   BondState = 4
+	// CREATED is when the validator/delegation has become unbonded
+	BondState_UNBONDED BondState = 3
+	// CREATED is when the validator/delegation has been removed
+	BondState_REMOVED BondState = 4
 )
 
 var BondState_name = map[int32]string{
@@ -63,6 +69,7 @@ func (BondState) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_2f2f209d5311f84c, []int{0}
 }
 
+// Epoch is a structure that contains the metadata of an epoch
 type Epoch struct {
 	EpochNumber          uint64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
 	CurrentEpochInterval uint64 `protobuf:"varint,2,opt,name=current_epoch_interval,json=currentEpochInterval,proto3" json:"current_epoch_interval,omitempty"`
@@ -309,6 +316,8 @@ func (*QueuedMessage) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// QueuedMessageList is a message that contains a list of staking-related
+// messages queued for an epoch
 type QueuedMessageList struct {
 	EpochNumber uint64           `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
 	Msgs        []*QueuedMessage `protobuf:"bytes,2,rep,name=msgs,proto3" json:"msgs,omitempty"`
@@ -361,6 +370,7 @@ func (m *QueuedMessageList) GetMsgs() []*QueuedMessage {
 	return nil
 }
 
+// ValStateUpdate is a messages that records a state update of a validator
 type ValStateUpdate struct {
 	State       BondState  `protobuf:"varint,1,opt,name=state,proto3,enum=babylon.epoching.v1.BondState" json:"state,omitempty"`
 	BlockHeight uint64     `protobuf:"varint,2,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
@@ -421,6 +431,8 @@ func (m *ValStateUpdate) GetBlockTime() *time.Time {
 	return nil
 }
 
+// ValidatorLifecycle is a message that records records the lifecycle of
+// a validator
 type ValidatorLifecycle struct {
 	ValAddr string            `protobuf:"bytes,1,opt,name=val_addr,json=valAddr,proto3" json:"val_addr,omitempty"`
 	ValLife []*ValStateUpdate `protobuf:"bytes,2,rep,name=val_life,json=valLife,proto3" json:"val_life,omitempty"`
@@ -473,6 +485,8 @@ func (m *ValidatorLifecycle) GetValLife() []*ValStateUpdate {
 	return nil
 }
 
+// DelegationStateUpdate is the message that records a state update of a
+// delegation
 type DelegationStateUpdate struct {
 	State       BondState  `protobuf:"varint,1,opt,name=state,proto3,enum=babylon.epoching.v1.BondState" json:"state,omitempty"`
 	ValAddr     string     `protobuf:"bytes,2,opt,name=val_addr,json=valAddr,proto3" json:"val_addr,omitempty"`
@@ -541,6 +555,8 @@ func (m *DelegationStateUpdate) GetBlockTime() *time.Time {
 	return nil
 }
 
+// ValidatorLifecycle is a message that records records the lifecycle of
+// a delegation
 type DelegationLifecycle struct {
 	DelAddr string                   `protobuf:"bytes,1,opt,name=del_addr,json=delAddr,proto3" json:"del_addr,omitempty"`
 	DelLife []*DelegationStateUpdate `protobuf:"bytes,2,rep,name=del_life,json=delLife,proto3" json:"del_life,omitempty"`
@@ -593,6 +609,7 @@ func (m *DelegationLifecycle) GetDelLife() []*DelegationStateUpdate {
 	return nil
 }
 
+// Validator is a message that denotes a validator
 type Validator struct {
 	// addr is the validator's address (in sdk.ValAddress)
 	Addr []byte `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`

--- a/x/epoching/types/events.pb.go
+++ b/x/epoching/types/events.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// EventBeginEpoch is the event that an epoch has started
+// EventBeginEpoch is the event emitted when an epoch has started
 type EventBeginEpoch struct {
 	EpochNumber uint64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
 }
@@ -69,7 +69,7 @@ func (m *EventBeginEpoch) GetEpochNumber() uint64 {
 	return 0
 }
 
-// EventEndEpoch is the event that an epoch has ended
+// EventEndEpoch is the event emitted when an epoch has ended
 type EventEndEpoch struct {
 	EpochNumber uint64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
 }
@@ -114,7 +114,8 @@ func (m *EventEndEpoch) GetEpochNumber() uint64 {
 	return 0
 }
 
-// EventHandleQueuedMsg is the event that a queued message has been handled
+// EventHandleQueuedMsg is the event emitted when a queued message has been
+// handled
 type EventHandleQueuedMsg struct {
 	OriginalEventType  string                                                   `protobuf:"bytes,1,opt,name=original_event_type,json=originalEventType,proto3" json:"original_event_type,omitempty"`
 	EpochNumber        uint64                                                   `protobuf:"varint,2,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
@@ -200,7 +201,8 @@ func (m *EventHandleQueuedMsg) GetError() string {
 	return ""
 }
 
-// EventSlashThreshold is the event that a set of validators have been slashed
+// EventSlashThreshold is the event emitted when a set of validators have been
+// slashed
 type EventSlashThreshold struct {
 	SlashedVotingPower int64    `protobuf:"varint,1,opt,name=slashed_voting_power,json=slashedVotingPower,proto3" json:"slashed_voting_power,omitempty"`
 	TotalVotingPower   int64    `protobuf:"varint,2,opt,name=total_voting_power,json=totalVotingPower,proto3" json:"total_voting_power,omitempty"`
@@ -261,7 +263,8 @@ func (m *EventSlashThreshold) GetSlashedValidators() [][]byte {
 	return nil
 }
 
-// EventWrappedDelegate is the event that a MsgWrappedDelegate has been queued
+// EventWrappedDelegate is the event emitted when a MsgWrappedDelegate has been
+// queued
 type EventWrappedDelegate struct {
 	DelegatorAddress string `protobuf:"bytes,1,opt,name=delegator_address,json=delegatorAddress,proto3" json:"delegator_address,omitempty"`
 	ValidatorAddress string `protobuf:"bytes,2,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
@@ -338,8 +341,8 @@ func (m *EventWrappedDelegate) GetEpochBoundary() uint64 {
 	return 0
 }
 
-// EventWrappedUndelegate is the event that a MsgWrappedUndelegate has been
-// queued
+// EventWrappedUndelegate is the event emitted when a MsgWrappedUndelegate has
+// been queued
 type EventWrappedUndelegate struct {
 	DelegatorAddress string `protobuf:"bytes,1,opt,name=delegator_address,json=delegatorAddress,proto3" json:"delegator_address,omitempty"`
 	ValidatorAddress string `protobuf:"bytes,2,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
@@ -416,8 +419,8 @@ func (m *EventWrappedUndelegate) GetEpochBoundary() uint64 {
 	return 0
 }
 
-// EventWrappedBeginRedelegate is the event that a MsgWrappedBeginRedelegate has
-// been queued
+// EventWrappedBeginRedelegate is the event emitted when a
+// MsgWrappedBeginRedelegate has been queued
 type EventWrappedBeginRedelegate struct {
 	DelegatorAddress            string `protobuf:"bytes,1,opt,name=delegator_address,json=delegatorAddress,proto3" json:"delegator_address,omitempty"`
 	SourceValidatorAddress      string `protobuf:"bytes,2,opt,name=source_validator_address,json=sourceValidatorAddress,proto3" json:"source_validator_address,omitempty"`

--- a/x/epoching/types/events.pb.go
+++ b/x/epoching/types/events.pb.go
@@ -24,6 +24,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// EventBeginEpoch is the event that an epoch has started
 type EventBeginEpoch struct {
 	EpochNumber uint64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
 }
@@ -68,6 +69,7 @@ func (m *EventBeginEpoch) GetEpochNumber() uint64 {
 	return 0
 }
 
+// EventEndEpoch is the event that an epoch has ended
 type EventEndEpoch struct {
 	EpochNumber uint64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
 }
@@ -112,6 +114,7 @@ func (m *EventEndEpoch) GetEpochNumber() uint64 {
 	return 0
 }
 
+// EventHandleQueuedMsg is the event that a queued message has been handled
 type EventHandleQueuedMsg struct {
 	OriginalEventType  string                                                   `protobuf:"bytes,1,opt,name=original_event_type,json=originalEventType,proto3" json:"original_event_type,omitempty"`
 	EpochNumber        uint64                                                   `protobuf:"varint,2,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
@@ -197,6 +200,7 @@ func (m *EventHandleQueuedMsg) GetError() string {
 	return ""
 }
 
+// EventSlashThreshold is the event that a set of validators have been slashed
 type EventSlashThreshold struct {
 	SlashedVotingPower int64    `protobuf:"varint,1,opt,name=slashed_voting_power,json=slashedVotingPower,proto3" json:"slashed_voting_power,omitempty"`
 	TotalVotingPower   int64    `protobuf:"varint,2,opt,name=total_voting_power,json=totalVotingPower,proto3" json:"total_voting_power,omitempty"`
@@ -257,6 +261,7 @@ func (m *EventSlashThreshold) GetSlashedValidators() [][]byte {
 	return nil
 }
 
+// EventWrappedDelegate is the event that a MsgWrappedDelegate has been queued
 type EventWrappedDelegate struct {
 	DelegatorAddress string `protobuf:"bytes,1,opt,name=delegator_address,json=delegatorAddress,proto3" json:"delegator_address,omitempty"`
 	ValidatorAddress string `protobuf:"bytes,2,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
@@ -333,6 +338,8 @@ func (m *EventWrappedDelegate) GetEpochBoundary() uint64 {
 	return 0
 }
 
+// EventWrappedUndelegate is the event that a MsgWrappedUndelegate has been
+// queued
 type EventWrappedUndelegate struct {
 	DelegatorAddress string `protobuf:"bytes,1,opt,name=delegator_address,json=delegatorAddress,proto3" json:"delegator_address,omitempty"`
 	ValidatorAddress string `protobuf:"bytes,2,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
@@ -409,6 +416,8 @@ func (m *EventWrappedUndelegate) GetEpochBoundary() uint64 {
 	return 0
 }
 
+// EventWrappedBeginRedelegate is the event that a MsgWrappedBeginRedelegate has
+// been queued
 type EventWrappedBeginRedelegate struct {
 	DelegatorAddress            string `protobuf:"bytes,1,opt,name=delegator_address,json=delegatorAddress,proto3" json:"delegator_address,omitempty"`
 	SourceValidatorAddress      string `protobuf:"bytes,2,opt,name=source_validator_address,json=sourceValidatorAddress,proto3" json:"source_validator_address,omitempty"`

--- a/x/epoching/types/query.pb.go
+++ b/x/epoching/types/query.pb.go
@@ -113,6 +113,7 @@ func (m *QueryParamsResponse) GetParams() Params {
 	return Params{}
 }
 
+// QueryEpochInfoRequest is the request type for the Query/EpochInfo method
 type QueryEpochInfoRequest struct {
 	EpochNum uint64 `protobuf:"varint,1,opt,name=epoch_num,json=epochNum,proto3" json:"epoch_num,omitempty"`
 }
@@ -157,6 +158,7 @@ func (m *QueryEpochInfoRequest) GetEpochNum() uint64 {
 	return 0
 }
 
+// QueryEpochInfoRequest is the response type for the Query/EpochInfo method
 type QueryEpochInfoResponse struct {
 	Epoch *Epoch `protobuf:"bytes,1,opt,name=epoch,proto3" json:"epoch,omitempty"`
 }
@@ -201,6 +203,7 @@ func (m *QueryEpochInfoResponse) GetEpoch() *Epoch {
 	return nil
 }
 
+// QueryEpochInfosRequest is the request type for the Query/EpochInfos method
 type QueryEpochsInfoRequest struct {
 	// pagination defines whether to have the pagination in the request
 	Pagination *query.PageRequest `protobuf:"bytes,1,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -246,6 +249,7 @@ func (m *QueryEpochsInfoRequest) GetPagination() *query.PageRequest {
 	return nil
 }
 
+// QueryEpochsInfoResponse is the response type for the Query/EpochInfos method
 type QueryEpochsInfoResponse struct {
 	Epochs []*Epoch `protobuf:"bytes,1,rep,name=epochs,proto3" json:"epochs,omitempty"`
 	// pagination defines the pagination in the response
@@ -625,6 +629,8 @@ func (m *QueryLatestEpochMsgsResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
+// QueryValidatorLifecycleRequest is the request type for the
+// Query/ValidatorLifecycle RPC method
 type QueryValidatorLifecycleRequest struct {
 	ValAddr string `protobuf:"bytes,1,opt,name=val_addr,json=valAddr,proto3" json:"val_addr,omitempty"`
 }
@@ -669,6 +675,8 @@ func (m *QueryValidatorLifecycleRequest) GetValAddr() string {
 	return ""
 }
 
+// QueryValidatorLifecycleResponse is the response type for the
+// Query/ValidatorLifecycle RPC method
 type QueryValidatorLifecycleResponse struct {
 	ValLife *ValidatorLifecycle `protobuf:"bytes,1,opt,name=val_life,json=valLife,proto3" json:"val_life,omitempty"`
 }
@@ -713,6 +721,8 @@ func (m *QueryValidatorLifecycleResponse) GetValLife() *ValidatorLifecycle {
 	return nil
 }
 
+// QueryDelegationLifecycleRequest is the request type for the
+// Query/DelegationLifecycle RPC method
 type QueryDelegationLifecycleRequest struct {
 	DelAddr string `protobuf:"bytes,1,opt,name=del_addr,json=delAddr,proto3" json:"del_addr,omitempty"`
 }
@@ -757,6 +767,8 @@ func (m *QueryDelegationLifecycleRequest) GetDelAddr() string {
 	return ""
 }
 
+// QueryDelegationLifecycleRequest is the response type for the
+// Query/DelegationLifecycle RPC method
 type QueryDelegationLifecycleResponse struct {
 	DelLife *DelegationLifecycle `protobuf:"bytes,1,opt,name=del_life,json=delLife,proto3" json:"del_life,omitempty"`
 }
@@ -801,6 +813,8 @@ func (m *QueryDelegationLifecycleResponse) GetDelLife() *DelegationLifecycle {
 	return nil
 }
 
+// QueryEpochValSetRequest is the request type for the Query/EpochValSet RPC
+// method
 type QueryEpochValSetRequest struct {
 	EpochNum   uint64             `protobuf:"varint,1,opt,name=epoch_num,json=epochNum,proto3" json:"epoch_num,omitempty"`
 	Pagination *query.PageRequest `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -853,6 +867,8 @@ func (m *QueryEpochValSetRequest) GetPagination() *query.PageRequest {
 	return nil
 }
 
+// QueryEpochValSetRequest is the response type for the Query/EpochValSet RPC
+// method
 type QueryEpochValSetResponse struct {
 	Validators       []*Validator        `protobuf:"bytes,1,rep,name=validators,proto3" json:"validators,omitempty"`
 	TotalVotingPower int64               `protobuf:"varint,2,opt,name=total_voting_power,json=totalVotingPower,proto3" json:"total_voting_power,omitempty"`

--- a/x/epoching/types/tx.pb.go
+++ b/x/epoching/types/tx.pb.go
@@ -29,6 +29,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// MsgWrappedDelegate is the message for delegating some stakes
 type MsgWrappedDelegate struct {
 	Msg *types.MsgDelegate `protobuf:"bytes,1,opt,name=msg,proto3" json:"msg,omitempty"`
 }
@@ -66,6 +67,7 @@ func (m *MsgWrappedDelegate) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWrappedDelegate proto.InternalMessageInfo
 
+// MsgWrappedDelegate is the response to the MsgWrappedDelegate message
 type MsgWrappedDelegateResponse struct {
 }
 
@@ -102,6 +104,7 @@ func (m *MsgWrappedDelegateResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWrappedDelegateResponse proto.InternalMessageInfo
 
+// MsgWrappedUndelegate is the message for undelegating some stakes
 type MsgWrappedUndelegate struct {
 	Msg *types.MsgUndelegate `protobuf:"bytes,1,opt,name=msg,proto3" json:"msg,omitempty"`
 }
@@ -139,6 +142,8 @@ func (m *MsgWrappedUndelegate) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWrappedUndelegate proto.InternalMessageInfo
 
+// MsgWrappedUndelegateResponse is the response to the MsgWrappedUndelegate
+// message
 type MsgWrappedUndelegateResponse struct {
 }
 
@@ -175,6 +180,8 @@ func (m *MsgWrappedUndelegateResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWrappedUndelegateResponse proto.InternalMessageInfo
 
+// MsgWrappedDelegate is the message for moving some bonded stakes from a
+// validator to another validator
 type MsgWrappedBeginRedelegate struct {
 	Msg *types.MsgBeginRedelegate `protobuf:"bytes,1,opt,name=msg,proto3" json:"msg,omitempty"`
 }
@@ -212,6 +219,8 @@ func (m *MsgWrappedBeginRedelegate) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWrappedBeginRedelegate proto.InternalMessageInfo
 
+// MsgWrappedBeginRedelegateResponse is the response to the
+// MsgWrappedBeginRedelegate message
 type MsgWrappedBeginRedelegateResponse struct {
 }
 

--- a/x/epoching/types/tx.pb.go
+++ b/x/epoching/types/tx.pb.go
@@ -29,7 +29,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// MsgWrappedDelegate is the message for delegating some stakes
+// MsgWrappedDelegate is the message for delegating stakes
 type MsgWrappedDelegate struct {
 	Msg *types.MsgDelegate `protobuf:"bytes,1,opt,name=msg,proto3" json:"msg,omitempty"`
 }
@@ -104,7 +104,7 @@ func (m *MsgWrappedDelegateResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWrappedDelegateResponse proto.InternalMessageInfo
 
-// MsgWrappedUndelegate is the message for undelegating some stakes
+// MsgWrappedUndelegate is the message for undelegating stakes
 type MsgWrappedUndelegate struct {
 	Msg *types.MsgUndelegate `protobuf:"bytes,1,opt,name=msg,proto3" json:"msg,omitempty"`
 }
@@ -180,7 +180,7 @@ func (m *MsgWrappedUndelegateResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWrappedUndelegateResponse proto.InternalMessageInfo
 
-// MsgWrappedDelegate is the message for moving some bonded stakes from a
+// MsgWrappedDelegate is the message for moving bonded stakes from a
 // validator to another validator
 type MsgWrappedBeginRedelegate struct {
 	Msg *types.MsgBeginRedelegate `protobuf:"bytes,1,opt,name=msg,proto3" json:"msg,omitempty"`

--- a/x/monitor/types/query.pb.go
+++ b/x/monitor/types/query.pb.go
@@ -112,6 +112,8 @@ func (m *QueryParamsResponse) GetParams() Params {
 	return Params{}
 }
 
+// QueryEndedEpochBtcHeightRequest defines a query type for EndedEpochBtcHeight
+// RPC method
 type QueryEndedEpochBtcHeightRequest struct {
 	EpochNum uint64 `protobuf:"varint,1,opt,name=epoch_num,json=epochNum,proto3" json:"epoch_num,omitempty"`
 }
@@ -156,6 +158,8 @@ func (m *QueryEndedEpochBtcHeightRequest) GetEpochNum() uint64 {
 	return 0
 }
 
+// QueryEndedEpochBtcHeightResponse defines a response type for EndedEpochBtcHeight
+// RPC method
 type QueryEndedEpochBtcHeightResponse struct {
 	// height of btc light client when epoch ended
 	BtcLightClientHeight uint64 `protobuf:"varint,1,opt,name=btc_light_client_height,json=btcLightClientHeight,proto3" json:"btc_light_client_height,omitempty"`
@@ -201,6 +205,8 @@ func (m *QueryEndedEpochBtcHeightResponse) GetBtcLightClientHeight() uint64 {
 	return 0
 }
 
+// QueryReportedCheckpointBtcHeightRequest defines a query type for ReportedCheckpointBtcHeight
+// RPC method
 type QueryReportedCheckpointBtcHeightRequest struct {
 	// ckpt_hash is hex encoded byte string of the hash of the checkpoint
 	CkptHash string `protobuf:"bytes,1,opt,name=ckpt_hash,json=ckptHash,proto3" json:"ckpt_hash,omitempty"`
@@ -248,6 +254,8 @@ func (m *QueryReportedCheckpointBtcHeightRequest) GetCkptHash() string {
 	return ""
 }
 
+// QueryReportedCheckpointBtcHeightResponse defines a response type for ReportedCheckpointBtcHeight
+// RPC method
 type QueryReportedCheckpointBtcHeightResponse struct {
 	// height of btc light client when checkpoint is reported
 	BtcLightClientHeight uint64 `protobuf:"varint,1,opt,name=btc_light_client_height,json=btcLightClientHeight,proto3" json:"btc_light_client_height,omitempty"`

--- a/x/monitor/types/query.pb.go
+++ b/x/monitor/types/query.pb.go
@@ -158,8 +158,8 @@ func (m *QueryEndedEpochBtcHeightRequest) GetEpochNum() uint64 {
 	return 0
 }
 
-// QueryEndedEpochBtcHeightResponse defines a response type for EndedEpochBtcHeight
-// RPC method
+// QueryEndedEpochBtcHeightResponse defines a response type for
+// EndedEpochBtcHeight RPC method
 type QueryEndedEpochBtcHeightResponse struct {
 	// height of btc light client when epoch ended
 	BtcLightClientHeight uint64 `protobuf:"varint,1,opt,name=btc_light_client_height,json=btcLightClientHeight,proto3" json:"btc_light_client_height,omitempty"`
@@ -205,8 +205,8 @@ func (m *QueryEndedEpochBtcHeightResponse) GetBtcLightClientHeight() uint64 {
 	return 0
 }
 
-// QueryReportedCheckpointBtcHeightRequest defines a query type for ReportedCheckpointBtcHeight
-// RPC method
+// QueryReportedCheckpointBtcHeightRequest defines a query type for
+// ReportedCheckpointBtcHeight RPC method
 type QueryReportedCheckpointBtcHeightRequest struct {
 	// ckpt_hash is hex encoded byte string of the hash of the checkpoint
 	CkptHash string `protobuf:"bytes,1,opt,name=ckpt_hash,json=ckptHash,proto3" json:"ckpt_hash,omitempty"`
@@ -254,8 +254,8 @@ func (m *QueryReportedCheckpointBtcHeightRequest) GetCkptHash() string {
 	return ""
 }
 
-// QueryReportedCheckpointBtcHeightResponse defines a response type for ReportedCheckpointBtcHeight
-// RPC method
+// QueryReportedCheckpointBtcHeightResponse defines a response type for
+// ReportedCheckpointBtcHeight RPC method
 type QueryReportedCheckpointBtcHeightResponse struct {
 	// height of btc light client when checkpoint is reported
 	BtcLightClientHeight uint64 `protobuf:"varint,1,opt,name=btc_light_client_height,json=btcLightClientHeight,proto3" json:"btc_light_client_height,omitempty"`

--- a/x/zoneconcierge/types/packet.pb.go
+++ b/x/zoneconcierge/types/packet.pb.go
@@ -22,7 +22,11 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// ZoneconciergePacketData is the message that defines the IBC packets of
+// ZoneConcierge
 type ZoneconciergePacketData struct {
+	// packet is the actual message carried in the IBC packet
+	//
 	// Types that are valid to be assigned to Packet:
 	//
 	//	*ZoneconciergePacketData_Heartbeart
@@ -95,6 +99,8 @@ func (*ZoneconciergePacketData) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// Heartbeat is a heartbeat message that can be carried in IBC packets of
+// ZoneConcierge
 type Heartbeat struct {
 	Msg string `protobuf:"bytes,1,opt,name=msg,proto3" json:"msg,omitempty"`
 }


### PR DESCRIPTION
Fixes [BM-566](https://babylon-chain.atlassian.net/browse/BM-566)

This PR fixes proto-linter in terms of the comments. It also updates the `buf.yaml` to enforce linting rules, executes `make proto-format` to format all proto files, and executes `make proto-all` to update all compiled stuff.