### PR TITLE
README: updating discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Bringing Bitcoin security to Cosmos and beyond.
 [![Website](https://badgen.net/badge/icon/website?label=)](https://babylonchain.io)
 [![Whitepaper](https://badgen.net/badge/icon/whitepaper?label=)](https://arxiv.org/abs/2207.08392)
 [![Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label)](https://twitter.com/babylon_chain)
-[![Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.gg/babylonchain)
+[![Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.com/invite/babylonglobal)
 [![Medium](https://badgen.net/badge/icon/medium?icon=medium&label)](https://medium.com/babylonchain-io)
 
 ## Build and install


### PR DESCRIPTION
Hi, reading the doc I found out the current discord link is down, so I figured I would correct it myself instead of opening an issue and requiring someone to open a PR.

I found the new discord link in the Babylon's twitter bio.

That's it, doesn't require testing or changelog entry. 