### PR TITLE
Use new version for our fork of ibc go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,7 +203,7 @@ replace (
 
 	// slay the dragonberry
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/ibc-go/v7 => github.com/babylonchain/ibc-go/v7 v7.0.0-20230317081654-61da7c3b41b6
+	github.com/cosmos/ibc-go/v7 => github.com/babylonchain/ibc-go/v7 v7.0.0-20230322083529-2c0496728e4a
 
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.203 h1:pcsP805b9acL3wUqa4JR2vg1k2wnItkDYNvfmcy6F+U=
 github.com/aws/aws-sdk-go v1.44.203/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonchain/ibc-go/v7 v7.0.0-20230317081654-61da7c3b41b6 h1:F41qzSK1VF6ZZqu+Xv3U9pHOYbJOSaWrw1iv8LeFsbg=
-github.com/babylonchain/ibc-go/v7 v7.0.0-20230317081654-61da7c3b41b6/go.mod h1:BFh8nKWjr5zeR2OZfhkzdgDzj1+KjRn3aJLpwapStj8=
+github.com/babylonchain/ibc-go/v7 v7.0.0-20230322083529-2c0496728e4a h1:2ys6u9PAdj/xJr9sCOzWfsvqXtoAsCnm8SJcP1xrq6g=
+github.com/babylonchain/ibc-go/v7 v7.0.0-20230322083529-2c0496728e4a/go.mod h1:BFh8nKWjr5zeR2OZfhkzdgDzj1+KjRn3aJLpwapStj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/testutil/datagen/tendermint.go
+++ b/testutil/datagen/tendermint.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	ibcclientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 )
 
@@ -25,5 +26,13 @@ func GenRandomIBCTMHeader(chainID string, height uint64) *ibctmtypes.Header {
 				LastCommitHash: GenRandomByteArray(32),
 			},
 		},
+	}
+}
+
+func HeaderToHeaderInfo(header *ibctmtypes.Header) *ibcclientkeeper.HeaderInfo {
+	return &ibcclientkeeper.HeaderInfo{
+		Hash:     header.Header.LastCommitHash,
+		ChaindId: header.Header.ChainID,
+		Height:   uint64(header.Header.Height),
 	}
 }

--- a/x/zoneconcierge/keeper/grpc_query_test.go
+++ b/x/zoneconcierge/keeper/grpc_query_test.go
@@ -43,7 +43,7 @@ func FuzzChainList(f *testing.F) {
 				allChainIDs = append(allChainIDs, chainID)
 			}
 			header := datagen.GenRandomIBCTMHeader(chainID, 0)
-			hooks.AfterHeaderWithValidCommit(ctx, datagen.GenRandomByteArray(32), header, false)
+			hooks.AfterHeaderWithValidCommit(ctx, datagen.GenRandomByteArray(32), datagen.HeaderToHeaderInfo(header), false)
 		}
 
 		limit := datagen.RandomInt(len(allChainIDs)) + 1

--- a/x/zoneconcierge/keeper/hooks.go
+++ b/x/zoneconcierge/keeper/hooks.go
@@ -9,7 +9,6 @@ import (
 	"github.com/babylonchain/babylon/x/zoneconcierge/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibcclientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
-	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 )
 
 type Hooks struct {
@@ -24,12 +23,12 @@ var _ epochingtypes.EpochingHooks = Hooks{}
 func (k Keeper) Hooks() Hooks { return Hooks{k} }
 
 // AfterHeaderWithValidCommit is triggered upon each CZ header with a valid QC
-func (h Hooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibctmtypes.Header, isOnFork bool) {
+func (h Hooks) AfterHeaderWithValidCommit(ctx sdk.Context, txHash []byte, header *ibcclientkeeper.HeaderInfo, isOnFork bool) {
 	babylonHeader := ctx.BlockHeader()
 	indexedHeader := types.IndexedHeader{
-		ChainId:       header.Header.ChainID,
-		Hash:          header.Header.LastCommitHash,
-		Height:        uint64(header.Header.Height),
+		ChainId:       header.ChaindId,
+		Hash:          header.Hash,
+		Height:        uint64(header.Height),
 		BabylonHeader: &babylonHeader,
 		BabylonEpoch:  h.k.GetEpoch(ctx).EpochNumber,
 		BabylonTxHash: txHash,

--- a/x/zoneconcierge/keeper/keeper_test.go
+++ b/x/zoneconcierge/keeper/keeper_test.go
@@ -40,7 +40,7 @@ func SimulateHeadersViaHook(ctx sdk.Context, hooks zckeeper.Hooks, chainID strin
 	// invoke the hook a number of times to simulate a number of blocks
 	for i := uint64(0); i < numHeaders; i++ {
 		header := datagen.GenRandomIBCTMHeader(chainID, startHeight+i)
-		hooks.AfterHeaderWithValidCommit(ctx, datagen.GenRandomByteArray(32), header, false)
+		hooks.AfterHeaderWithValidCommit(ctx, datagen.GenRandomByteArray(32), datagen.HeaderToHeaderInfo(header), false)
 		headers = append(headers, header)
 	}
 	return headers
@@ -52,7 +52,7 @@ func SimulateHeadersAndForksViaHook(ctx sdk.Context, hooks zckeeper.Hooks, chain
 	// invoke the hook a number of times to simulate a number of blocks
 	for i := uint64(0); i < numHeaders; i++ {
 		header := datagen.GenRandomIBCTMHeader(chainID, startHeight+i)
-		hooks.AfterHeaderWithValidCommit(ctx, datagen.GenRandomByteArray(32), header, false)
+		hooks.AfterHeaderWithValidCommit(ctx, datagen.GenRandomByteArray(32), datagen.HeaderToHeaderInfo(header), false)
 		headers = append(headers, header)
 	}
 
@@ -60,7 +60,7 @@ func SimulateHeadersAndForksViaHook(ctx sdk.Context, hooks zckeeper.Hooks, chain
 	forkHeaders := []*ibctmtypes.Header{}
 	for i := uint64(0); i < numForkHeaders; i++ {
 		header := datagen.GenRandomIBCTMHeader(chainID, startHeight+numHeaders-1)
-		hooks.AfterHeaderWithValidCommit(ctx, datagen.GenRandomByteArray(32), header, true)
+		hooks.AfterHeaderWithValidCommit(ctx, datagen.GenRandomByteArray(32), datagen.HeaderToHeaderInfo(header), true)
 		forkHeaders = append(forkHeaders, header)
 	}
 	return headers, forkHeaders


### PR DESCRIPTION
New version has been simplified due to usage of ibc-go v7 
New version can work with other types of light clients not only tendermint