### PR TITLE
Bump wasmd to rc2

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -635,6 +635,7 @@ func NewBabylonApp(
 		app.StakingKeeper,
 		distrkeeper.NewQuerier(app.DistrKeeper),
 		app.IBCKeeper.ChannelKeeper,
+		app.IBCKeeper.ChannelKeeper,
 		&app.IBCKeeper.PortKeeper,
 		scopedWasmKeeper,
 		app.TransferKeeper,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ go 1.20
 module github.com/babylonchain/babylon
 
 require (
-	github.com/CosmWasm/wasmd v0.40.0-rc.1
+	github.com/CosmWasm/wasmd v0.40.0-rc.2
 	github.com/btcsuite/btcd v0.23.4
 	github.com/cometbft/cometbft v0.37.1
 	github.com/cometbft/cometbft-db v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmd v0.40.0-rc.1 h1:prIM2vP1jNh0zgs9seua5BgKdayBgp3FiHtwxFcZSGs=
-github.com/CosmWasm/wasmd v0.40.0-rc.1/go.mod h1:uacdue6EGn9JA1TqBNHB3iCe4PCIChuFT23AzIl2VME=
+github.com/CosmWasm/wasmd v0.40.0-rc.2 h1:UgOr8CaitJ8C8Y80viKLT6mL2Xh4yg2X4szCdTVr6xg=
+github.com/CosmWasm/wasmd v0.40.0-rc.2/go.mod h1:l2s42GHKp1CHcR0N6J8P6p02b5RMWFCpcmRjyKMtqqg=
 github.com/CosmWasm/wasmvm v1.2.3 h1:OKYlobwmVGbl0eSn0mXoAAjE5hIuXnQCLPjbNd91sVY=
 github.com/CosmWasm/wasmvm v1.2.3/go.mod h1:vW/E3h8j9xBQs9bCoijDuawKo9kCtxOaS8N8J7KFtkc=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
Small pr to bump wasmd to rc2 versions.

One thing I noticed, both ibc-go and wasmd uses `FeeKeeper` as their `ICS4Wrapper` implementation in their test-apps (https://github.com/cosmos/ibc-go/blob/main/testing/simapp/app.go#LL413C6-L413C18), where we only use `ChannelKeeper`. 

From what I understand `FeeKeeper` is actually enables https://github.com/cosmos/ibc/tree/main/spec/app/ics-029-fee-payment, which is scheme used to pay rewards to relayers. It seems like a good idea to enable it also on Babylon . What do you think @SebastianElvis  ? 