### PR TITLE
fix: marshaling of MsgWrappedCreateValidator and flaky test

### DIFF
--- a/x/checkpointing/keeper/msg_server_test.go
+++ b/x/checkpointing/keeper/msg_server_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	codec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+
 	"github.com/babylonchain/babylon/app"
 	appparams "github.com/babylonchain/babylon/app/params"
 	"github.com/babylonchain/babylon/crypto/bls12381"
@@ -14,11 +20,6 @@ import (
 	"github.com/babylonchain/babylon/x/checkpointing/types"
 	"github.com/babylonchain/babylon/x/epoching/testepoching"
 	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
-	"github.com/cometbft/cometbft/crypto/ed25519"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/stretchr/testify/require"
 )
 
 // FuzzWrappedCreateValidator_InsufficientTokens tests adding new validators with zero voting power
@@ -420,7 +421,7 @@ func buildMsgWrappedCreateValidatorWithAmount(addr sdk.AccAddress, bondTokens ma
 	description := stakingtypes.NewDescription("foo_moniker", "", "", "", "")
 	commission := stakingtypes.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
 
-	pk, err := cryptocodec.FromTmPubKeyInterface(tmValPrivkey.PubKey())
+	pk, err := codec.FromTmPubKeyInterface(tmValPrivkey.PubKey())
 	if err != nil {
 		return nil, err
 	}

--- a/x/checkpointing/types/msgs.go
+++ b/x/checkpointing/types/msgs.go
@@ -100,6 +100,7 @@ func (m *MsgWrappedCreateValidator) GetSigners() []sdk.AccAddress {
 }
 
 // UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
+// Needed since msg.MsgCreateValidator.Pubkey is in type Any
 func (msg MsgWrappedCreateValidator) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 	return msg.MsgCreateValidator.UnpackInterfaces(unpacker)
 }

--- a/x/checkpointing/types/msgs.go
+++ b/x/checkpointing/types/msgs.go
@@ -3,12 +3,12 @@ package types
 import (
 	"errors"
 
+	"github.com/babylonchain/babylon/crypto/bls12381"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	ed255192 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
-	"github.com/babylonchain/babylon/crypto/bls12381"
 )
 
 var (
@@ -97,4 +97,9 @@ func (m *MsgWrappedCreateValidator) ValidateBasic() error {
 
 func (m *MsgWrappedCreateValidator) GetSigners() []sdk.AccAddress {
 	return m.MsgCreateValidator.GetSigners()
+}
+
+// UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
+func (msg MsgWrappedCreateValidator) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	return msg.MsgCreateValidator.UnpackInterfaces(unpacker)
 }

--- a/x/checkpointing/types/msgs_test.go
+++ b/x/checkpointing/types/msgs_test.go
@@ -29,22 +29,27 @@ func TestMsgDecode(t *testing.T) {
 	stakingtypes.RegisterInterfaces(registry)
 	cdc := codec.NewProtoCodec(registry)
 
+	// build MsgWrappedCreateValidator
 	msg, err := buildMsgWrappedCreateValidatorWithAmount(
 		sdk.AccAddress(valAddr1),
 		sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction),
 	)
 	require.NoError(t, err)
 
+	// marshal
 	msgBytes, err := cdc.MarshalInterface(msg)
 	require.NoError(t, err)
 
+	// unmarshal to sdk.Msg interface
 	var msg2 sdk.Msg
 	err = cdc.UnmarshalInterface(msgBytes, &msg2)
 	require.NoError(t, err)
 
+	// type assertion
 	msgWithType, ok := msg2.(*types.MsgWrappedCreateValidator)
 	require.True(t, ok)
 
+	// ensure msgWithType.MsgCreateValidator.Pubkey with type Any is unmarshaled successfully
 	require.NotNil(t, msgWithType.MsgCreateValidator.Pubkey.GetCachedValue())
 }
 

