### PR TITLE
chore: circleci: Use image with go 1.20.3 installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,26 +4,30 @@ version: 2.1
 
 orbs:
   aws-ecr: circleci/aws-ecr@8.2.1
+  go: circleci/go@1.7.3
+
 
 jobs:
   build-test:
-    docker:
-      - image: cimg/go:1.20.3
+    machine:
+      image: ubuntu-2204:2022.10.1
+      resource_class: large
     steps:
+      - go/install:
+          version: 1.20
       - checkout
       - run:
           name: Print Go environment
           command: "go env"
-      - restore_cache: # restores saved cache if no changes are detected since last run
-          keys:
-            - go-mod-v6-{{ checksum "go.sum" }}
+      - go/load-cache:
+          key: go-mod-v6-{{ checksum "go.sum" }}
+      - go/mod-download
+      - go/save-cache:
+          key: go-mod-v6-{{ checksum "go.sum" }}
+          path: "/home/circleci/.go_workspace/pkg/mod"
       - run:
           name: Build babylond
           command: make build
-      - save_cache:
-          key: go-mod-v6-{{ checksum "go.sum" }}
-          paths:
-            - "/home/circleci/.go_workspace/pkg/mod"
       - run:
           name: Run tests
           command: |
@@ -39,9 +43,12 @@ jobs:
           command: |
              make test-e2e
   lint:
-    docker:
-      - image: cimg/go:1.20.3
+    machine:
+      image: ubuntu-2204:2022.10.1
+      resource_class: large
     steps:
+      - go/install:
+          version: 1.20
       - checkout
       - run:
           name: Lint proto files
@@ -49,7 +56,7 @@ jobs:
       - run:
           name: Lint
           command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2
             ./bin/golangci-lint run
 
   build_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,10 @@ version: 2.1
 orbs:
   aws-ecr: circleci/aws-ecr@8.2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
   build-test:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    machine:
-      image: ubuntu-2204:2022.10.1
-      resource_class: large
+    docker:
+      - image: cimg/go:1.20.3
     steps:
       - checkout
       - run:
@@ -44,9 +39,8 @@ jobs:
           command: |
              make test-e2e
   lint:
-    machine:
-      image: ubuntu-2204:2022.10.1
-      resource_class: medium
+    docker:
+      - image: cimg/go:1.20.3
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ jobs:
   build-test:
     machine:
       image: ubuntu-2204:2022.10.1
-      resource_class: large
+    resource_class: large
     steps:
       - go/install:
-          version: 1.20
+          version: "1.20"
       - checkout
       - run:
           name: Print Go environment
@@ -45,10 +45,10 @@ jobs:
   lint:
     machine:
       image: ubuntu-2204:2022.10.1
-      resource_class: large
+    resource_class: large
     steps:
       - go/install:
-          version: 1.20
+          version: "1.20"
       - checkout
       - run:
           name: Lint proto files
@@ -62,7 +62,7 @@ jobs:
   build_docker:
     machine:
       image: ubuntu-2204:2022.10.1
-      resource_class: large
+    resource_class: large
     steps:
       - checkout
       - aws-ecr/build-image:

--- a/btctxformatter/formatter_test.go
+++ b/btctxformatter/formatter_test.go
@@ -9,7 +9,7 @@ import (
 
 func randNBytes(n int) []byte {
 	bytes := make([]byte, n)
-	cprand.Read(bytes)
+	cprand.Read(bytes) //nolint:errcheck // This is a test.
 	return bytes
 }
 

--- a/btctxformatter/formatter_test.go
+++ b/btctxformatter/formatter_test.go
@@ -2,13 +2,14 @@ package btctxformatter
 
 import (
 	"bytes"
+	cprand "crypto/rand"
 	"math/rand"
 	"testing"
 )
 
 func randNBytes(n int) []byte {
 	bytes := make([]byte, n)
-	rand.Read(bytes)
+	cprand.Read(bytes)
 	return bytes
 }
 


### PR DESCRIPTION
On the [rpc-client repository](https://github.com/babylonchain/rpc-client/pull/33) I encountered issues due to the Ubuntu image being used having Go 1.18 installed instead of the 1.20 version that we use. These were fixed when I used an image with the appropriate version installed, so figured to do the same here.

Given that we use Docker for some of the build steps this fails. Will investigate further.