### PR TITLE
BTC time-stamping phase 2 tests follow-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ endif
 
 .PHONY: run-tests test test-all $(TEST_TARGETS)
 
-test-e2e: build-docker build-cosmos-relayer-docker
+test-e2e: build-docker
 	go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e
 
 test-sim-nondeterminism:

--- a/contrib/images/cosmos-relayer/Dockerfile
+++ b/contrib/images/cosmos-relayer/Dockerfile
@@ -4,10 +4,12 @@ RUN apt-get update && apt-get install -y git make jq gcc make wget
 
 WORKDIR /work
 
-ARG TARGETARCH="amd64"
+ARG TARGETARCH
 
 # Download and install Go
 ENV GOLANG_VERSION 1.21.4
+RUN echo "Target arch: ${TARGETARCH}"
+RUN echo "Go version: ${GOLANG_VERSION}"
 RUN wget -q https://golang.org/dl/go${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz && \
     tar -C /usr/local -xzf go${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz && \
     rm go${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz

--- a/test/e2e/btc_timestamping_phase2_rly_test.go
+++ b/test/e2e/btc_timestamping_phase2_rly_test.go
@@ -105,8 +105,9 @@ func (s *BTCTimestampingPhase2RlyTestSuite) Test1IbcCheckpointingPhase2Rly() {
 	}, time.Minute, time.Second*2)
 
 	// ensure the next receive sequence number of Babylon contract is also 3
+	var nextSequenceRecv *channeltypes.QueryNextSequenceReceiveResponse
 	s.Eventually(func() bool {
-		nextSequenceRecv, err := czNode.QueryNextSequenceReceive(babylonChannel.Counterparty.ChannelId, babylonChannel.Counterparty.PortId)
+		nextSequenceRecv, err = czNode.QueryNextSequenceReceive(babylonChannel.Counterparty.ChannelId, babylonChannel.Counterparty.PortId)
 		if err != nil {
 			return false
 		}
@@ -115,7 +116,7 @@ func (s *BTCTimestampingPhase2RlyTestSuite) Test1IbcCheckpointingPhase2Rly() {
 	}, time.Minute, time.Second*2)
 
 	// Ensure the IBC packet acknowledgements (on chain B) are there
-	nextSequence := uint64(4)
+	nextSequence := nextSequenceRecv.NextSequenceReceive
 	for seq := uint64(1); seq < nextSequence; seq++ {
 		var seqResp *channeltypes.QueryPacketAcknowledgementResponse
 		s.Eventually(func() bool {

--- a/test/e2e/btc_timestamping_phase2_rly_test.go
+++ b/test/e2e/btc_timestamping_phase2_rly_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/babylonchain/babylon/test/e2e/configurer"
 	"github.com/babylonchain/babylon/test/e2e/initialization"
 	ct "github.com/babylonchain/babylon/x/checkpointing/types"
-	zctypes "github.com/babylonchain/babylon/x/zoneconcierge/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	"github.com/stretchr/testify/suite"
@@ -57,24 +56,45 @@ func (s *BTCTimestampingPhase2RlyTestSuite) Test1IbcCheckpointingPhase2Rly() {
 	s.NoError(err)
 
 	// Validate channel state and kind (Babylon side)
-	babylonChannelsResp, err := babylonNode.QueryIBCChannels()
-	s.NoError(err)
-	s.Len(babylonChannelsResp.Channels, 1)
-	babylonChannel := babylonChannelsResp.Channels[0]
-	// channel has to be open and ordered
-	s.Equal(channeltypes.OPEN, babylonChannel.State)
-	s.Equal(channeltypes.ORDERED, babylonChannel.Ordering)
-	// the counterparty has to be the Babylon smart contract
-	s.Contains(babylonChannel.Counterparty.PortId, "wasm.")
+	// Wait until the channel (Babylon side) is open
+	var babylonChannel *channeltypes.IdentifiedChannel
+	s.Eventually(func() bool {
+		babylonChannelsResp, err := babylonNode.QueryIBCChannels()
+		if err != nil {
+			return false
+		}
+		if len(babylonChannelsResp.Channels) != 1 {
+			return false
+		}
+		// channel has to be open and ordered
+		babylonChannel = babylonChannelsResp.Channels[0]
+		if babylonChannel.State != channeltypes.OPEN {
+			return false
+		}
+		s.Equal(channeltypes.ORDERED, babylonChannel.Ordering)
+		// the counterparty has to be the Babylon smart contract
+		s.Contains(babylonChannel.Counterparty.PortId, "wasm.")
+		return true
+	}, time.Minute, time.Second*2)
 
-	// Validate channel state (CZ side)
-	czChannelsResp, err := czNode.QueryIBCChannels()
-	s.NoError(err)
-	s.Len(czChannelsResp.Channels, 1)
-	czChannel := czChannelsResp.Channels[0]
-	s.Equal(channeltypes.OPEN, czChannel.State)
-	s.Equal(channeltypes.ORDERED, czChannel.Ordering)
-	s.Equal(zctypes.PortID, czChannel.Counterparty.PortId)
+	// Wait until the channel (CZ side) is open
+	var czChannel *channeltypes.IdentifiedChannel
+	s.Eventually(func() bool {
+		czChannelsResp, err := czNode.QueryIBCChannels()
+		if err != nil {
+			return false
+		}
+		if len(czChannelsResp.Channels) != 1 {
+			return false
+		}
+		czChannel = czChannelsResp.Channels[0]
+		if czChannel.State != channeltypes.OPEN {
+			return false
+		}
+		s.Equal(channeltypes.ORDERED, czChannel.Ordering)
+		s.Equal(babylonChannel.PortId, czChannel.Counterparty.PortId)
+		return true
+	}, time.Minute, time.Second*2)
 
 	// Query checkpoint chain info for the consumer chain
 	listHeaderResp, err := babylonNode.QueryListHeaders(initialization.ChainBID, &query.PageRequest{Limit: 1})

--- a/test/e2e/configurer/base.go
+++ b/test/e2e/configurer/base.go
@@ -85,6 +85,8 @@ func (bc *baseConfigurer) InstantiateBabylonContract() error {
 	}
 	nonValidatorNode.StoreWasmCode(contractPath, initialization.ValidatorWalletName)
 	nonValidatorNode.WaitForNextBlock()
+	nonValidatorNode.WaitForNextBlock()
+
 	latestWasmId := int(nonValidatorNode.QueryLatestWasmCodeID())
 
 	// Instantiate the contract

--- a/test/e2e/containers/config.go
+++ b/test/e2e/containers/config.go
@@ -15,7 +15,7 @@ const (
 	hermesRelayerRepository = "informalsystems/hermes"
 	// TODO: Replace with version tag once we have a working version
 	hermesRelayerTag        = "master"
-	cosmosRelayerRepository = "babylonchain/cosmos-relayer"
+	cosmosRelayerRepository = "public.ecr.aws/t9e9i3h0/cosmos-relayer"
 	// TODO: Replace with version tag once we have a working version
 	cosmosRelayerTag = "main"
 )

--- a/test/e2e/containers/config.go
+++ b/test/e2e/containers/config.go
@@ -14,7 +14,8 @@ const (
 
 	hermesRelayerRepository = "informalsystems/hermes"
 	// TODO: Replace with version tag once we have a working version
-	hermesRelayerTag        = "master"
+	hermesRelayerTag = "master"
+	// Built using the `build-cosmos-relayer-docker` target on an Intel (amd64) machine and pushed to ECR
 	cosmosRelayerRepository = "public.ecr.aws/t9e9i3h0/cosmos-relayer"
 	// TODO: Replace with version tag once we have a working version
 	cosmosRelayerTag = "main"


### PR DESCRIPTION
A small PR with some improvements  / follow-up of #419.

This uses a pre-built public `cosmos-relayer` image to try and save some time during e2e tests. The image _has_ to be built for the same platform the CI is running on (`amd64`), or the phase 2 tests will fail with obscure error messages.