--- a/x/checkpointing/types/msgs_test.go
+++ b/x/checkpointing/types/msgs_test.go
@@ -1,0 +1,76 @@
+package types_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	appparams "github.com/babylonchain/babylon/app/params"
+	"github.com/babylonchain/babylon/crypto/bls12381"
+	"github.com/babylonchain/babylon/privval"
+	"github.com/babylonchain/babylon/x/checkpointing/types"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	pk1      = ed25519.GenPrivKey().PubKey()
+	valAddr1 = sdk.ValAddress(pk1.Address())
+)
+
+func TestMsgDecode(t *testing.T) {
+	registry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(registry)
+	types.RegisterInterfaces(registry)
+	stakingtypes.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+
+	msg, err := buildMsgWrappedCreateValidatorWithAmount(
+		sdk.AccAddress(valAddr1),
+		sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction),
+	)
+	require.NoError(t, err)
+
+	msgBytes, err := cdc.MarshalInterface(msg)
+	require.NoError(t, err)
+
+	var msg2 sdk.Msg
+	err = cdc.UnmarshalInterface(msgBytes, &msg2)
+	require.NoError(t, err)
+
+	msgWithType, ok := msg2.(*types.MsgWrappedCreateValidator)
+	require.True(t, ok)
+
+	require.NotNil(t, msgWithType.MsgCreateValidator.Pubkey.GetCachedValue())
+}
+
+func buildMsgWrappedCreateValidatorWithAmount(addr sdk.AccAddress, bondTokens math.Int) (*types.MsgWrappedCreateValidator, error) {
+	tmValPrivkey := ed25519.GenPrivKey()
+	bondCoin := sdk.NewCoin(appparams.DefaultBondDenom, bondTokens)
+	description := stakingtypes.NewDescription("foo_moniker", "", "", "", "")
+	commission := stakingtypes.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+
+	pk, err := cryptocodec.FromTmPubKeyInterface(tmValPrivkey.PubKey())
+	if err != nil {
+		return nil, err
+	}
+
+	createValidatorMsg, err := stakingtypes.NewMsgCreateValidator(
+		sdk.ValAddress(addr), pk, bondCoin, description, commission, sdk.OneInt(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	blsPrivKey := bls12381.GenPrivKey()
+	pop, err := privval.BuildPoP(tmValPrivkey, blsPrivKey)
+	if err != nil {
+		return nil, err
+	}
+	blsPubKey := blsPrivKey.PubKey()
+
+	return types.NewMsgWrappedCreateValidator(createValidatorMsg, &blsPubKey, pop)
+}

--- a/x/zoneconcierge/keeper/grpc_query_test.go
+++ b/x/zoneconcierge/keeper/grpc_query_test.go
@@ -417,7 +417,7 @@ func FuzzFinalizedChainInfo(f *testing.F) {
 		)
 		numChains := datagen.RandomInt(r, 100) + 1
 		for i := uint64(0); i < numChains; i++ {
-			czChainIDLen := datagen.RandomInt(r, 50) + 1
+			czChainIDLen := datagen.RandomInt(r, 50) + 100
 			czChainID := string(datagen.GenRandomByteArray(r, czChainIDLen))
 
 			// invoke the hook a random number of times to simulate a random number of blocks


### PR DESCRIPTION
This PR fixes two bugs:

1. Marshaling of `MsgWrappedCreateValidator`: The `Pubkey` inside `MsgWrappedCreateValidator.MsgCreateValidator` is in type `Any`, thus requires extra handling for marshaling/unmarshaling. Specifically, `MsgWrappedCreateValidator` needs to implement `UnpackInterfacesMessage` interface. This PR also adds a test ensuring the decoding is correct. This PR is largely based on https://github.com/babylonchain/babylon/pull/215/files. 
2. Flaky test: `FuzzFinalizedChainInfo` is flaky because the `chainIDs` sometimes contains duplicated value. Worked around this by enforcing a lower bound on random chain ID length.