### PR TITLE
chore: Parallelize CircleCI lint build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,10 @@ jobs:
             make localnet-stop
       # TODO: If CI tests will take to long consider having only this e2e test
       # instead of separate integration tests and e2e tests.
-      # TODO: re-enable e2e test after bumping heremes releyer
-      # - run:
-      #     name: Run e2e tests
-      #     command: |
-      #       make test-e2e
+       - run:
+           name: Run e2e tests
+           command: |
+             make test-e2e
   lint:
     machine:
       image: ubuntu-2204:2022.10.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,6 @@ jobs:
     machine:
       image: ubuntu-2204:2022.10.1
       resource_class: large
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
     steps:
       - checkout
       - run:
@@ -31,23 +29,54 @@ jobs:
           key: go-mod-v6-{{ checksum "go.sum" }}
           paths:
             - "/home/circleci/.go_workspace/pkg/mod"
+  lint:
+    machine:
+      image: ubuntu-2204:2022.10.1
+      resource_class: large
+    steps:
+      - checkout
       - run:
           name: Lint
           command: |
             curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
             ./bin/golangci-lint run
+  unit-test:
+    machine:
+      image: ubuntu-2204:2022.10.1
+      resource_class: large
+    steps:
+      - checkout
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - go-mod-v6-{{ checksum "go.sum" }}
       - run:
           name: Run tests
           command: |
             make test
+  integration-test:
+    machine:
+      image: ubuntu-2204:2022.10.1
+      resource_class: large
+    steps:
+      - checkout
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - go-mod-v6-{{ checksum "go.sum" }}
       - run: # sudo is needed, so that integration test binary have proper access to nodes keyring
           name: Run integration tests
           command: |
             make localnet-start-test
             sudo -E env "PATH=$PATH" make test-babylon-integration
             make localnet-stop
-      # TODO: If CI tests will take to long consider having only this e2e test
-      # instead of separate integration tests and e2e tests.
+  e2e-test:
+    machine:
+      image: ubuntu-2204:2022.10.1
+      resource_class: large
+    steps:
+      - checkout
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - go-mod-v6-{{ checksum "go.sum" }}
       - run:
           name: Run e2e tests
           command: |
@@ -99,9 +128,21 @@ jobs:
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  build-lint-test:
+  version: 2
+  build-test:
     jobs:
       - build
+      - unit-test:
+          requires:
+            - build
+      - integration-test:
+          requires:
+            - build
+  lint:
+    jobs:
+      - lint
+  docker:
+    jobs:
       - build_docker:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
   lint:
     machine:
       image: ubuntu-2204:2022.10.1
-      resource_class: large
+      resource_class: medium
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  build:
+  build-test:
     # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     machine:
@@ -29,6 +29,23 @@ jobs:
           key: go-mod-v6-{{ checksum "go.sum" }}
           paths:
             - "/home/circleci/.go_workspace/pkg/mod"
+      - run:
+          name: Run tests
+          command: |
+            make test
+      - run: # sudo is needed, so that integration test binary have proper access to nodes keyring
+          name: Run integration tests
+          command: |
+            make localnet-start-test
+            sudo -E env "PATH=$PATH" make test-babylon-integration
+            make localnet-stop
+      # TODO: If CI tests will take to long consider having only this e2e test
+      # instead of separate integration tests and e2e tests.
+      # TODO: re-enable e2e test after bumping heremes releyer
+      # - run:
+      #     name: Run e2e tests
+      #     command: |
+      #       make test-e2e
   lint:
     machine:
       image: ubuntu-2204:2022.10.1
@@ -40,47 +57,6 @@ jobs:
           command: |
             curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
             ./bin/golangci-lint run
-  unit-test:
-    machine:
-      image: ubuntu-2204:2022.10.1
-      resource_class: large
-    steps:
-      - checkout
-      - restore_cache: # restores saved cache if no changes are detected since last run
-          keys:
-            - go-mod-v6-{{ checksum "go.sum" }}
-      - run:
-          name: Run tests
-          command: |
-            make test
-  integration-test:
-    machine:
-      image: ubuntu-2204:2022.10.1
-      resource_class: large
-    steps:
-      - checkout
-      - restore_cache: # restores saved cache if no changes are detected since last run
-          keys:
-            - go-mod-v6-{{ checksum "go.sum" }}
-      - run: # sudo is needed, so that integration test binary have proper access to nodes keyring
-          name: Run integration tests
-          command: |
-            make localnet-start-test
-            sudo -E env "PATH=$PATH" make test-babylon-integration
-            make localnet-stop
-  e2e-test:
-    machine:
-      image: ubuntu-2204:2022.10.1
-      resource_class: large
-    steps:
-      - checkout
-      - restore_cache: # restores saved cache if no changes are detected since last run
-          keys:
-            - go-mod-v6-{{ checksum "go.sum" }}
-      - run:
-          name: Run e2e tests
-          command: |
-            make test-e2e
 
   build_docker:
     machine:
@@ -131,13 +107,7 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - build
-      - unit-test:
-          requires:
-            - build
-      - integration-test:
-          requires:
-            - build
+      - build-test
   lint:
     jobs:
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,9 @@ jobs:
             make localnet-stop
       # TODO: If CI tests will take to long consider having only this e2e test
       # instead of separate integration tests and e2e tests.
-       - run:
-           name: Run e2e tests
-           command: |
+      - run:
+          name: Run e2e tests
+          command: |
              make test-e2e
   lint:
     machine:


### PR DESCRIPTION
The sequential execution of all of the CircleCI steps takes too long. In this PR we parallelize them to improve CI times.