### PR TITLE
chore: Enable building docker image with unpushed changes

### DIFF
--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -18,11 +18,13 @@ RUN apk add --update --no-cache make git bash gcc linux-headers eudev-dev ncurse
 RUN apk add --no-cache musl-dev
 
 # Build
-WORKDIR /go/src/github.com/babylonchain
-RUN git clone https://github.com/babylonchain/babylon.git
 WORKDIR /go/src/github.com/babylonchain/babylon
-RUN git fetch
-RUN git checkout ${VERSION}
+# First cache dependencies
+COPY go.mod go.sum /go/src/github.com/babylonchain/babylon/
+RUN go mod download
+# Then copy everything else
+COPY ./ /go/src/github.com/babylonchain/babylon/
+RUN git checkout -f ${VERSION}
 
 # Cosmwasm - Download correct libwasmvm version
 RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \


### PR DESCRIPTION
The current Docker image clones the Babylon repository from GitHub, then it proceeds to checkout to the version specified, and finally builds the Babylon executable. This has the following issues:
1. In order for the Docker image to be built based on the local changes, those changes need to be pushed and a `--build-arg` specifying the location in which those changes are pushed needs to be specified. This is counter-intuitive, as someone running on their local machine should be able to build the local changes.
2. In the case of a fork of the repository, the Docker image still gets built based on changes here.

Also, currently the CI process that builds the Docker image doesn't work properly as it doesn't specify a `--build-arg` denoting the branch it is building against. This means that every time a Docker image for the default branch (i.e. `dev` is getting built).

However, the current Docker image also had the positive that it could be built as a standalone in any location (which I suppose is why @danbryan built it like that). While this would do for an external actor it does not help us at all and adds issues. For this, I decided to change it to get the local changes instead of cloning etc. 