### PR TITLE
fix: fix query height in `ProveEpochSealed`

### DIFF
--- a/x/zoneconcierge/keeper/query_kvstore.go
+++ b/x/zoneconcierge/keeper/query_kvstore.go
@@ -28,7 +28,7 @@ func (k Keeper) QueryStore(moduleStoreKey string, key []byte, queryHeight int64)
 	resp := k.storeQuerier.Query(abci.RequestQuery{
 		Path:   path,
 		Data:   key,
-		Height: queryHeight,
+		Height: queryHeight - 1, // NOTE: the inclusion proof corresponds to the NEXT header
 		Prove:  true,
 	})
 	if resp.Code != 0 {

--- a/x/zoneconcierge/keeper/query_kvstore_test.go
+++ b/x/zoneconcierge/keeper/query_kvstore_test.go
@@ -25,10 +25,11 @@ func FuzzQueryStore(f *testing.F) {
 
 		ctx := babylonChain.GetContext()
 
-		// NOTE: the queryHeight has to be the previous block because
-		// NextBlock() only invokes BeginBlock(), but not EndBlock(), for the new block
 		epochQueryKey := append(epochingtypes.EpochInfoKey, sdk.Uint64ToBigEndian(1)...)
-		key, value, proof, err := zcKeeper.QueryStore(epochingtypes.StoreKey, epochQueryKey, ctx.BlockHeight()-1)
+		// NOTE: QueryStore will use ctx.BlockHeight() - 1 as the height for ABCI query
+		// This is because the ABCI query will return the inclusion proof corresponding
+		// to the NEXT block rather than the given block.
+		key, value, proof, err := zcKeeper.QueryStore(epochingtypes.StoreKey, epochQueryKey, ctx.BlockHeight())
 
 		require.NoError(t, err)
 		require.NotNil(t, proof)


### PR DESCRIPTION
This PR fixes a bug in `ProveEpochSealed`. 

When executing an ABCI query `abci.RequestQuery`, one needs to feed a `height`, such that the node will reply an inclusion proof of the queried KV pair against the header at `height+1`. 

We use this ABCI query for generating proofs of inclusion for the validator set and the metadata of epoch `i` against the sealer header, i.e., the 2nd header of epoch `i+1`. In order to allow verifier to verify the proofs against the sealer header, the ABCI query should be given height `queryHeight-1` rather than `queryHeight`, where `queryHeight` will be the sealer header's height. This PR fixes the bug where we use `queryHeight` rather than `queryHeight - 1`.

The corresponding unit test is also fixed.
