### PR TITLE
chore: Temporarily disable e2e tests until Docker issues are resolved

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,10 @@ jobs:
             sudo -E env "PATH=$PATH" make localnet-test-integration
       # TODO: If CI tests will take to long consider having only this e2e test
       # instead of separate integration tests and e2e tests.
-      - run:
-          name: Run e2e tests
-          command: |
-             make test-e2e
+      # - run:
+      #     name: Run e2e tests
+      #     command: |
+      #        make test-e2e
   lint:
     machine:
       image: ubuntu-2204:2022.10.1


### PR DESCRIPTION
This PR disables e2e tests until #345 gets merged. When #340 got merged its context had e2e tests commented out and therefore the build failed. Currently the e2e tests don't work out of the box with the new Docker image so some modifications need to be made. Until then let's disable e2e tests.