### PR TITLE
chore: Use more descriptive error message for using wrapped transactions

### DIFF
--- a/x/epoching/types/errors.go
+++ b/x/epoching/types/errors.go
@@ -6,12 +6,13 @@ import (
 	errorsmod "cosmossdk.io/errors"
 )
 
-// x/epoching module sentinel errors
 var (
-	ErrUnwrappedMsgType          = errorsmod.Register(ModuleName, 1, "invalid message type in {MsgCreateValidator, MsgDelegate, MsgUndelegate, MsgBeginRedelegate} messages. use wrapped versions instead")
+	ErrUnwrappedMsgType = errorsmod.Register(ModuleName, 1, `
+										invalid message type in {MsgCreateValidator, MsgDelegate, MsgUndelegate, MsgBeginRedelegate}
+										messages. For creating a validator use the wrapped version under 'tx checkpointing create-validator'
+										and for the other messages use the wrapped versions under 'tx epoching {delegate,undelegate,redelegate}'`)
 	ErrInvalidQueuedMessageType  = errorsmod.Register(ModuleName, 2, "invalid message type of a QueuedMessage")
 	ErrUnknownEpochNumber        = errorsmod.Register(ModuleName, 3, "the epoch number is not known in DB")
-	ErrUnknownQueueLen           = errorsmod.Register(ModuleName, 4, "the msg queue length is not known in DB")
 	ErrUnknownSlashedVotingPower = errorsmod.Register(ModuleName, 5, "the slashed voting power is not known in DB. Maybe the epoch has been checkpointed?")
 	ErrUnknownValidator          = errorsmod.Register(ModuleName, 6, "the validator is not known in the validator set.")
 	ErrUnknownTotalVotingPower   = errorsmod.Register(ModuleName, 7, "the total voting power is not known in DB.")


### PR DESCRIPTION
The `use wrapped versions instead` message is a bit cryptic and has led to many people asking us what they should do. This PR adds some more details on what one can do to resolve the issue.