### PR TITLE
Migrate epoching and btccheckpointing module to new way of handling params

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -432,7 +432,7 @@ func NewBabylonApp(
 
 	// NOTE: the epoching module has to be set before the chekpointing module, as the checkpointing module will have access to the epoching module
 	epochingKeeper := epochingkeeper.NewKeeper(
-		appCodec, keys[epochingtypes.StoreKey], keys[epochingtypes.StoreKey], app.GetSubspace(epochingtypes.ModuleName), app.BankKeeper, app.StakingKeeper,
+		appCodec, keys[epochingtypes.StoreKey], keys[epochingtypes.StoreKey], app.BankKeeper, app.StakingKeeper, authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
 	app.MintKeeper = mintkeeper.NewKeeper(appCodec, keys[minttypes.StoreKey], app.StakingKeeper, app.AccountKeeper, app.BankKeeper, authtypes.FeeCollectorName, authtypes.NewModuleAddress(govtypes.ModuleName).String())
@@ -597,13 +597,11 @@ func NewBabylonApp(
 			keys[btccheckpointtypes.StoreKey],
 			tkeys[btccheckpointtypes.TStoreKey],
 			keys[btccheckpointtypes.MemStoreKey],
-			app.GetSubspace(btccheckpointtypes.ModuleName),
 			&btclightclientKeeper,
 			app.CheckpointingKeeper,
-			// TODO decide on proper values for those constants, also those should be taken
-			// from some global config
 			&powLimit,
 			btcConfig.CheckpointTag(),
+			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		)
 	app.ZoneConciergeKeeper.SetBtcCheckpointKeeper(app.BtcCheckpointKeeper)
 
@@ -1054,19 +1052,9 @@ func BlockedAddresses() map[string]bool {
 func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey storetypes.StoreKey) paramskeeper.Keeper {
 	paramsKeeper := paramskeeper.NewKeeper(appCodec, legacyAmino, key, tkey)
 
-	paramsKeeper.Subspace(authtypes.ModuleName)
-	paramsKeeper.Subspace(banktypes.ModuleName)
-	paramsKeeper.Subspace(stakingtypes.ModuleName)
-	paramsKeeper.Subspace(minttypes.ModuleName)
-	paramsKeeper.Subspace(distrtypes.ModuleName)
-	paramsKeeper.Subspace(slashingtypes.ModuleName)
-	paramsKeeper.Subspace(govtypes.ModuleName)
-	paramsKeeper.Subspace(crisistypes.ModuleName)
-	// Babylon modules
-	paramsKeeper.Subspace(epochingtypes.ModuleName)
-	paramsKeeper.Subspace(btccheckpointtypes.ModuleName)
-
-	// IBC-related modules
+	// TODO: Only modules which did not migrate yet to new way of hanldling params
+	// are the IBC-related modules. Once they are migrated, we can remove this and
+	// whole usage of params module
 	paramsKeeper.Subspace(ibcexported.ModuleName)
 	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
 	paramsKeeper.Subspace(zctypes.ModuleName)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/boljen/go-bitmap v0.0.0-20151001105940-23cd2fb0ce7d
 	github.com/btcsuite/btcd/btcutil v1.1.2
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/gogoproto v1.4.6
 	github.com/cosmos/ibc-go/v7 v7.0.0
 	github.com/golang/mock v1.6.0
@@ -138,7 +139,6 @@ require (
 	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
 	github.com/coinbase/rosetta-sdk-go/types v1.0.0 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/ics23/go v0.9.1-0.20221207100636-b1abd8678aab // indirect
 	github.com/cosmos/rosetta-sdk-go v0.10.0 // indirect

--- a/proto/babylon/btccheckpoint/v1/tx.proto
+++ b/proto/babylon/btccheckpoint/v1/tx.proto
@@ -2,6 +2,10 @@ syntax = "proto3";
 package babylon.btccheckpoint.v1;
 
 import "babylon/btccheckpoint/v1/btccheckpoint.proto";
+import "cosmos_proto/cosmos.proto";
+import "cosmos/msg/v1/msg.proto";
+import "babylon/btccheckpoint/v1/params.proto";
+import "gogoproto/gogo.proto";
 
 option go_package = "github.com/babylonchain/babylon/x/btccheckpoint/types";
 
@@ -10,6 +14,9 @@ service Msg {
   // InsertBTCSpvProof tries to insert a new checkpoint into the store.
   rpc InsertBTCSpvProof(MsgInsertBTCSpvProof)
       returns (MsgInsertBTCSpvProofResponse);
+
+  // UpdateParams updates the btccheckpoint module parameters.
+  rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
 }
 
 // MsgInsertBTCSpvProof defines resquest to insert a new checkpoint into the
@@ -22,3 +29,22 @@ message MsgInsertBTCSpvProof {
 // MsgInsertBTCSpvProofResponse defines the response for the
 // MsgInsertBTCSpvProof message
 message MsgInsertBTCSpvProofResponse {}
+
+// MsgUpdateParams defines a message to update the btccheckpoint module params.
+message MsgUpdateParams {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the address of the governance account.
+  // just FYI: cosmos.AddressString marks that this field should use type alias
+  // for AddressString instead of string, but the functionality is not yet implemented
+  // in cosmos-proto
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+
+  // params defines the btccheckpoint parameters to update.
+  //
+  // NOTE: All parameters must be supplied.
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// MsgUpdateParamsResponse defines the response to the MsgUpdateParams message.
+message MsgUpdateParamsResponse {}

--- a/proto/babylon/epoching/v1/tx.proto
+++ b/proto/babylon/epoching/v1/tx.proto
@@ -3,6 +3,10 @@ package babylon.epoching.v1;
 
 import "gogoproto/gogo.proto";
 import "cosmos/staking/v1beta1/tx.proto";
+import "babylon/epoching/v1/params.proto";
+
+import "cosmos_proto/cosmos.proto";
+import "cosmos/msg/v1/msg.proto";
 
 option go_package = "github.com/babylonchain/babylon/x/epoching/types";
 
@@ -21,6 +25,9 @@ service Msg {
   // coins from a delegator and source validator to a destination validator.
   rpc WrappedBeginRedelegate(MsgWrappedBeginRedelegate)
       returns (MsgWrappedBeginRedelegateResponse);
+
+  // UpdateParams defines a method for updating epoching module parameters.
+  rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
 }
 
 // MsgWrappedDelegate is the message for delegating stakes
@@ -58,3 +65,22 @@ message MsgWrappedBeginRedelegate {
 // MsgWrappedBeginRedelegateResponse is the response to the
 // MsgWrappedBeginRedelegate message
 message MsgWrappedBeginRedelegateResponse {}
+
+// MsgUpdateParams defines a message for updating epoching module parameters.
+message MsgUpdateParams {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the address of the governance account.
+  // just FYI: cosmos.AddressString marks that this field should use type alias
+  // for AddressString instead of string, but the functionality is not yet implemented
+  // in cosmos-proto
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+
+  // params defines the epoching paramaeters parameters to update.
+  //
+  // NOTE: All parameters must be supplied.
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// MsgUpdateParamsResponse is the response to the MsgUpdateParams message.
+message MsgUpdateParamsResponse {}

--- a/testutil/keeper/btccheckpoint.go
+++ b/testutil/keeper/btccheckpoint.go
@@ -55,7 +55,9 @@ func NewBTCCheckpointKeeper(
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
 
 	// Initialize params
-	k.SetParams(ctx, btcctypes.DefaultParams())
+	if err := k.SetParams(ctx, btcctypes.DefaultParams()); err != nil {
+		panic(err)
+	}
 
 	return &k, ctx
 }

--- a/testutil/keeper/btccheckpoint.go
+++ b/testutil/keeper/btccheckpoint.go
@@ -16,7 +16,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,24 +39,17 @@ func NewBTCCheckpointKeeper(
 	registry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(registry)
 
-	paramsSubspace := typesparams.NewSubspace(cdc,
-		btcctypes.Amino,
-		storeKey,
-		memStoreKey,
-		"BTCCheckpointParams",
-	)
-
 	k := keeper.NewKeeper(
 		cdc,
 		storeKey,
 		tstoreKey,
 		memStoreKey,
-		paramsSubspace,
 		lk,
 		ek,
 		powLimit,
 		// use MainTag tests
 		txformat.MainTag(0),
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())

--- a/testutil/keeper/epoching.go
+++ b/testutil/keeper/epoching.go
@@ -47,7 +47,9 @@ func EpochingKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
 
 	// Initialize params
-	k.SetParams(ctx, types.DefaultParams())
+	if err := k.SetParams(ctx, types.DefaultParams()); err != nil {
+		panic(err)
+	}
 
 	return &k, ctx
 }

--- a/testutil/keeper/epoching.go
+++ b/testutil/keeper/epoching.go
@@ -11,7 +11,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/babylonchain/babylon/x/epoching/keeper"
@@ -31,20 +32,14 @@ func EpochingKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	registry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(registry)
 
-	paramsSubspace := typesparams.NewSubspace(cdc,
-		types.Amino,
-		storeKey,
-		memStoreKey,
-		"EpochingParams",
-	)
 	k := keeper.NewKeeper(
 		cdc,
 		storeKey,
 		memStoreKey,
-		paramsSubspace,
 		// TODO: make this compile at the moment, will fix for integrated testing
 		nil,
 		nil,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
 	// TODO: add msgServiceRouter?

--- a/x/btccheckpoint/genesis.go
+++ b/x/btccheckpoint/genesis.go
@@ -9,7 +9,10 @@ import (
 // InitGenesis initializes the capability module's state from a provided genesis
 // state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
-	k.SetParams(ctx, genState.Params)
+	// set params for this module
+	if err := k.SetParams(ctx, genState.Params); err != nil {
+		panic(err)
+	}
 }
 
 // ExportGenesis returns the capability module's exported genesis.

--- a/x/btccheckpoint/genesis_test.go
+++ b/x/btccheckpoint/genesis_test.go
@@ -15,7 +15,10 @@ func TestExportGenesis(t *testing.T) {
 	app := simapp.Setup(t, false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
-	app.BtcCheckpointKeeper.SetParams(ctx, types.DefaultParams())
+	if err := app.BtcCheckpointKeeper.SetParams(ctx, types.DefaultParams()); err != nil {
+		panic(err)
+	}
+
 	genesisState := btccheckpoint.ExportGenesis(ctx, app.BtcCheckpointKeeper)
 	require.Equal(t, genesisState.Params, types.DefaultParams())
 }

--- a/x/btccheckpoint/genesis_test.go
+++ b/x/btccheckpoint/genesis_test.go
@@ -26,12 +26,12 @@ func TestInitGenesis(t *testing.T) {
 
 	genesisState := types.GenesisState{
 		Params: types.Params{
-			BtcConfirmationDepth:          999,
-			CheckpointFinalizationTimeout: 888,
+			BtcConfirmationDepth:          888,
+			CheckpointFinalizationTimeout: 999,
 		},
 	}
 
 	btccheckpoint.InitGenesis(ctx, app.BtcCheckpointKeeper, genesisState)
-	require.Equal(t, app.BtcCheckpointKeeper.GetParams(ctx).BtcConfirmationDepth, uint64(999))
-	require.Equal(t, app.BtcCheckpointKeeper.GetParams(ctx).CheckpointFinalizationTimeout, uint64(888))
+	require.Equal(t, app.BtcCheckpointKeeper.GetParams(ctx).BtcConfirmationDepth, uint64(888))
+	require.Equal(t, app.BtcCheckpointKeeper.GetParams(ctx).CheckpointFinalizationTimeout, uint64(999))
 }

--- a/x/btccheckpoint/keeper/keeper.go
+++ b/x/btccheckpoint/keeper/keeper.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
 type (
@@ -22,11 +21,11 @@ type (
 		storeKey              storetypes.StoreKey
 		tstoreKey             storetypes.StoreKey
 		memKey                storetypes.StoreKey
-		paramstore            paramtypes.Subspace
 		btcLightClientKeeper  types.BTCLightClientKeeper
 		checkpointingKeeper   types.CheckpointingKeeper
 		powLimit              *big.Int
 		expectedCheckpointTag txformat.BabylonTag
+		authority             string
 	}
 
 	submissionBtcError string
@@ -63,27 +62,23 @@ func NewKeeper(
 	storeKey,
 	tstoreKey,
 	memKey storetypes.StoreKey,
-	ps paramtypes.Subspace,
 	bk types.BTCLightClientKeeper,
 	ck types.CheckpointingKeeper,
 	powLimit *big.Int,
 	expectedTag txformat.BabylonTag,
+	authority string,
 ) Keeper {
-	// set KeyTable if it has not already been set
-	if !ps.HasKeyTable() {
-		ps = ps.WithKeyTable(types.ParamKeyTable())
-	}
 
 	return Keeper{
 		cdc:                   cdc,
 		storeKey:              storeKey,
 		tstoreKey:             tstoreKey,
 		memKey:                memKey,
-		paramstore:            ps,
 		btcLightClientKeeper:  bk,
 		checkpointingKeeper:   ck,
 		powLimit:              powLimit,
 		expectedCheckpointTag: expectedTag,
+		authority:             authority,
 	}
 }
 

--- a/x/btccheckpoint/keeper/msg_server.go
+++ b/x/btccheckpoint/keeper/msg_server.go
@@ -3,8 +3,10 @@ package keeper
 import (
 	"context"
 
+	errorsmod "cosmossdk.io/errors"
 	"github.com/babylonchain/babylon/x/btccheckpoint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
 var _ types.MsgServer = msgServer{}
@@ -90,4 +92,18 @@ func (m msgServer) InsertBTCSpvProof(ctx context.Context, req *types.MsgInsertBT
 	}
 
 	return &types.MsgInsertBTCSpvProofResponse{}, nil
+}
+
+// UpdateParams updates the params.
+func (ms msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
+	if ms.k.authority != req.Authority {
+		return nil, errorsmod.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", ms.k.authority, req.Authority)
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	if err := ms.k.SetParams(ctx, req.Params); err != nil {
+		return nil, err
+	}
+
+	return &types.MsgUpdateParamsResponse{}, nil
 }

--- a/x/btccheckpoint/keeper/params.go
+++ b/x/btccheckpoint/keeper/params.go
@@ -5,13 +5,27 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// GetParams get all parameters as types.Params
-func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
-	k.paramstore.GetParamSet(ctx, &params)
-	return params
+// SetParams sets the x/btccheckpoint module parameters.
+func (k Keeper) SetParams(ctx sdk.Context, p types.Params) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+
+	store := ctx.KVStore(k.storeKey)
+	bz := k.cdc.MustMarshal(&p)
+	store.Set(types.ParamsKey, bz)
+
+	return nil
 }
 
-// SetParams set the params
-func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
-	k.paramstore.SetParamSet(ctx, &params)
+// GetParams returns the current x/btccheckpoint module parameters.
+func (k Keeper) GetParams(ctx sdk.Context) (p types.Params) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.ParamsKey)
+	if bz == nil {
+		return p
+	}
+
+	k.cdc.MustUnmarshal(bz, &p)
+	return p
 }

--- a/x/btccheckpoint/keeper/params_test.go
+++ b/x/btccheckpoint/keeper/params_test.go
@@ -10,9 +10,12 @@ import (
 
 func TestGetParams(t *testing.T) {
 	k, ctx := testkeeper.NewBTCCheckpointKeeper(t, nil, nil, nil)
+
 	params := types.DefaultParams()
 
-	k.SetParams(ctx, params)
+	if err := k.SetParams(ctx, params); err != nil {
+		panic(err)
+	}
 
 	require.EqualValues(t, params, k.GetParams(ctx))
 }

--- a/x/btccheckpoint/types/codec.go
+++ b/x/btccheckpoint/types/codec.go
@@ -9,14 +9,18 @@ import (
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&MsgInsertBTCSpvProof{}, "btccheckpoint/MsgInsertBTCSpvProof", nil)
+	cdc.RegisterConcrete(&MsgUpdateParams{}, "btccheckpoint/MsgUpdateParams", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
-
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgInsertBTCSpvProof{},
 	)
-
+	registry.RegisterImplementations(
+		(*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 

--- a/x/btccheckpoint/types/keys.go
+++ b/x/btccheckpoint/types/keys.go
@@ -33,6 +33,7 @@ var (
 	EpochDataPrefix          = []byte{4}
 	LastFinalizedEpochKey    = append([]byte{5}, []byte(LatestFinalizedEpochKey)...)
 	BtcLightClientUpdatedKey = append([]byte{6}, []byte(btcLightClientUpdated)...)
+	ParamsKey                = []byte{7}
 )
 
 func KeyPrefix(p string) []byte {

--- a/x/btccheckpoint/types/msgs.go
+++ b/x/btccheckpoint/types/msgs.go
@@ -5,6 +5,8 @@ import (
 	fmt "fmt"
 	"math/big"
 
+	errorsmod "cosmossdk.io/errors"
+
 	txformat "github.com/babylonchain/babylon/btctxformatter"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -13,6 +15,7 @@ import (
 var (
 	// Ensure that MsgInsertBTCSpvProof implements all functions of the Msg interface
 	_ sdk.Msg = (*MsgInsertBTCSpvProof)(nil)
+	_ sdk.Msg = (*MsgUpdateParams)(nil)
 )
 
 // Parse and Validate transactions which should contain OP_RETURN data.
@@ -129,4 +132,23 @@ func (m *MsgInsertBTCSpvProof) GetSigners() []sdk.AccAddress {
 	}
 
 	return []sdk.AccAddress{submitter}
+}
+
+// GetSigners returns the expected signers for a MsgUpdateParams message.
+func (m *MsgUpdateParams) GetSigners() []sdk.AccAddress {
+	addr, _ := sdk.AccAddressFromBech32(m.Authority)
+	return []sdk.AccAddress{addr}
+}
+
+// ValidateBasic does a sanity check on the provided data.
+func (m *MsgUpdateParams) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(m.Authority); err != nil {
+		return errorsmod.Wrap(err, "invalid authority address")
+	}
+
+	if err := m.Params.Validate(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/x/btccheckpoint/types/params.go
+++ b/x/btccheckpoint/types/params.go
@@ -2,26 +2,12 @@ package types
 
 import (
 	fmt "fmt"
-
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
 const (
 	DefaultBtcConfirmationDepth          uint64 = 10
 	DefaultCheckpointFinalizationTimeout uint64 = 100
 )
-
-var (
-	KeyBtcConfirmationDepth          = []byte("BtcConfirmationDepth")
-	KeyCheckpointFinalizationTimeout = []byte("CheckpointFinalizationTimeout")
-)
-
-var _ paramtypes.ParamSet = (*Params)(nil)
-
-// ParamKeyTable the param key table for launch module
-func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
-}
 
 // NewParams creates a new Params instance
 func NewParams(btcConfirmationDepth uint64, checkpointFinalizationTimeout uint64) Params {
@@ -37,14 +23,6 @@ func DefaultParams() Params {
 		DefaultBtcConfirmationDepth,
 		DefaultCheckpointFinalizationTimeout,
 	)
-}
-
-// ParamSetPairs get the params.ParamSet
-func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
-	return paramtypes.ParamSetPairs{
-		paramtypes.NewParamSetPair(KeyBtcConfirmationDepth, &p.BtcConfirmationDepth, validateBtcConfirmationDepth),
-		paramtypes.NewParamSetPair(KeyCheckpointFinalizationTimeout, &p.CheckpointFinalizationTimeout, validateCheckpointFinalizationTimeout),
-	}
 }
 
 // Validate validates the set of params

--- a/x/btccheckpoint/types/tx.pb.go
+++ b/x/btccheckpoint/types/tx.pb.go
@@ -6,6 +6,9 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	_ "github.com/cosmos/cosmos-proto"
+	_ "github.com/cosmos/cosmos-sdk/types/msgservice"
+	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 	proto "github.com/cosmos/gogoproto/proto"
 	grpc "google.golang.org/grpc"
@@ -119,31 +122,141 @@ func (m *MsgInsertBTCSpvProofResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgInsertBTCSpvProofResponse proto.InternalMessageInfo
 
+// MsgUpdateParams defines a message to update the btccheckpoint module params.
+type MsgUpdateParams struct {
+	// authority is the address of the governance account.
+	// just FYI: cosmos.AddressString marks that this field should use type alias
+	// for AddressString instead of string, but the functionality is not yet implemented
+	// in cosmos-proto
+	Authority string `protobuf:"bytes,1,opt,name=authority,proto3" json:"authority,omitempty"`
+	// params defines the btccheckpoint parameters to update.
+	//
+	// NOTE: All parameters must be supplied.
+	Params Params `protobuf:"bytes,2,opt,name=params,proto3" json:"params"`
+}
+
+func (m *MsgUpdateParams) Reset()         { *m = MsgUpdateParams{} }
+func (m *MsgUpdateParams) String() string { return proto.CompactTextString(m) }
+func (*MsgUpdateParams) ProtoMessage()    {}
+func (*MsgUpdateParams) Descriptor() ([]byte, []int) {
+	return fileDescriptor_69a562325f8b35c5, []int{2}
+}
+func (m *MsgUpdateParams) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUpdateParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUpdateParams.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUpdateParams) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUpdateParams.Merge(m, src)
+}
+func (m *MsgUpdateParams) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUpdateParams) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUpdateParams.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUpdateParams proto.InternalMessageInfo
+
+func (m *MsgUpdateParams) GetAuthority() string {
+	if m != nil {
+		return m.Authority
+	}
+	return ""
+}
+
+func (m *MsgUpdateParams) GetParams() Params {
+	if m != nil {
+		return m.Params
+	}
+	return Params{}
+}
+
+// MsgUpdateParamsResponse defines the response to the MsgUpdateParams message.
+type MsgUpdateParamsResponse struct {
+}
+
+func (m *MsgUpdateParamsResponse) Reset()         { *m = MsgUpdateParamsResponse{} }
+func (m *MsgUpdateParamsResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgUpdateParamsResponse) ProtoMessage()    {}
+func (*MsgUpdateParamsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_69a562325f8b35c5, []int{3}
+}
+func (m *MsgUpdateParamsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUpdateParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUpdateParamsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUpdateParamsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUpdateParamsResponse.Merge(m, src)
+}
+func (m *MsgUpdateParamsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUpdateParamsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUpdateParamsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUpdateParamsResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgInsertBTCSpvProof)(nil), "babylon.btccheckpoint.v1.MsgInsertBTCSpvProof")
 	proto.RegisterType((*MsgInsertBTCSpvProofResponse)(nil), "babylon.btccheckpoint.v1.MsgInsertBTCSpvProofResponse")
+	proto.RegisterType((*MsgUpdateParams)(nil), "babylon.btccheckpoint.v1.MsgUpdateParams")
+	proto.RegisterType((*MsgUpdateParamsResponse)(nil), "babylon.btccheckpoint.v1.MsgUpdateParamsResponse")
 }
 
 func init() { proto.RegisterFile("babylon/btccheckpoint/v1/tx.proto", fileDescriptor_69a562325f8b35c5) }
 
 var fileDescriptor_69a562325f8b35c5 = []byte{
-	// 255 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x4c, 0x4a, 0x4c, 0xaa,
-	0xcc, 0xc9, 0xcf, 0xd3, 0x4f, 0x2a, 0x49, 0x4e, 0xce, 0x48, 0x4d, 0xce, 0x2e, 0xc8, 0xcf, 0xcc,
-	0x2b, 0xd1, 0x2f, 0x33, 0xd4, 0x2f, 0xa9, 0xd0, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x92, 0x80,
-	0x2a, 0xd1, 0x43, 0x51, 0xa2, 0x57, 0x66, 0x28, 0xa5, 0x83, 0x53, 0x33, 0xaa, 0x52, 0xb0, 0x39,
-	0x4a, 0xc5, 0x5c, 0x22, 0xbe, 0xc5, 0xe9, 0x9e, 0x79, 0xc5, 0xa9, 0x45, 0x25, 0x4e, 0x21, 0xce,
-	0xc1, 0x05, 0x65, 0x01, 0x45, 0xf9, 0xf9, 0x69, 0x42, 0x32, 0x5c, 0x9c, 0xc5, 0xa5, 0x49, 0xb9,
-	0x99, 0x25, 0x25, 0xa9, 0x45, 0x12, 0x8c, 0x0a, 0x8c, 0x1a, 0x9c, 0x41, 0x08, 0x01, 0x21, 0x5b,
-	0x2e, 0xb6, 0x02, 0x90, 0xb2, 0x62, 0x09, 0x26, 0x05, 0x66, 0x0d, 0x6e, 0x23, 0x55, 0x3d, 0x5c,
-	0xce, 0xd1, 0x43, 0x32, 0x34, 0x08, 0xaa, 0x49, 0x49, 0x8e, 0x4b, 0x06, 0x9b, 0xa5, 0x41, 0xa9,
-	0xc5, 0x05, 0xf9, 0x79, 0xc5, 0xa9, 0x46, 0x4d, 0x8c, 0x5c, 0xcc, 0xbe, 0xc5, 0xe9, 0x42, 0xd5,
-	0x5c, 0x82, 0x98, 0x2e, 0xd3, 0xc3, 0x6d, 0x17, 0x36, 0x43, 0xa5, 0xcc, 0x48, 0x53, 0x0f, 0x73,
-	0x84, 0x93, 0xff, 0x89, 0x47, 0x72, 0x8c, 0x17, 0x1e, 0xc9, 0x31, 0x3e, 0x78, 0x24, 0xc7, 0x38,
-	0xe1, 0xb1, 0x1c, 0xc3, 0x85, 0xc7, 0x72, 0x0c, 0x37, 0x1e, 0xcb, 0x31, 0x44, 0x99, 0xa6, 0x67,
-	0x96, 0x64, 0x94, 0x26, 0xe9, 0x25, 0xe7, 0xe7, 0xea, 0x43, 0xcd, 0x4e, 0xce, 0x48, 0xcc, 0xcc,
-	0x83, 0x71, 0xf4, 0x2b, 0xd0, 0xc2, 0xbe, 0xa4, 0xb2, 0x20, 0xb5, 0x38, 0x89, 0x0d, 0x1c, 0xe2,
-	0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0x8a, 0x0e, 0xae, 0xdc, 0xde, 0x01, 0x00, 0x00,
+	// 425 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x52, 0xcb, 0xaa, 0xd3, 0x40,
+	0x18, 0xce, 0x9c, 0x23, 0x85, 0xce, 0x11, 0xc5, 0x50, 0x38, 0x69, 0x28, 0x31, 0x06, 0x0a, 0x55,
+	0x34, 0xa1, 0x15, 0xbb, 0x10, 0x14, 0x8c, 0x2b, 0x17, 0xc5, 0x92, 0xea, 0xc6, 0x8d, 0x24, 0xe9,
+	0x38, 0x09, 0x36, 0x99, 0x61, 0xfe, 0x69, 0x69, 0x71, 0xe7, 0x13, 0xb8, 0xf5, 0x2d, 0x5c, 0xf8,
+	0x10, 0x5d, 0x16, 0x57, 0xae, 0x44, 0xda, 0x85, 0x5b, 0x1f, 0x41, 0x9a, 0x0b, 0xbd, 0xd8, 0x88,
+	0x67, 0x37, 0xff, 0xcc, 0x77, 0x9b, 0x8f, 0x1f, 0xdf, 0x09, 0xfc, 0x60, 0x31, 0x61, 0xa9, 0x13,
+	0xc8, 0x30, 0x8c, 0x48, 0xf8, 0x9e, 0xb3, 0x38, 0x95, 0xce, 0xac, 0xeb, 0xc8, 0xb9, 0xcd, 0x05,
+	0x93, 0x4c, 0xd5, 0x0a, 0x88, 0x7d, 0x00, 0xb1, 0x67, 0x5d, 0xfd, 0x7e, 0x25, 0xf9, 0x10, 0x9a,
+	0xe9, 0xe8, 0xcd, 0x90, 0x41, 0xc2, 0xe0, 0x6d, 0x36, 0x39, 0xf9, 0x50, 0x3c, 0x5d, 0xe6, 0x93,
+	0x93, 0x00, 0xdd, 0xb2, 0x13, 0xa0, 0xc5, 0x43, 0xbb, 0xd2, 0x81, 0xfb, 0xc2, 0x4f, 0x4a, 0x7e,
+	0x83, 0x32, 0xca, 0x72, 0xdd, 0xed, 0x29, 0xbf, 0xb5, 0x00, 0x37, 0x06, 0x40, 0x5f, 0xa4, 0x40,
+	0x84, 0x74, 0x5f, 0x3d, 0x1f, 0xf1, 0xd9, 0x50, 0x30, 0xf6, 0x4e, 0x6d, 0xe1, 0x3a, 0x4c, 0x83,
+	0x24, 0x96, 0x92, 0x08, 0x0d, 0x99, 0xa8, 0x53, 0xf7, 0x76, 0x17, 0xea, 0x13, 0x5c, 0xe3, 0x5b,
+	0x18, 0x68, 0x67, 0xe6, 0x79, 0xe7, 0xa2, 0xd7, 0xb6, 0xab, 0xfe, 0x6f, 0xef, 0x89, 0x7a, 0x05,
+	0xc9, 0x32, 0x70, 0xeb, 0x94, 0xa9, 0x47, 0x80, 0xb3, 0x14, 0x88, 0xf5, 0x19, 0xe1, 0x9b, 0x03,
+	0xa0, 0xaf, 0xf9, 0xd8, 0x97, 0x64, 0x98, 0x7d, 0x42, 0xed, 0xe3, 0xba, 0x3f, 0x95, 0x11, 0x13,
+	0xb1, 0x5c, 0xe4, 0x81, 0x5c, 0xed, 0xdb, 0xd7, 0x07, 0x8d, 0xa2, 0xa3, 0x67, 0xe3, 0xb1, 0x20,
+	0x00, 0x23, 0x29, 0xe2, 0x94, 0x7a, 0x3b, 0xa8, 0xfa, 0x14, 0xd7, 0xf2, 0x1a, 0xb4, 0x33, 0x13,
+	0x75, 0x2e, 0x7a, 0x66, 0x75, 0xd4, 0xdc, 0xc9, 0xbd, 0xb6, 0xfc, 0x71, 0x5b, 0xf1, 0x0a, 0xd6,
+	0xe3, 0x1b, 0x1f, 0x7f, 0x7d, 0xb9, 0xb7, 0xd3, 0xb3, 0x9a, 0xf8, 0xf2, 0x28, 0x5a, 0x19, 0xbb,
+	0xf7, 0x1b, 0xe1, 0xf3, 0x01, 0x50, 0xf5, 0x03, 0xbe, 0xf5, 0x77, 0xa1, 0x76, 0xb5, 0xef, 0xa9,
+	0x2e, 0xf4, 0xfe, 0xd5, 0xf0, 0x65, 0x08, 0x75, 0x82, 0xaf, 0x1f, 0xf4, 0x76, 0xf7, 0x9f, 0x3a,
+	0xfb, 0x50, 0xbd, 0xfb, 0xdf, 0xd0, 0xd2, 0xcd, 0x7d, 0xb9, 0x5c, 0x1b, 0x68, 0xb5, 0x36, 0xd0,
+	0xcf, 0xb5, 0x81, 0x3e, 0x6d, 0x0c, 0x65, 0xb5, 0x31, 0x94, 0xef, 0x1b, 0x43, 0x79, 0xf3, 0x88,
+	0xc6, 0x32, 0x9a, 0x06, 0x76, 0xc8, 0x12, 0xa7, 0x90, 0x0d, 0x23, 0x3f, 0x4e, 0xcb, 0xc1, 0x99,
+	0x1f, 0xed, 0xab, 0x5c, 0x70, 0x02, 0x41, 0x2d, 0x5b, 0xcb, 0x87, 0x7f, 0x02, 0x00, 0x00, 0xff,
+	0xff, 0x53, 0xca, 0xbd, 0x84, 0x74, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -160,6 +273,8 @@ const _ = grpc.SupportPackageIsVersion4
 type MsgClient interface {
 	// InsertBTCSpvProof tries to insert a new checkpoint into the store.
 	InsertBTCSpvProof(ctx context.Context, in *MsgInsertBTCSpvProof, opts ...grpc.CallOption) (*MsgInsertBTCSpvProofResponse, error)
+	// UpdateParams updates the btccheckpoint module parameters.
+	UpdateParams(ctx context.Context, in *MsgUpdateParams, opts ...grpc.CallOption) (*MsgUpdateParamsResponse, error)
 }
 
 type msgClient struct {
@@ -179,10 +294,21 @@ func (c *msgClient) InsertBTCSpvProof(ctx context.Context, in *MsgInsertBTCSpvPr
 	return out, nil
 }
 
+func (c *msgClient) UpdateParams(ctx context.Context, in *MsgUpdateParams, opts ...grpc.CallOption) (*MsgUpdateParamsResponse, error) {
+	out := new(MsgUpdateParamsResponse)
+	err := c.cc.Invoke(ctx, "/babylon.btccheckpoint.v1.Msg/UpdateParams", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	// InsertBTCSpvProof tries to insert a new checkpoint into the store.
 	InsertBTCSpvProof(context.Context, *MsgInsertBTCSpvProof) (*MsgInsertBTCSpvProofResponse, error)
+	// UpdateParams updates the btccheckpoint module parameters.
+	UpdateParams(context.Context, *MsgUpdateParams) (*MsgUpdateParamsResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -191,6 +317,9 @@ type UnimplementedMsgServer struct {
 
 func (*UnimplementedMsgServer) InsertBTCSpvProof(ctx context.Context, req *MsgInsertBTCSpvProof) (*MsgInsertBTCSpvProofResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method InsertBTCSpvProof not implemented")
+}
+func (*UnimplementedMsgServer) UpdateParams(ctx context.Context, req *MsgUpdateParams) (*MsgUpdateParamsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateParams not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -215,6 +344,24 @@ func _Msg_InsertBTCSpvProof_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_UpdateParams_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgUpdateParams)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).UpdateParams(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/babylon.btccheckpoint.v1.Msg/UpdateParams",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).UpdateParams(ctx, req.(*MsgUpdateParams))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "babylon.btccheckpoint.v1.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -222,6 +369,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "InsertBTCSpvProof",
 			Handler:    _Msg_InsertBTCSpvProof_Handler,
+		},
+		{
+			MethodName: "UpdateParams",
+			Handler:    _Msg_UpdateParams_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -295,6 +446,69 @@ func (m *MsgInsertBTCSpvProofResponse) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgUpdateParams) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUpdateParams) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUpdateParams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Params.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
+	if len(m.Authority) > 0 {
+		i -= len(m.Authority)
+		copy(dAtA[i:], m.Authority)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Authority)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgUpdateParamsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUpdateParamsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUpdateParamsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -326,6 +540,30 @@ func (m *MsgInsertBTCSpvProof) Size() (n int) {
 }
 
 func (m *MsgInsertBTCSpvProofResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgUpdateParams) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Authority)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.Params.Size()
+	n += 1 + l + sovTx(uint64(l))
+	return n
+}
+
+func (m *MsgUpdateParamsResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -483,6 +721,171 @@ func (m *MsgInsertBTCSpvProofResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgInsertBTCSpvProofResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUpdateParams) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUpdateParams: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUpdateParams: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Authority", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Authority = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Params", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUpdateParamsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUpdateParamsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUpdateParamsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/x/epoching/genesis.go
+++ b/x/epoching/genesis.go
@@ -10,7 +10,10 @@ import (
 // state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	// set params for this module
-	k.SetParams(ctx, genState.Params)
+	if err := k.SetParams(ctx, genState.Params); err != nil {
+		panic(err)
+	}
+
 	// init epoch number
 	k.InitEpoch(ctx)
 	// init msg queue

--- a/x/epoching/genesis_test.go
+++ b/x/epoching/genesis_test.go
@@ -15,7 +15,10 @@ func TestExportGenesis(t *testing.T) {
 	app := simapp.Setup(t, false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
-	app.EpochingKeeper.SetParams(ctx, types.DefaultParams())
+	if err := app.EpochingKeeper.SetParams(ctx, types.DefaultParams()); err != nil {
+		panic(err)
+	}
+
 	genesisState := epoching.ExportGenesis(ctx, app.EpochingKeeper)
 	require.Equal(t, genesisState.Params, types.DefaultParams())
 }

--- a/x/epoching/keeper/apphash_chain_test.go
+++ b/x/epoching/keeper/apphash_chain_test.go
@@ -26,9 +26,14 @@ func FuzzAppHashChain(f *testing.F) {
 
 		// set a random epoch interval
 		epochInterval := rand.Uint64()%100 + 2 // the epoch interval should at at least 2
-		k.SetParams(ctx, types.Params{
+
+		params := types.Params{
 			EpochInterval: epochInterval,
-		})
+		}
+
+		if err := k.SetParams(ctx, params); err != nil {
+			panic(err)
+		}
 
 		// reach the end of the 1st epoch
 		expectedHeight := epochInterval

--- a/x/epoching/keeper/epochs_test.go
+++ b/x/epoching/keeper/epochs_test.go
@@ -25,9 +25,15 @@ func FuzzEpochs(f *testing.F) {
 
 		// set a random epoch interval
 		epochInterval := rand.Uint64()%100 + 2 // the epoch interval should at at least 2
-		keeper.SetParams(ctx, types.Params{
+
+		params := types.Params{
 			EpochInterval: epochInterval,
-		})
+		}
+
+		if err := keeper.SetParams(ctx, params); err != nil {
+			panic(err)
+		}
+
 		// increment a random number of new blocks
 		numIncBlocks := rand.Uint64()%1000 + 1
 		for i := uint64(0); i < numIncBlocks; i++ {

--- a/x/epoching/keeper/grpc_query_test.go
+++ b/x/epoching/keeper/grpc_query_test.go
@@ -43,7 +43,9 @@ func FuzzParamsQuery(f *testing.F) {
 		// if setParamsFlag == 0, set params
 		setParamsFlag := rand.Intn(2)
 		if setParamsFlag == 0 {
-			keeper.SetParams(ctx, params)
+			if err := keeper.SetParams(ctx, params); err != nil {
+				panic(err)
+			}
 		}
 		req := types.QueryParamsRequest{}
 		resp, err := queryClient.Params(wctx, &req)

--- a/x/epoching/keeper/keeper.go
+++ b/x/epoching/keeper/keeper.go
@@ -8,21 +8,22 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/babylonchain/babylon/x/epoching/types"
 )
 
 type (
 	Keeper struct {
-		cdc        codec.BinaryCodec
-		storeKey   storetypes.StoreKey
-		memKey     storetypes.StoreKey
-		hooks      types.EpochingHooks
-		paramstore paramtypes.Subspace
-		bk         types.BankKeeper
-		stk        types.StakingKeeper
-		router     *baseapp.MsgServiceRouter
+		cdc      codec.BinaryCodec
+		storeKey storetypes.StoreKey
+		memKey   storetypes.StoreKey
+		hooks    types.EpochingHooks
+		bk       types.BankKeeper
+		stk      types.StakingKeeper
+		router   *baseapp.MsgServiceRouter
+		// the address capable of executing a MsgUpdateParams message. Typically, this
+		// should be the x/gov module account.
+		authority string
 	}
 )
 
@@ -30,23 +31,19 @@ func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeKey,
 	memKey storetypes.StoreKey,
-	ps paramtypes.Subspace,
 	bk types.BankKeeper,
 	stk types.StakingKeeper,
+	authority string,
 ) Keeper {
-	// set KeyTable if it has not already been set
-	if !ps.HasKeyTable() {
-		ps = ps.WithKeyTable(types.ParamKeyTable())
-	}
 
 	return Keeper{
-		cdc:        cdc,
-		storeKey:   storeKey,
-		memKey:     memKey,
-		paramstore: ps,
-		hooks:      nil,
-		bk:         bk,
-		stk:        stk,
+		cdc:       cdc,
+		storeKey:  storeKey,
+		memKey:    memKey,
+		hooks:     nil,
+		bk:        bk,
+		stk:       stk,
+		authority: authority,
 	}
 }
 

--- a/x/epoching/keeper/keeper_test.go
+++ b/x/epoching/keeper/keeper_test.go
@@ -22,7 +22,11 @@ func TestParams(t *testing.T) {
 
 	//modify a params, save, and retrieve
 	expParams.EpochInterval = 777
-	keeper.SetParams(ctx, expParams)
+
+	if err := keeper.SetParams(ctx, expParams); err != nil {
+		panic(err)
+	}
+
 	resParams = keeper.GetParams(ctx)
 	require.True(t, expParams.Equal(resParams))
 }

--- a/x/epoching/keeper/msg_server.go
+++ b/x/epoching/keeper/msg_server.go
@@ -186,6 +186,9 @@ func (k msgServer) WrappedBeginRedelegate(goCtx context.Context, msg *types.MsgW
 }
 
 // UpdateParams updates the params.
+// TODO investigate when it is the best time to update the params. We can update them
+// when the epoch changes, but we can also update them during the epoch and extend
+// the epoch duration.
 func (ms msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
 	if ms.authority != req.Authority {
 		return nil, errorsmod.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", ms.authority, req.Authority)

--- a/x/epoching/keeper/msg_server.go
+++ b/x/epoching/keeper/msg_server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -182,4 +183,18 @@ func (k msgServer) WrappedBeginRedelegate(goCtx context.Context, msg *types.MsgW
 	}
 
 	return &types.MsgWrappedBeginRedelegateResponse{}, nil
+}
+
+// UpdateParams updates the params.
+func (ms msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
+	if ms.authority != req.Authority {
+		return nil, errorsmod.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", ms.authority, req.Authority)
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	if err := ms.SetParams(ctx, req.Params); err != nil {
+		return nil, err
+	}
+
+	return &types.MsgUpdateParamsResponse{}, nil
 }

--- a/x/epoching/keeper/params.go
+++ b/x/epoching/keeper/params.go
@@ -6,12 +6,27 @@ import (
 )
 
 // GetParams get all parameters as types.Params
-func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
-	k.paramstore.GetParamSet(ctx, &params)
-	return params
+// SetParams sets the x/epoching module parameters.
+func (k Keeper) SetParams(ctx sdk.Context, p types.Params) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+
+	store := ctx.KVStore(k.storeKey)
+	bz := k.cdc.MustMarshal(&p)
+	store.Set(types.ParamsKey, bz)
+
+	return nil
 }
 
-// SetParams set the params
-func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
-	k.paramstore.SetParamSet(ctx, &params)
+// GetParams returns the current x/epoching module parameters.
+func (k Keeper) GetParams(ctx sdk.Context) (p types.Params) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.ParamsKey)
+	if bz == nil {
+		return p
+	}
+
+	k.cdc.MustUnmarshal(bz, &p)
+	return p
 }

--- a/x/epoching/keeper/params_test.go
+++ b/x/epoching/keeper/params_test.go
@@ -12,7 +12,9 @@ func TestGetParams(t *testing.T) {
 	k, ctx := testkeeper.EpochingKeeper(t)
 	params := types.DefaultParams()
 
-	k.SetParams(ctx, params)
+	if err := k.SetParams(ctx, params); err != nil {
+		panic(err)
+	}
 
 	require.EqualValues(t, params, k.GetParams(ctx))
 }

--- a/x/epoching/types/codec.go
+++ b/x/epoching/types/codec.go
@@ -12,6 +12,7 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgWrappedUndelegate{}, "epoching/WrappedUndelegate", nil)
 	cdc.RegisterConcrete(&MsgWrappedBeginRedelegate{}, "epoching/WrappedBeginRedelegate", nil)
 	cdc.RegisterConcrete(&QueuedMessage{}, "epoching/QueuedMessage", nil)
+	cdc.RegisterConcrete(&MsgUpdateParams{}, "epoching/MsgUpdateParams", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
@@ -31,6 +32,10 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		&QueuedMessage{},
+	)
+	registry.RegisterImplementations(
+		(*sdk.Msg)(nil),
+		&MsgUpdateParams{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/epoching/types/keys.go
+++ b/x/epoching/types/keys.go
@@ -29,6 +29,7 @@ var (
 	ValidatorLifecycleKey  = []byte{0x19} // key prefix for validator life cycle
 	DelegationLifecycleKey = []byte{0x20} // key prefix for delegation life cycle
 	AppHashKey             = []byte{0x21} // key prefix for the app hash
+	ParamsKey              = []byte{0x22} // key prefix for the parameters
 )
 
 func KeyPrefix(p string) []byte {

--- a/x/epoching/types/msg.go
+++ b/x/epoching/types/msg.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -17,6 +18,7 @@ var (
 	_ sdk.Msg = &MsgWrappedDelegate{}
 	_ sdk.Msg = &MsgWrappedUndelegate{}
 	_ sdk.Msg = &MsgWrappedBeginRedelegate{}
+	_ sdk.Msg = &MsgUpdateParams{}
 )
 
 // NewMsgWrappedDelegate creates a new MsgWrappedDelegate instance.
@@ -119,4 +121,23 @@ func (msg MsgWrappedBeginRedelegate) ValidateBasic() error {
 		return ErrNoWrappedMsg
 	}
 	return msg.Msg.ValidateBasic()
+}
+
+// GetSigners returns the expected signers for a MsgUpdateParams message.
+func (m *MsgUpdateParams) GetSigners() []sdk.AccAddress {
+	addr, _ := sdk.AccAddressFromBech32(m.Authority)
+	return []sdk.AccAddress{addr}
+}
+
+// ValidateBasic does a sanity check on the provided data.
+func (m *MsgUpdateParams) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(m.Authority); err != nil {
+		return errorsmod.Wrap(err, "invalid authority address")
+	}
+
+	if err := m.Params.Validate(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/x/epoching/types/params.go
+++ b/x/epoching/types/params.go
@@ -2,8 +2,6 @@ package types
 
 import (
 	fmt "fmt"
-
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
 const (
@@ -14,24 +12,10 @@ var (
 	KeyEpochInterval = []byte("EpochInterval")
 )
 
-var _ paramtypes.ParamSet = (*Params)(nil)
-
-// ParamKeyTable the param key table for launch module
-func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
-}
-
 // NewParams creates a new Params instance
 func NewParams(epochInterval uint64) Params {
 	return Params{
 		EpochInterval: epochInterval,
-	}
-}
-
-// ParamSetPairs get the params.ParamSet
-func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
-	return paramtypes.ParamSetPairs{
-		paramtypes.NewParamSetPair(KeyEpochInterval, &p.EpochInterval, validateEpochInterval),
 	}
 }
 

--- a/x/epoching/types/tx.pb.go
+++ b/x/epoching/types/tx.pb.go
@@ -6,6 +6,8 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	_ "github.com/cosmos/cosmos-proto"
+	_ "github.com/cosmos/cosmos-sdk/types/msgservice"
 	types "github.com/cosmos/cosmos-sdk/x/staking/types"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
@@ -257,6 +259,103 @@ func (m *MsgWrappedBeginRedelegateResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWrappedBeginRedelegateResponse proto.InternalMessageInfo
 
+// MsgUpdateParams defines a message for updating epoching module parameters.
+type MsgUpdateParams struct {
+	// authority is the address of the governance account.
+	// just FYI: cosmos.AddressString marks that this field should use type alias
+	// for AddressString instead of string, but the functionality is not yet implemented
+	// in cosmos-proto
+	Authority string `protobuf:"bytes,1,opt,name=authority,proto3" json:"authority,omitempty"`
+	// params defines the epoching paramaeters parameters to update.
+	//
+	// NOTE: All parameters must be supplied.
+	Params Params `protobuf:"bytes,2,opt,name=params,proto3" json:"params"`
+}
+
+func (m *MsgUpdateParams) Reset()         { *m = MsgUpdateParams{} }
+func (m *MsgUpdateParams) String() string { return proto.CompactTextString(m) }
+func (*MsgUpdateParams) ProtoMessage()    {}
+func (*MsgUpdateParams) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5fc8fed8f4e58b6, []int{6}
+}
+func (m *MsgUpdateParams) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUpdateParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUpdateParams.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUpdateParams) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUpdateParams.Merge(m, src)
+}
+func (m *MsgUpdateParams) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUpdateParams) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUpdateParams.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUpdateParams proto.InternalMessageInfo
+
+func (m *MsgUpdateParams) GetAuthority() string {
+	if m != nil {
+		return m.Authority
+	}
+	return ""
+}
+
+func (m *MsgUpdateParams) GetParams() Params {
+	if m != nil {
+		return m.Params
+	}
+	return Params{}
+}
+
+// MsgUpdateParamsResponse is the response to the MsgUpdateParams message.
+type MsgUpdateParamsResponse struct {
+}
+
+func (m *MsgUpdateParamsResponse) Reset()         { *m = MsgUpdateParamsResponse{} }
+func (m *MsgUpdateParamsResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgUpdateParamsResponse) ProtoMessage()    {}
+func (*MsgUpdateParamsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5fc8fed8f4e58b6, []int{7}
+}
+func (m *MsgUpdateParamsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUpdateParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUpdateParamsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUpdateParamsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUpdateParamsResponse.Merge(m, src)
+}
+func (m *MsgUpdateParamsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUpdateParamsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUpdateParamsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUpdateParamsResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgWrappedDelegate)(nil), "babylon.epoching.v1.MsgWrappedDelegate")
 	proto.RegisterType((*MsgWrappedDelegateResponse)(nil), "babylon.epoching.v1.MsgWrappedDelegateResponse")
@@ -264,35 +363,46 @@ func init() {
 	proto.RegisterType((*MsgWrappedUndelegateResponse)(nil), "babylon.epoching.v1.MsgWrappedUndelegateResponse")
 	proto.RegisterType((*MsgWrappedBeginRedelegate)(nil), "babylon.epoching.v1.MsgWrappedBeginRedelegate")
 	proto.RegisterType((*MsgWrappedBeginRedelegateResponse)(nil), "babylon.epoching.v1.MsgWrappedBeginRedelegateResponse")
+	proto.RegisterType((*MsgUpdateParams)(nil), "babylon.epoching.v1.MsgUpdateParams")
+	proto.RegisterType((*MsgUpdateParamsResponse)(nil), "babylon.epoching.v1.MsgUpdateParamsResponse")
 }
 
 func init() { proto.RegisterFile("babylon/epoching/v1/tx.proto", fileDescriptor_a5fc8fed8f4e58b6) }
 
 var fileDescriptor_a5fc8fed8f4e58b6 = []byte{
-	// 370 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x93, 0x4f, 0x4b, 0x3a, 0x41,
-	0x18, 0xc7, 0x77, 0x7f, 0xc2, 0x8f, 0x78, 0x3a, 0x44, 0x9b, 0x44, 0x2d, 0x32, 0x96, 0x12, 0xfd,
-	0x39, 0xcc, 0xa4, 0x51, 0x41, 0x74, 0x92, 0x4e, 0x81, 0x17, 0x41, 0xa2, 0x6e, 0xbb, 0xeb, 0x30,
-	0x2e, 0xea, 0xce, 0xe6, 0x4c, 0xa2, 0xb7, 0x8e, 0x1d, 0x7b, 0x09, 0xbe, 0x9c, 0x8e, 0x1e, 0x3b,
-	0x86, 0x5e, 0x7c, 0x19, 0xa1, 0xee, 0x38, 0xb2, 0xfe, 0xed, 0xa6, 0x7c, 0xbf, 0xcf, 0xe7, 0xf3,
-	0xf0, 0x2c, 0x03, 0x29, 0xd7, 0x71, 0x3b, 0x75, 0x1e, 0x10, 0x1a, 0x72, 0xaf, 0xea, 0x07, 0x8c,
-	0xb4, 0x72, 0x44, 0xb6, 0x71, 0xd8, 0xe4, 0x92, 0x5b, 0x7b, 0x51, 0x8a, 0x55, 0x8a, 0x5b, 0x39,
-	0x3b, 0xc9, 0x38, 0xe3, 0xe3, 0x9c, 0x8c, 0x7e, 0x4d, 0xaa, 0x76, 0xda, 0xe3, 0xa2, 0xc1, 0x05,
-	0x11, 0xd2, 0xa9, 0x4d, 0x30, 0x2e, 0x95, 0x8e, 0x66, 0x65, 0xca, 0x60, 0x15, 0x05, 0x7b, 0x6a,
-	0x3a, 0x61, 0x48, 0x2b, 0x0f, 0xb4, 0x4e, 0x99, 0x23, 0xa9, 0x75, 0x0d, 0x89, 0x86, 0x60, 0x07,
-	0xe6, 0x91, 0x79, 0xb6, 0x9d, 0xcf, 0xe2, 0x09, 0x04, 0x47, 0x10, 0x1c, 0x41, 0x70, 0x51, 0x30,
-	0x35, 0x51, 0x1a, 0xf5, 0xef, 0xb6, 0x3e, 0xba, 0x69, 0x63, 0xd8, 0x4d, 0x1b, 0x99, 0x14, 0xd8,
-	0xf3, 0xd8, 0x12, 0x15, 0x21, 0x0f, 0x04, 0xcd, 0x3c, 0x43, 0x52, 0xa7, 0xe5, 0xa0, 0xa2, 0xb4,
-	0xb7, 0xb3, 0xda, 0x93, 0x15, 0x5a, 0x3d, 0x13, 0x17, 0x23, 0x48, 0x2d, 0x42, 0x4f, 0xd5, 0x1e,
-	0x1c, 0xea, 0xbc, 0x40, 0x99, 0x1f, 0x94, 0xe8, 0xd4, 0x7f, 0x3f, 0xeb, 0xbf, 0x58, 0xe1, 0x8f,
-	0x0d, 0xc6, 0x97, 0xc8, 0xc2, 0xf1, 0x52, 0x89, 0xda, 0x24, 0x3f, 0xfc, 0x07, 0x89, 0xa2, 0x60,
-	0x56, 0x0d, 0x76, 0xe2, 0xe7, 0x3f, 0xc5, 0x0b, 0xbe, 0x30, 0x9e, 0x3f, 0xa8, 0x4d, 0x36, 0x2c,
-	0x2a, 0xa9, 0xf5, 0x0a, 0xbb, 0xf3, 0x67, 0x3f, 0x5f, 0x43, 0xd1, 0x55, 0x3b, 0xb7, 0x71, 0x75,
-	0xaa, 0x7c, 0x37, 0x61, 0x7f, 0xc9, 0xbd, 0xf1, 0x1a, 0x5a, 0xac, 0x6f, 0xdf, 0xfc, 0xad, 0xaf,
-	0x56, 0x28, 0x3c, 0x7e, 0xf5, 0x91, 0xd9, 0xeb, 0x23, 0xf3, 0xa7, 0x8f, 0xcc, 0xcf, 0x01, 0x32,
-	0x7a, 0x03, 0x64, 0x7c, 0x0f, 0x90, 0xf1, 0x72, 0xc9, 0x7c, 0x59, 0x7d, 0x73, 0xb1, 0xc7, 0x1b,
-	0x24, 0x62, 0x7b, 0x55, 0xc7, 0x0f, 0xd4, 0x1f, 0xd2, 0xd6, 0x4f, 0x50, 0x76, 0x42, 0x2a, 0xdc,
-	0xff, 0xe3, 0x77, 0x73, 0xf5, 0x1b, 0x00, 0x00, 0xff, 0xff, 0x97, 0xc6, 0x4a, 0xb3, 0xa3, 0x03,
+	// 514 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x94, 0x31, 0x6f, 0xd3, 0x40,
+	0x1c, 0xc5, 0x6d, 0x82, 0x2a, 0xfa, 0x07, 0x51, 0x61, 0x22, 0x9a, 0x98, 0xc8, 0x29, 0x29, 0x08,
+	0xa8, 0xe0, 0x4c, 0x8a, 0x28, 0xa2, 0x62, 0x21, 0x62, 0x42, 0x8a, 0x84, 0x8c, 0x2a, 0x04, 0x0b,
+	0x3a, 0xdb, 0xa7, 0x8b, 0xd5, 0xda, 0x67, 0x7c, 0xd7, 0xaa, 0xd9, 0x10, 0x13, 0x23, 0x03, 0x1f,
+	0xa0, 0x1f, 0x81, 0x81, 0x0f, 0xd1, 0x81, 0xa1, 0x62, 0x62, 0x42, 0x28, 0x19, 0xe0, 0x63, 0xa0,
+	0xd8, 0x67, 0x5f, 0x70, 0x92, 0x26, 0xdd, 0x62, 0xbd, 0xf7, 0x7f, 0xbf, 0x17, 0xf9, 0xc9, 0xd0,
+	0x70, 0xb1, 0xdb, 0xdf, 0x63, 0x91, 0x4d, 0x62, 0xe6, 0xf5, 0x82, 0x88, 0xda, 0x07, 0x6d, 0x5b,
+	0x1c, 0xa2, 0x38, 0x61, 0x82, 0x19, 0x57, 0xa5, 0x8a, 0x72, 0x15, 0x1d, 0xb4, 0xcd, 0x2a, 0x65,
+	0x94, 0xa5, 0xba, 0x3d, 0xfa, 0x95, 0x59, 0xcd, 0xa6, 0xc7, 0x78, 0xc8, 0xb8, 0xcd, 0x05, 0xde,
+	0xcd, 0x62, 0x5c, 0x22, 0xb0, 0xca, 0x32, 0xd7, 0xa6, 0x91, 0x62, 0x9c, 0xe0, 0x90, 0x4b, 0x47,
+	0x3d, 0x8b, 0x78, 0x97, 0x65, 0x67, 0x0f, 0x52, 0x5a, 0x95, 0xe9, 0x21, 0x4f, 0xcf, 0x42, 0x4e,
+	0x33, 0xa1, 0xb5, 0x03, 0x46, 0x97, 0xd3, 0xd7, 0x09, 0x8e, 0x63, 0xe2, 0x3f, 0x27, 0x7b, 0x84,
+	0x62, 0x41, 0x8c, 0x47, 0x50, 0x09, 0x39, 0xad, 0xe9, 0x6b, 0xfa, 0x9d, 0x8b, 0x9b, 0xeb, 0x48,
+	0x46, 0xc9, 0x6a, 0x48, 0x56, 0x43, 0x5d, 0x4e, 0xf3, 0x0b, 0x67, 0xe4, 0xdf, 0xbe, 0xf0, 0xe9,
+	0xa8, 0xa9, 0xfd, 0x3d, 0x6a, 0x6a, 0xad, 0x06, 0x98, 0x93, 0xb1, 0x0e, 0xe1, 0x31, 0x8b, 0x38,
+	0x69, 0xbd, 0x81, 0xaa, 0x52, 0x77, 0x22, 0x3f, 0xc7, 0x3e, 0x1e, 0xc7, 0xde, 0x3a, 0x05, 0xab,
+	0x6e, 0xca, 0x60, 0x0b, 0x1a, 0xd3, 0xa2, 0x0b, 0xb4, 0x07, 0x75, 0xa5, 0x77, 0x08, 0x0d, 0x22,
+	0x87, 0x14, 0xfc, 0xa7, 0xe3, 0xfc, 0x8d, 0x53, 0xf8, 0xa5, 0xc3, 0x72, 0x89, 0x75, 0xb8, 0x31,
+	0x13, 0x52, 0x34, 0xf9, 0xa2, 0xc3, 0xca, 0xe8, 0xaf, 0xc4, 0x3e, 0x16, 0xe4, 0x65, 0xfa, 0x1e,
+	0x8d, 0x2d, 0x58, 0xc6, 0xfb, 0xa2, 0xc7, 0x92, 0x40, 0xf4, 0xd3, 0x1a, 0xcb, 0x9d, 0xda, 0x8f,
+	0x6f, 0xf7, 0xab, 0xb2, 0xc9, 0x33, 0xdf, 0x4f, 0x08, 0xe7, 0xaf, 0x44, 0x12, 0x44, 0xd4, 0x51,
+	0x56, 0xe3, 0x09, 0x2c, 0x65, 0x4b, 0xa8, 0x9d, 0x4b, 0xbb, 0x5f, 0x47, 0x53, 0x86, 0x87, 0x32,
+	0x48, 0xe7, 0xfc, 0xf1, 0xaf, 0xa6, 0xe6, 0xc8, 0x83, 0xed, 0xcb, 0x1f, 0xff, 0x7c, 0xdd, 0x50,
+	0x51, 0xad, 0x3a, 0xac, 0x96, 0x5a, 0xe5, 0x8d, 0x37, 0xbf, 0x57, 0xa0, 0xd2, 0xe5, 0xd4, 0xd8,
+	0x85, 0x95, 0xf2, 0x60, 0x6e, 0x4f, 0x05, 0x4e, 0x4e, 0xc0, 0xb4, 0x17, 0x34, 0xe6, 0x50, 0xe3,
+	0x3d, 0x5c, 0x99, 0x1c, 0xca, 0xdd, 0x39, 0x29, 0xca, 0x6a, 0xb6, 0x17, 0xb6, 0x16, 0xc8, 0x0f,
+	0x3a, 0x5c, 0x9b, 0xb1, 0x10, 0x34, 0x27, 0xad, 0xe4, 0x37, 0xb7, 0xce, 0xe6, 0x2f, 0x2a, 0xb8,
+	0x70, 0xe9, 0xbf, 0x61, 0xdc, 0x9c, 0x95, 0x33, 0xee, 0x32, 0xef, 0x2d, 0xe2, 0xca, 0x19, 0x9d,
+	0x17, 0xc7, 0x03, 0x4b, 0x3f, 0x19, 0x58, 0xfa, 0xef, 0x81, 0xa5, 0x7f, 0x1e, 0x5a, 0xda, 0xc9,
+	0xd0, 0xd2, 0x7e, 0x0e, 0x2d, 0xed, 0xed, 0x03, 0x1a, 0x88, 0xde, 0xbe, 0x8b, 0x3c, 0x16, 0xda,
+	0x32, 0xd1, 0xeb, 0xe1, 0x20, 0xca, 0x1f, 0xec, 0x43, 0xf5, 0x11, 0x12, 0xfd, 0x98, 0x70, 0x77,
+	0x29, 0xfd, 0x9a, 0x3c, 0xfc, 0x17, 0x00, 0x00, 0xff, 0xff, 0xcd, 0x69, 0x5c, 0x18, 0x0f, 0x05,
 	0x00, 0x00,
 }
 
@@ -317,6 +427,8 @@ type MsgClient interface {
 	// WrappedBeginRedelegate defines a method for performing a redelegation of
 	// coins from a delegator and source validator to a destination validator.
 	WrappedBeginRedelegate(ctx context.Context, in *MsgWrappedBeginRedelegate, opts ...grpc.CallOption) (*MsgWrappedBeginRedelegateResponse, error)
+	// UpdateParams defines a method for updating epoching module parameters.
+	UpdateParams(ctx context.Context, in *MsgUpdateParams, opts ...grpc.CallOption) (*MsgUpdateParamsResponse, error)
 }
 
 type msgClient struct {
@@ -354,6 +466,15 @@ func (c *msgClient) WrappedBeginRedelegate(ctx context.Context, in *MsgWrappedBe
 	return out, nil
 }
 
+func (c *msgClient) UpdateParams(ctx context.Context, in *MsgUpdateParams, opts ...grpc.CallOption) (*MsgUpdateParamsResponse, error) {
+	out := new(MsgUpdateParamsResponse)
+	err := c.cc.Invoke(ctx, "/babylon.epoching.v1.Msg/UpdateParams", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	// WrappedDelegate defines a method for performing a delegation of coins from
@@ -365,6 +486,8 @@ type MsgServer interface {
 	// WrappedBeginRedelegate defines a method for performing a redelegation of
 	// coins from a delegator and source validator to a destination validator.
 	WrappedBeginRedelegate(context.Context, *MsgWrappedBeginRedelegate) (*MsgWrappedBeginRedelegateResponse, error)
+	// UpdateParams defines a method for updating epoching module parameters.
+	UpdateParams(context.Context, *MsgUpdateParams) (*MsgUpdateParamsResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -379,6 +502,9 @@ func (*UnimplementedMsgServer) WrappedUndelegate(ctx context.Context, req *MsgWr
 }
 func (*UnimplementedMsgServer) WrappedBeginRedelegate(ctx context.Context, req *MsgWrappedBeginRedelegate) (*MsgWrappedBeginRedelegateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method WrappedBeginRedelegate not implemented")
+}
+func (*UnimplementedMsgServer) UpdateParams(ctx context.Context, req *MsgUpdateParams) (*MsgUpdateParamsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateParams not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -439,6 +565,24 @@ func _Msg_WrappedBeginRedelegate_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_UpdateParams_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgUpdateParams)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).UpdateParams(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/babylon.epoching.v1.Msg/UpdateParams",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).UpdateParams(ctx, req.(*MsgUpdateParams))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "babylon.epoching.v1.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -454,6 +598,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "WrappedBeginRedelegate",
 			Handler:    _Msg_WrappedBeginRedelegate_Handler,
+		},
+		{
+			MethodName: "UpdateParams",
+			Handler:    _Msg_UpdateParams_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -634,6 +782,69 @@ func (m *MsgWrappedBeginRedelegateResponse) MarshalToSizedBuffer(dAtA []byte) (i
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgUpdateParams) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUpdateParams) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUpdateParams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Params.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
+	if len(m.Authority) > 0 {
+		i -= len(m.Authority)
+		copy(dAtA[i:], m.Authority)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Authority)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgUpdateParamsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUpdateParamsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUpdateParamsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -703,6 +914,30 @@ func (m *MsgWrappedBeginRedelegate) Size() (n int) {
 }
 
 func (m *MsgWrappedBeginRedelegateResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgUpdateParams) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Authority)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.Params.Size()
+	n += 1 + l + sovTx(uint64(l))
+	return n
+}
+
+func (m *MsgUpdateParamsResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1102,6 +1337,171 @@ func (m *MsgWrappedBeginRedelegateResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgWrappedBeginRedelegateResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUpdateParams) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUpdateParams: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUpdateParams: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Authority", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Authority = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Params", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUpdateParamsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUpdateParamsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUpdateParamsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
Migrates btcheckpoint module and epoching module to new way of handling params i.e storing them themselves and giving authority to gov module to execute UpdateParamsMsg on their behalf.

We sadly can't yet remove params module from app.go totally as IBC modules did not migrate yet