### PR TITLE
Feature/lint proto ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,6 @@ jobs:
           paths:
             - "/home/circleci/.go_workspace/pkg/mod"
       - run:
-          name: Lint proto files
-          command: make proto-lint
-      - run:
           name: Run tests
           command: |
             make test
@@ -54,6 +51,9 @@ jobs:
       resource_class: medium
     steps:
       - checkout
+      - run:
+          name: Lint proto files
+          command: make proto-lint
       - run:
           name: Lint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
           paths:
             - "/home/circleci/.go_workspace/pkg/mod"
       - run:
+          name: Lint proto files
+          command: make proto-lint
+      - run:
           name: Run tests
           command: |
             make test

--- a/proto/babylon/checkpointing/v1/genesis.proto
+++ b/proto/babylon/checkpointing/v1/genesis.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package babylon.checkpointing.v1;
 
-import "gogoproto/gogo.proto";
 import "cosmos/crypto/ed25519/keys.proto";
 import "babylon/checkpointing/v1/bls_key.proto";
 

--- a/proto/babylon/checkpointing/v1/query.proto
+++ b/proto/babylon/checkpointing/v1/query.proto
@@ -3,7 +3,6 @@ package babylon.checkpointing.v1;
 
 import "babylon/checkpointing/v1/bls_key.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
-import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "babylon/checkpointing/v1/checkpoint.proto";
 

--- a/proto/babylon/monitor/v1/genesis.proto
+++ b/proto/babylon/monitor/v1/genesis.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package babylon.monitor.v1;
 
-import "gogoproto/gogo.proto";
-
 option go_package = "github.com/babylonchain/babylon/x/monitor/types";
 
 // GenesisState defines the monitor module's genesis state.

--- a/proto/babylon/monitor/v1/query.proto
+++ b/proto/babylon/monitor/v1/query.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package babylon.monitor.v1;
 
-import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 
 option go_package = "github.com/babylonchain/babylon/x/monitor/types";

--- a/proto/babylon/zoneconcierge/v1/genesis.proto
+++ b/proto/babylon/zoneconcierge/v1/genesis.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package babylon.zoneconcierge.v1;
 
-import "gogoproto/gogo.proto";
-
 option go_package = "github.com/babylonchain/babylon/x/zoneconcierge/types";
 
 // GenesisState defines the zoneconcierge module's genesis state.

--- a/proto/babylon/zoneconcierge/v1/query.proto
+++ b/proto/babylon/zoneconcierge/v1/query.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package babylon.zoneconcierge.v1;
 
-import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "babylon/btccheckpoint/v1/btccheckpoint.proto";


### PR DESCRIPTION
In pr which removed not needed params I have broken proto-linting. The only conclusion is that whatever is not part of regular CI will ultimately rot. This pr add linting of protos as CI step. 

One question I have, maybe to someone who knows more about Circle CI, currently `make proto-lint` will always pull image from ghcr with correct version of `buf`  (which ultimately does the linting), is it possible to cache this image between CI runs to avoid pulling it every time ?