### PR TITLE
fix: Make testnet command produce addresses bound to the host IP

### DIFF
--- a/cmd/babylond/cmd/testnet.go
+++ b/cmd/babylond/cmd/testnet.go
@@ -156,6 +156,7 @@ func InitTestnet(
 	babylonConfig := DefaultBabylonConfig()
 	babylonConfig.MinGasPrices = minGasPrices
 	babylonConfig.API.Enable = true
+	babylonConfig.API.Address = "tcp://0.0.0.0:1317"
 	babylonConfig.Telemetry.Enabled = true
 	babylonConfig.Telemetry.PrometheusRetentionTime = 60
 	babylonConfig.Telemetry.EnableHostnameLabel = false
@@ -166,6 +167,7 @@ func InitTestnet(
 	// Explorer related config. Allow CORS connections.
 	babylonConfig.API.EnableUnsafeCORS = true
 	babylonConfig.GRPC.Address = "0.0.0.0:9090"
+	babylonConfig.GRPCWeb.Address = "0.0.0.0:9091"
 
 	var (
 		genAccounts []authtypes.GenesisAccount


### PR DESCRIPTION
The `testnet` command no longer produced gRPC addresses with the `0.0.0.0` host but instead `localhost`. Given that the `testnet` command leads to the generation of config files for the devnet it's more helpful if the IP is the host's IP (similar to what we do for P2P and RPC addresses).