### PR TITLE
Re-enable e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,10 @@ jobs:
             make localnet-stop
       # TODO: If CI tests will take to long consider having only this e2e test
       # instead of separate integration tests and e2e tests.
-      # TODO: re-enable e2e test after bumping heremes releyer
-      # - run:
-      #     name: Run e2e tests
-      #     command: |
-      #       make test-e2e
+      - run:
+          name: Run e2e tests
+          command: |
+            make test-e2e
 
   build_docker:
     machine:

--- a/test/e2e/containers/config.go
+++ b/test/e2e/containers/config.go
@@ -13,7 +13,7 @@ const (
 	BabylonContainerName = "babylonchain/babylond"
 
 	relayerRepository = "informalsystems/hermes"
-	relayerTag        = "1.3.0"
+	relayerTag        = "1.4.0"
 )
 
 // Returns ImageConfig needed for running e2e test.

--- a/test/e2e/containers/containers.go
+++ b/test/e2e/containers/containers.go
@@ -61,7 +61,7 @@ func (m *Manager) ExecTxCmd(t *testing.T, chainId string, containerName string, 
 // namely adding flags `--chain-id={chain-id} -b=block --yes --keyring-backend=test "--log_format=json"`,
 // and searching for `successStr`
 func (m *Manager) ExecTxCmdWithSuccessString(t *testing.T, chainId string, containerName string, command []string, successStr string) (bytes.Buffer, bytes.Buffer, error) {
-	allTxArgs := []string{fmt.Sprintf("--chain-id=%s", chainId), "-b=block", "--yes", "--keyring-backend=test", "--log_format=json", "--home=/babylondata"}
+	allTxArgs := []string{fmt.Sprintf("--chain-id=%s", chainId), "-b=sync", "--yes", "--keyring-backend=test", "--log_format=json", "--home=/babylondata"}
 	txCommand := append(command, allTxArgs...)
 	return m.ExecCmd(t, containerName, txCommand, successStr)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,18 +24,18 @@ func (s *IntegrationTestSuite) TestConnectIbc() {
 func (s *IntegrationTestSuite) TestIbcCheckpointing() {
 	chainA := s.configurer.GetChainConfig(0)
 
-	chainA.WaitUntilHeight(25)
+	chainA.WaitUntilHeight(35)
 
 	nonValidatorNode, err := chainA.GetNodeAtIndex(2)
 	s.NoError(err)
 
-	// Finalize epoch 1 and 2, as first headers of opposing chain are in epoch 2
-	nonValidatorNode.FinalizeSealedEpochs(1, 2)
+	// Finalize epoch 1,2,3 , as first headers of opposing chain are in epoch 3
+	nonValidatorNode.FinalizeSealedEpochs(1, 3)
 
-	epoch2, err := nonValidatorNode.QueryCheckpointForEpoch(2)
+	epoch3, err := nonValidatorNode.QueryCheckpointForEpoch(3)
 	s.NoError(err)
 
-	if epoch2.Status != ct.Finalized {
+	if epoch3.Status != ct.Finalized {
 		s.FailNow("Epoch 2 should be finalized")
 	}
 
@@ -44,7 +44,7 @@ func (s *IntegrationTestSuite) TestIbcCheckpointing() {
 	s.NoError(err)
 	// TODO Add more assertion here. Maybe check proofs ?
 	s.Equal(fininfo.FinalizedChainInfo.ChainId, initialization.ChainBID)
-	s.Equal(fininfo.EpochInfo.EpochNumber, uint64(2))
+	s.Equal(fininfo.EpochInfo.EpochNumber, uint64(3))
 
 	currEpoch, err := nonValidatorNode.QueryCurrentEpoch()
 	s.NoError(err)


### PR DESCRIPTION
New version of hermes supports new version of tendermint, it is possible to re-enable e2e tests.