### PR TITLE
Fix bug in submission btc info

### DIFF
--- a/x/btccheckpoint/keeper/keeper_test.go
+++ b/x/btccheckpoint/keeper/keeper_test.go
@@ -1,0 +1,64 @@
+package keeper_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/babylonchain/babylon/testutil/datagen"
+	"github.com/babylonchain/babylon/x/btccheckpoint/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeeper_GetSubmissionBtcInfo(t *testing.T) {
+	type TxKeyDesc struct {
+		TxIdx uint32
+		Depth uint64
+	}
+
+	type args struct {
+		Key1 TxKeyDesc
+		Key2 TxKeyDesc
+	}
+
+	tests := []struct {
+		name                       string
+		args                       args
+		expectedYoungestBlockDepth uint64
+		expectedTxIndex            uint32
+		expectedOldestBlockDepth   uint64
+	}{
+		{"First header older. TxIndex larger in older header.", args{TxKeyDesc{TxIdx: 5, Depth: 10}, TxKeyDesc{TxIdx: 1, Depth: 0}}, 0, 1, 10},
+		{"First header older. TxIndex larger in younger header.", args{TxKeyDesc{TxIdx: 1, Depth: 10}, TxKeyDesc{TxIdx: 5, Depth: 0}}, 0, 5, 10},
+		{"Second header older. TxIndex larger in older header.", args{TxKeyDesc{TxIdx: 1, Depth: 0}, TxKeyDesc{TxIdx: 5, Depth: 10}}, 0, 1, 10},
+		{"Second header older. TxIndex larger in younger header.", args{TxKeyDesc{TxIdx: 5, Depth: 0}, TxKeyDesc{TxIdx: 1, Depth: 10}}, 0, 5, 10},
+		{"Same block. TxIndex larger in first transaction key.", args{TxKeyDesc{TxIdx: 5, Depth: 10}, TxKeyDesc{TxIdx: 1, Depth: 10}}, 10, 1, 10},
+		{"Same block. TxIndex larger in second transaction key.", args{TxKeyDesc{TxIdx: 1, Depth: 10}, TxKeyDesc{TxIdx: 5, Depth: 10}}, 10, 1, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := rand.New(rand.NewSource(time.Now().Unix()))
+
+			k := InitTestKeepers(t)
+
+			hash1 := datagen.GenRandomBTCHeaderPrevBlock(r)
+			hash2 := datagen.GenRandomBTCHeaderPrevBlock(r)
+
+			sk := types.SubmissionKey{Key: []*types.TransactionKey{
+				{Index: tt.args.Key1.TxIdx, Hash: hash1},
+				{Index: tt.args.Key2.TxIdx, Hash: hash2},
+			}}
+
+			k.BTCLightClient.SetDepth(hash1, int64(tt.args.Key1.Depth))
+			k.BTCLightClient.SetDepth(hash2, int64(tt.args.Key2.Depth))
+
+			info, err := k.BTCCheckpoint.GetSubmissionBtcInfo(k.SdkCtx, sk)
+
+			require.NoError(t, err)
+
+			require.Equal(t, info.YoungestBlockDepth, tt.expectedYoungestBlockDepth, tt.name)
+			require.Equal(t, info.LatestTxIndex, tt.expectedTxIndex, tt.name)
+			require.Equal(t, info.OldestBlockDepth, tt.expectedOldestBlockDepth, tt.name)
+		})
+	}
+}

--- a/x/btccheckpoint/keeper/keeper_test.go
+++ b/x/btccheckpoint/keeper/keeper_test.go
@@ -64,15 +64,20 @@ func TestKeeper_GetSubmissionBtcInfo(t *testing.T) {
 }
 
 func FuzzGetSubmissionBtcInfo(f *testing.F) {
-	f.Add(int64(1), uint32(0), uint32(1), uint32(1), uint32(1))
+	datagen.AddRandomSeedsToFuzzer(f, 100)
 
-	f.Fuzz(func(t *testing.T, seed int64, depth1 uint32, txidx1 uint32, depth2 uint32, txidx2 uint32) {
+	f.Fuzz(func(t *testing.T, seed int64) {
 		r := rand.New(rand.NewSource(seed))
+
+		depth1 := r.Uint32()
+		txidx1 := r.Uint32()
+		depth2 := r.Uint32()
+		txidx2 := r.Uint32()
 
 		if txidx1 == txidx2 {
 			// transaction indexes must be different to cover the case where transactions are
-			// in the same block (then they cannot have same indexes)
-			t.Skip()
+			// in the same block.
+			txidx1 = txidx1 + 1
 		}
 
 		k := InitTestKeepers(t)


### PR DESCRIPTION
While looking for ways of optimizing `BtcCheckpointInfo` endpoint I encountered bug in getting submission btc info, which could lead to misindexing of transaction.

This pr fixes the bug and provides set of tests triggering given problem.

In general I think we need ADR for describing how we decide which submission is the best. It can be done when we will start working on rewards.