### PR TITLE
Use fee module

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -122,6 +122,9 @@ import (
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
 	extendedkeeper "github.com/babylonchain/babylon/x/zoneconcierge/extended-client-keeper"
+	ibcfee "github.com/cosmos/ibc-go/v7/modules/apps/29-fee"
+	ibcfeekeeper "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/keeper"
+	ibcfeetypes "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
@@ -204,6 +207,7 @@ var (
 		ibctm.AppModuleBasic{},
 		transfer.AppModuleBasic{},
 		zoneconcierge.AppModuleBasic{},
+		ibcfee.AppModuleBasic{},
 	)
 
 	// module account permissions
@@ -215,6 +219,7 @@ var (
 		stakingtypes.NotBondedPoolName: {authtypes.Burner, authtypes.Staking},
 		govtypes.ModuleName:            {authtypes.Burner},
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
+		ibcfeetypes.ModuleName:         nil,
 		// TODO: decide ZonConcierge's permissions here
 		zctypes.ModuleName: {authtypes.Minter, authtypes.Burner},
 	}
@@ -309,6 +314,7 @@ type BabylonApp struct {
 
 	// IBC-related modules
 	IBCKeeper           *ibckeeper.Keeper        // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	IBCFeeKeeper        ibcfeekeeper.Keeper      // for relayer incentivization - https://github.com/cosmos/ibc/tree/main/spec/app/ics-029-fee-payment
 	TransferKeeper      ibctransferkeeper.Keeper // for cross-chain fungible token transfers
 	ZoneConciergeKeeper zckeeper.Keeper          // for cross-chain fungible token transfers
 
@@ -378,6 +384,7 @@ func NewBabylonApp(
 		// IBC-related modules
 		ibcexported.StoreKey,
 		ibctransfertypes.StoreKey,
+		ibcfeetypes.StoreKey,
 		zctypes.StoreKey,
 		wasm.StoreKey,
 	)
@@ -512,11 +519,19 @@ func NewBabylonApp(
 	if !ok {
 		panic(errorsmod.Wrap(sdkerrors.ErrUnknownRequest, "multistore doesn't support queries"))
 	}
+
+	app.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
+		appCodec, keys[ibcfeetypes.StoreKey],
+		app.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
+		app.IBCKeeper.ChannelKeeper,
+		&app.IBCKeeper.PortKeeper, app.AccountKeeper, app.BankKeeper,
+	)
+
 	zcKeeper := zckeeper.NewKeeper(
 		appCodec,
 		keys[zctypes.StoreKey],
 		keys[zctypes.MemStoreKey],
-		app.IBCKeeper.ChannelKeeper,
+		app.IBCFeeKeeper,
 		app.IBCKeeper.ChannelKeeper,
 		&app.IBCKeeper.PortKeeper,
 		app.AccountKeeper,
@@ -542,20 +557,9 @@ func NewBabylonApp(
 	// Create Transfer Keepers
 	app.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec, keys[ibctransfertypes.StoreKey], app.GetSubspace(ibctransfertypes.ModuleName),
-		app.IBCKeeper.ChannelKeeper, app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
+		app.IBCFeeKeeper, app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
 		app.AccountKeeper, app.BankKeeper, scopedTransferKeeper,
 	)
-	transferModule := transfer.NewAppModule(app.TransferKeeper)
-
-	// Create static IBC router, add ibc-tranfer module route, then set and seal it
-	ibcRouter := porttypes.NewRouter()
-	transferIBCModule := transfer.NewIBCModule(app.TransferKeeper)
-	ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferIBCModule)
-	zcIBCModule := zoneconcierge.NewIBCModule(app.ZoneConciergeKeeper)
-	ibcRouter.AddRoute(zctypes.ModuleName, zcIBCModule)
-	// Setting Router will finalize all routes by sealing router
-	// No more routes can be added
-	app.IBCKeeper.SetRouter(ibcRouter)
 
 	btclightclientKeeper := *btclightclientkeeper.NewKeeper(
 		appCodec,
@@ -634,7 +638,7 @@ func NewBabylonApp(
 		app.BankKeeper,
 		app.StakingKeeper,
 		distrkeeper.NewQuerier(app.DistrKeeper),
-		app.IBCKeeper.ChannelKeeper,
+		app.IBCFeeKeeper,
 		app.IBCKeeper.ChannelKeeper,
 		&app.IBCKeeper.PortKeeper,
 		scopedWasmKeeper,
@@ -647,6 +651,29 @@ func NewBabylonApp(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		wasmOpts...,
 	)
+
+	// Create all supported IBC routes
+	var transferStack porttypes.IBCModule
+	transferStack = transfer.NewIBCModule(app.TransferKeeper)
+	transferStack = ibcfee.NewIBCMiddleware(transferStack, app.IBCFeeKeeper)
+
+	var zoneConciergeStack porttypes.IBCModule
+	zoneConciergeStack = zoneconcierge.NewIBCModule(app.ZoneConciergeKeeper)
+	zoneConciergeStack = ibcfee.NewIBCMiddleware(zoneConciergeStack, app.IBCFeeKeeper)
+
+	var wasmStack porttypes.IBCModule
+	wasmStack = wasm.NewIBCHandler(app.WasmKeeper, app.IBCKeeper.ChannelKeeper, app.IBCFeeKeeper)
+	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, app.IBCFeeKeeper)
+
+	// Create static IBC router, add ibc-tranfer module route, then set and seal it
+	ibcRouter := porttypes.NewRouter().
+		AddRoute(ibctransfertypes.ModuleName, transferStack).
+		AddRoute(zctypes.ModuleName, zoneConciergeStack).
+		AddRoute(wasm.ModuleName, wasmStack)
+
+	// Setting Router will finalize all routes by sealing router
+	// No more routes can be added
+	app.IBCKeeper.SetRouter(ibcRouter)
 
 	// The gov proposal types can be individually enabled
 	if len(wasmEnabledProposals) != 0 {
@@ -694,8 +721,9 @@ func NewBabylonApp(
 		monitor.NewAppModule(appCodec, app.MonitorKeeper, app.AccountKeeper, app.BankKeeper),
 		// IBC-related modules
 		ibc.NewAppModule(app.IBCKeeper),
-		transferModule,
+		transfer.NewAppModule(app.TransferKeeper),
 		zoneconcierge.NewAppModule(appCodec, app.ZoneConciergeKeeper, app.AccountKeeper, app.BankKeeper),
+		ibcfee.NewAppModule(app.IBCFeeKeeper),
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -719,6 +747,7 @@ func NewBabylonApp(
 		ibcexported.ModuleName,
 		ibctransfertypes.ModuleName,
 		zctypes.ModuleName,
+		ibcfeetypes.ModuleName,
 		wasm.ModuleName,
 	)
 	// TODO: there will be an architecture design on whether to modify slashing/evidence, specifically
@@ -743,6 +772,7 @@ func NewBabylonApp(
 		ibcexported.ModuleName,
 		ibctransfertypes.ModuleName,
 		zctypes.ModuleName,
+		ibcfeetypes.ModuleName,
 		wasm.ModuleName,
 	)
 	// Babylon does not want EndBlock processing in staking
@@ -769,6 +799,7 @@ func NewBabylonApp(
 		ibcexported.ModuleName,
 		ibctransfertypes.ModuleName,
 		zctypes.ModuleName,
+		ibcfeetypes.ModuleName,
 		wasm.ModuleName,
 	)
 


### PR DESCRIPTION
Wires up and uses ibc fee module. Module is implementation of https://github.com/cosmos/ibc/tree/main/spec/app/ics-029-fee-payment which spec of relayer incentivization.

To wire up fee module there are two changes necessary:
1. Pass FeeKeeper as ics4wrapper to other ibc modules (transferKeeper, zoneconciergeKeeeper, wasmKeeper)
2. Create `ibcfee.NewIBCMiddleware` and route for each ibc module used

Imo it makes sense for Babylon to enable this module, as we will be using a lot of IBC to distribute checkpoints to other cosmos zones.