### PR TITLE
dockerfile: opt out version when building

### DIFF
--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -4,8 +4,8 @@ FROM golang:1.20-alpine AS build-env
 
 # TARGETPLATFORM should be one of linux/amd64 or linux/arm64.
 ARG TARGETPLATFORM="linux/amd64"
-# Version to build. Default is the Git HEAD.
-ARG VERSION="HEAD"
+# Version to build. Default is empty
+ARG VERSION
 
 # Use muslc for static libs
 ARG BUILD_TAGS="muslc"
@@ -24,7 +24,10 @@ COPY go.mod go.sum /go/src/github.com/babylonchain/babylon/
 RUN go mod download
 # Then copy everything else
 COPY ./ /go/src/github.com/babylonchain/babylon/
-RUN git checkout -f ${VERSION}
+# If version is set, then checkout this version
+RUN if [ -n "${VERSION}" ]; then \
+        git checkout -f ${VERSION}; \
+    fi
 
 # Cosmwasm - Download correct libwasmvm version
 RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \


### PR DESCRIPTION
The current Dockerfile gets the last commit of the current branch to build by default. Sometimes we want to test uncommitted changes locally. This PR proposes to opt out the version in the sense that 
- by default, Dockerfile builds with the latest code (even uncommitted), 
- one can specify its preferred version by setting an nonempty $VERSION