### PR TITLE
doc: more details in ZoneConcierge's documentation

### DIFF
--- a/x/zoneconcierge/README.md
+++ b/x/zoneconcierge/README.md
@@ -4,7 +4,8 @@ The Zone Concierge module is responsible for generating BTC timestamps of
 headers from other PoS blockchains. These BTC timestamps allow PoS blockchains
 integrating with Babylon to achieve Bitcoin security, i.e., forking the PoS
 blockchain is as hard as forking Bitcoin. The Zone Concierge module leverages
-the IBC light client protocol to receive PoS blockchains' headers.
+the IBC protocol to receive PoS blockchains' headers and provide them with
+succint and provable information about their timestamps.
 
 There are two phases of integration for a PoS blockchain:
 
@@ -13,10 +14,10 @@ There are two phases of integration for a PoS blockchain:
   functions as a canonical chain oracle for the PoS blockchain.
   [Babylonscan](https://babylonscan.io/) shows PoS blockchains with phase 1
   integration.
-- **Phase 2 integration:** In addition to phase 1, phase 2 allows a consumer
-  chain to receive BTC timestamps from Babylon via an IBC channel, such that the
-  PoS blockchain can use BTC timestamps to detect and resolve forks, as well as
-  other use cases such as Bitcoin-assisted fast unbonding.
+- **Phase 2 integration:** In addition to phase 1, phase 2 allows a PoS
+  blockchain to receive BTC timestamps from Babylon via an IBC channel, such
+  that the PoS blockchain can use BTC timestamps to detect and resolve forks, as
+  well as other use cases such as Bitcoin-assisted fast unbonding.
 
 ## Table of contents
 

--- a/x/zoneconcierge/README.md
+++ b/x/zoneconcierge/README.md
@@ -2,19 +2,20 @@
 
 The Zone Concierge module is responsible for generating BTC timestamps of
 headers from other PoS blockchains. These BTC timestamps allow PoS blockchains
-integrating with Babylon to achieve Bitcoin security, i.e., forking the PoS blockchain is as hard as forking Bitcoin. The Zone Concierge module leverages the IBC
-light client protocol to receive PoS blockchains' headers.
+integrating with Babylon to achieve Bitcoin security, i.e., forking the PoS
+blockchain is as hard as forking Bitcoin. The Zone Concierge module leverages
+the IBC light client protocol to receive PoS blockchains' headers.
 
-There are two phases of integration for a consumer chain:
+There are two phases of integration for a PoS blockchain:
 
-- **Phase 1 integration:** Babylon receives consumer chain headers via standard
+- **Phase 1 integration:** Babylon receives PoS blockchain headers via standard
   `MsgUpdateClient` messages in IBC light client protocol, timestamps them, and
-  functions as a canonical chain oracle for the consumer chain.
+  functions as a canonical chain oracle for the PoS blockchain.
   [Babylonscan](https://babylonscan.io/) shows PoS blockchains with phase 1
   integration.
 - **Phase 2 integration:** In addition to phase 1, phase 2 allows a consumer
   chain to receive BTC timestamps from Babylon via an IBC channel, such that the
-  consumer chain can use BTC timestamps to detect and resolve forks, as well as
+  PoS blockchain can use BTC timestamps to detect and resolve forks, as well as
   other use cases such as Bitcoin-assisted fast unbonding.
 
 ## Table of contents
@@ -31,97 +32,156 @@ There are two phases of integration for a consumer chain:
   - [CanonicalChain](#canonicalchain)
   - [Fork](#fork)
   - [Params](#params)
-- [Interaction with consumer chains under phase 1 integration](#interaction-with-consumer-chains-under-phase-1-integration)
-- [Interaction with consumer chains under phase 2 integration](#interaction-with-consumer-chains-under-phase-2-integration)
+- [PostHandler for intercepting IBC headers](#posthandler-for-intercepting-ibc-headers)
+- [Hooks](#hooks)
+  - [Indexing headers upon `AfterEpochEnds`](#indexing-headers-upon-afterepochends)
+  - [Sending BTC timestamps upon `AfterRawCheckpointFinalized`](#sending-btc-timestamps-upon-afterrawcheckpointfinalized)
+- [Interaction with PoS blockchains under phase 1 integration](#interaction-with-pos-blockchains-under-phase-1-integration)
+- [Interaction with PoS blockchains under phase 2 integration](#interaction-with-pos-blockchains-under-phase-2-integration)
 - [Queries](#queries)
 
 ## Concepts
 
-The Zone Concierge module is responsible for providing BTC timestamps of headers from other PoS blockchains.
-These BTC timestamps allow PoS blockchains to achieve Bitcoin security, i.e., forking a PoS blockchain is as hard as forking Bitcoin.
-The Zone Concierge module leverages the IBC light client protocol to maintain headers with a valid quorum certificate from PoS blockchains.
-These headers receive Bitcoin timestamps together with the Babylon blockchain, thereby achieving Bitcoin security.
+The Zone Concierge module is responsible for providing BTC timestamps of headers
+from other PoS blockchains. These BTC timestamps allow PoS blockchains to
+achieve Bitcoin security, i.e., forking a PoS blockchain is as hard as forking
+Bitcoin. The Zone Concierge module leverages the IBC light client protocol to
+maintain headers with a valid quorum certificate from PoS blockchains. These
+headers receive Bitcoin timestamps together with the Babylon blockchain, thereby
+achieving Bitcoin security.
 
 ### Problem Statement
 
-Babylon aims at providing Bitcoin security to other PoS blockchains.
-This involves two functionalities: 1) checkpointing Babylon to Bitcoin, and 2) checkpointing other PoS blockchains to Babylon.
-The {[Epoching](../epoching/), [Checkpointing](../checkpointing/), [BTCCheckpoint](../btccheckpoint/), [BTCLightclient](../btclightclient/)} modules jointly provide the functionality of checkpointing Babylon to Bitcoin.
-The Zone Concierge module and the [IBC modules](https://github.com/cosmos/ibc-go) jointly provide the functionality of checkpointing PoS blockchains to Babylon.
+Babylon aims at providing Bitcoin security to other PoS blockchains. This
+involves two functionalities: 1) checkpointing Babylon to Bitcoin, and 2)
+checkpointing other PoS blockchains to Babylon. The {[Epoching](../epoching/),
+[Checkpointing](../checkpointing/), [BTCCheckpoint](../btccheckpoint/),
+[BTCLightclient](../btclightclient/)} modules jointly provide the functionality
+of checkpointing Babylon to Bitcoin. The Zone Concierge module and the [IBC
+modules](https://github.com/cosmos/ibc-go) jointly provide the functionality of
+checkpointing PoS blockchains to Babylon.
 
-In order to checkpoint PoS blockchains to Babylon, Babylon needs to receive headers of PoS blockchains, and maintain all headers that have a *quorum certificate* (a set of signatures from validators with > 2/3 total voting power).
-Checkpointing canonical headers allows Babylon to act as a canonical chain oracle.
-Checkpointing fork headers allows Babylon to identify dishonest majority attacks.
+In order to checkpoint PoS blockchains to Babylon, Babylon needs to receive
+headers of PoS blockchains, and maintain all headers that have a *quorum
+certificate* (a set of signatures from validators with > 2/3 total voting
+power). Checkpointing canonical headers allows Babylon to act as a canonical
+chain oracle. Checkpointing fork headers allows Babylon to identify dishonest
+majority attacks.
 
-To summarize, the Zone Concierge module aims at providing the following guarantees:
+To summarize, the Zone Concierge module aims at providing the following
+guarantees:
 
-- **Timestamping headers:** Babylon checkpoints PoS blockchains' (canonical and fork) headers with a valid quorum certificate.
-- **Verifiability of timestamps:** Babylon can provide a proof that a given header is checkpointed by Bitcoin, where the proof is publicly verifiable assuming access to a BTC light client.
+- **Timestamping headers:** Babylon checkpoints PoS blockchains' (canonical and
+  fork) headers with a valid quorum certificate.
+- **Verifiability of timestamps:** Babylon can provide a proof that a given
+  header is checkpointed by Bitcoin, where the proof is publicly verifiable
+  assuming access to a BTC light client.
 
 under the following assumptions:
 
-- BTC is always secure with the [k-deep confirmation rule](https://en.bitcoin.it/wiki/Confirmation);
-- There exists >=1 honest IBC relayer and >=1 vigilante {submitter, reporter}; and
-- The network is synchronous (i.e., messages are delivered within a known and finite time bound).
+- BTC is always secure with the [k-deep confirmation
+  rule](https://en.bitcoin.it/wiki/Confirmation);
+- There exists >=1 honest IBC relayer and >=1 vigilante {submitter, reporter};
+  and
+- The network is synchronous (i.e., messages are delivered within a known and
+  finite time bound).
 
-Note that the Bitcoin timestamping protocol uses Bitcoin as a single source of truth, and does not make any assumption on the fraction of adversarial validators in Babylon or PoS blockchains.
-That is, the above statement shall hold even if Babylon and a PoS blockchain have dishonest supermajority.
-The formal security analysis of the Bitcoin timestamping protocol can be found at the [S\&P'23 paper](https://arxiv.org/pdf/2207.08392.pdf).
+Note that the Bitcoin timestamping protocol uses Bitcoin as a single source of
+truth, and does not make any assumption on the fraction of adversarial
+validators in Babylon or PoS blockchains. That is, the above statement shall
+hold even if Babylon and a PoS blockchain have dishonest supermajority. The
+formal security analysis of the Bitcoin timestamping protocol can be found at
+the [S\&P'23 paper](https://arxiv.org/pdf/2207.08392.pdf).
 
 ### Design
 
-The Zone Concierge module is responsible for checkpointing headers from PoS blockchains.
-Specifically, the Zone Concierge module
+The Zone Concierge module is responsible for checkpointing headers from PoS
+blockchains. Specifically, the Zone Concierge module
 
 - leverages IBC light clients for checkpointing PoS blockchains;
 - intercepts and indexes headers from PoS blockchains; and
 - provides proofs that a header is checkpointed by Babylon and Bitcoin.
 
-**Leveraging IBC light clients for checkpointing PoS blockchains.** Babylon leverages the [IBC light client protocol](https://github.com/cosmos/ibc/tree/main/spec/client/ics-007-tendermint-client) to receive and verify headers of PoS blockchains.
-The IBC light client protocol allows a blockchain `A` to maintain a *light client* of another blockchain `B`.
-The light client contains a subset of headers in the ledger of blockchain `B`, securing the following properties when blockchain `B` has more than 2/3 honest voting power and there exists at least 1 honest IBC relayer.
+**Leveraging IBC light clients for checkpointing PoS blockchains.** Babylon
+leverages the [IBC light client
+protocol](https://github.com/cosmos/ibc/tree/main/spec/client/ics-007-tendermint-client)
+to receive and verify headers of PoS blockchains. The IBC light client protocol
+allows a blockchain `A` to maintain a *light client* of another blockchain `B`.
+The light client contains a subset of headers in the ledger of blockchain `B`,
+securing the following properties when blockchain `B` has more than 2/3 honest
+voting power and there exists at least 1 honest IBC relayer.
 
-- **Safety:** The IBC light client in blockchain `A` is consistent with the ledger of blockchain `B`.
+- **Safety:** The IBC light client in blockchain `A` is consistent with the
+  ledger of blockchain `B`.
 - **Liveness:** The IBC light client in blockchain `A` keeps growing.
 
-Verifying a header is done by a special [quorum intersection mechanism](https://arxiv.org/abs/2010.07031): upon a header from the relayer, the light client checks whether the intersected voting power between the quorum certificates of the current tip and the header is more than 1/3 of the voting power in the current tip.
-If yes, then this ensures that there exists at least one honest validator in the header's quorum certificate, and this header is agreed by all honest validators.
+Verifying a header is done by a special [quorum intersection
+mechanism](https://arxiv.org/abs/2010.07031): upon a header from the relayer,
+the light client checks whether the intersected voting power between the quorum
+certificates of the current tip and the header is more than 1/3 of the voting
+power in the current tip. If yes, then this ensures that there exists at least
+one honest validator in the header's quorum certificate, and this header is
+agreed by all honest validators.
 
-Babylon leverages the IBC light client protocol to checkpoint PoS blockchains to itself.
-In particular, each header with a valid quorum certificate can be viewed as a timestamp, and Babylon can generate an inclusion proof that a given header of a PoS blockchain is committed to Babylon's `AppHash`.
+Babylon leverages the IBC light client protocol to checkpoint PoS blockchains to
+itself. In particular, each header with a valid quorum certificate can be viewed
+as a timestamp, and Babylon can generate an inclusion proof that a given header
+of a PoS blockchain is committed to Babylon's `AppHash`.
 
-**Intercepting and Indexing Headers from PoS blockchains.** In order to further checkpoint headers of PoS blockchains to Bitcoin, the Zone Concierge module builds an index recording headers' positions on Babylon's ledger, which will eventually be checkpointed by Bitcoin.
-To this end, the Zone Concierge module intercepts headers from IBC light clients via a [PostHandler](https://docs.cosmos.network/v0.50/learn/advanced/baseapp#runtx-antehandler-runmsgs-posthandler), and indexes them.
+**Intercepting and Indexing Headers from PoS blockchains.** In order to further
+checkpoint headers of PoS blockchains to Bitcoin, the Zone Concierge module
+builds an index recording headers' positions on Babylon's ledger, which will
+eventually be checkpointed by Bitcoin. To this end, the Zone Concierge module
+intercepts headers from IBC light clients via a
+[PostHandler](https://docs.cosmos.network/v0.50/learn/advanced/baseapp#runtx-antehandler-runmsgs-posthandler),
+and indexes them.
 
-Note that the Zone Concierge module intercepts all headers that have a valid quorum certificate, including canonical headers and fork headers.
-A fork header with a valid quorum certificate is a signal of the dishonest majority attack: the majority of validators are honest and sign conflicted headers.
+Note that the Zone Concierge module intercepts all headers that have a valid
+quorum certificate, including canonical headers and fork headers. A fork header
+with a valid quorum certificate is a signal of the dishonest majority attack:
+the majority of validators are honest and sign conflicted headers.
 
-**Providing Proofs that a Header is Checkpointed by Bitcoin.** To supports use cases that need to verify BTC timestamps of headers, Zone Concierge can provide proofs that the headers are indeed checkpointed all the way to Bitocin.
-The proof includes the following:
+**Providing Proofs that a Header is Checkpointed by Bitcoin.** To supports use
+cases that need to verify BTC timestamps of headers, Zone Concierge can provide
+proofs that the headers are indeed checkpointed to Bitocin. The proof includes
+the following:
 
-- `ProofCzHeaderInEpoch`: Proof that the header of the PoS blockchain is included in an epoch of Babylon;
-- `ProofEpochSealed`: Proof that the epoch has been agreed by > 2/3 voting power of the validator set; and
-- `ProofEpochSubmitted`: Proof that the epoch's checkpoint has been submitted to Bitcoin.
+- `ProofCzHeaderInEpoch`: Proof that the header of the PoS blockchain is
+  included in an epoch of Babylon;
+- `ProofEpochSealed`: Proof that the epoch has been agreed by > 2/3 voting power
+  of the validator set; and
+- `ProofEpochSubmitted`: Proof that the epoch's checkpoint has been submitted to
+  Bitcoin.
 
-The first proof is formed as a Merkle proof that the IBC header is committed to the `AppHash` after the epoch.
-The second proof is formed as a BLS multi-signature jointly generated by the epoch's validator set.
-The last proof is formed as Merkle proofs of two transactions that constitute a BTC checkpoint, same as in [BTCCheckpoint module](../btccheckpoint/README.md).
+The first proof is formed as a Merkle proof that the IBC header is committed to
+the `AppHash` after the epoch. The second proof is formed as a BLS
+multi-signature jointly generated by the epoch's validator set. The last proof
+is formed as Merkle proofs of two transactions that constitute a BTC checkpoint,
+same as in [BTCCheckpoint module](../btccheckpoint/README.md).
 
 ### Use cases
 
-The Bitcoin-checkpointed PoS blockchain will enable a number of applications, such as raising alarms upon dishonest majority attacks and reducing the unbonding time period.
-These use cases require new plugins in the PoS blockchains, and will be developed by Babylon team in the future.
+The Bitcoin-checkpointed PoS blockchain will enable several applications, such
+as raising alarms upon dishonest majority attacks and reducing the unbonding
+period. These use cases require new plugins in the PoS blockchains, and will be
+developed by Babylon team in the future.
 
-**Raising Alarms upon Dishonest Majority Attacks.** Zone Concierge timestamps fork headers that have valid quorum certificates.
-Such fork header signals a safety attack launched by the dishonest majority of validators.
-Babylon can send the fork header back to the corresponding PoS blockchain, such that the PoS blockchain will get notified with this dishonest majority attack, and can decide to stall or initiate a social consensus.
+**Raising Alarms upon Dishonest Majority Attacks.** Zone Concierge timestamps
+fork headers that have valid quorum certificates. Such fork header signals a
+safety attack launched by the dishonest majority of validators. Babylon can send
+the fork header back to the corresponding PoS blockchain, such that the PoS
+blockchain will get notified with this dishonest majority attack, and can decide
+to stall or initiate a social consensus.
 
-**Reducing Unbonding Time.** Zone Concierge provides a Bitcoin-checkpointed prefix for a PoS blockchain.
-Such Bitcoin-checkpointed prefix resists against the long range attacks, thus unbonding requests in this prefix can be safely finished, leading to much shorter unbonding period compared to that in existing PoS blockchains (e.g., 21 days in Cosmos SDK chains).
+**Reducing Unbonding Period.** Zone Concierge provides a Bitcoin-checkpointed
+prefix for a PoS blockchain. Such Bitcoin-checkpointed prefix resists against
+the long range attacks, thus unbonding requests in this prefix can be safely
+finished, leading to much shorter unbonding period compared to that in existing
+PoS blockchains (e.g., 21 days in Cosmos SDK chains).
 
 ## State
 
-The Zone Concierge module keeps handling IBC headers of consumer chains, and
+The Zone Concierge module keeps handling IBC headers of PoS blockchains, and
 maintains the following KV stores.
 
 ### Parameters
@@ -145,9 +205,9 @@ message Params {
 ### ChainInfo
 
 The [chain info storage](./keeper/chain_info_indexer.go) maintains `ChainInfo`
-for each consumer chain. The key is the consumer chain's `ChainID`, and the
+for each PoS blockchain. The key is the PoS blockchain's `ChainID`, and the
 value is a `ChainInfo` object. The `ChainInfo` is a structure storing the
-information of a consumer chain that checkpoints to Babylon.
+information of a PoS blockchain that checkpoints to Babylon.
 
 ```protobuf
 // ChainInfo is the information of a CZ
@@ -168,14 +228,14 @@ message ChainInfo {
 ### EpochChainInfo
 
 The [epoch chain info storage](./keeper/epoch_chain_info_indexer.go) maintains
-`ChainInfo` at the end of each Babylon epoch for each consumer chain. The key is
-the consumer chain's `ChainID` plus the epoch number, and the value is a
+`ChainInfo` at the end of each Babylon epoch for each PoS blockchain. The key is
+the PoS blockchain's `ChainID` plus the epoch number, and the value is a
 `ChainInfo` object.
 
 ### CanonicalChain
 
 The [canonical chain storage](./keeper/canonical_chain_indexer.go) maintains the
-metadata of canonical IBC headers of a consumer chain. The key is the consumer
+metadata of canonical IBC headers of a PoS blockchain. The key is the consumer
 chain's `ChainID` plus the height, and the value is a `IndexedHeader` object.
 `IndexedHeader` is a structure storing an IBC header's metadata.
 
@@ -191,7 +251,7 @@ message IndexedHeader {
   uint64 height = 3;
   // time is the timestamp of this header on CZ ledger
   // it is needed for CZ to unbond all mature validators/delegations
-  // before this timestamp when this header is BTC-finalised
+  // before this timestamp when this header is BTC-finalized
   google.protobuf.Timestamp time = 4 [ (gogoproto.stdtime) = true ];
   // babylon_header_hash is the hash of the babylon block that includes this CZ
   // header
@@ -211,7 +271,7 @@ message IndexedHeader {
 ### Fork
 
 The [fork storage](./keeper/fork_indexer.go) maintains the metadata of canonical
-IBC headers of a consumer chain. The key is the consumer chain's `ChainID` plus
+IBC headers of a PoS blockchain. The key is the PoS blockchain's `ChainID` plus
 the height, and the value is a list of `IndexedHeader` objects, which represent
 fork headers at that height.
 
@@ -232,62 +292,59 @@ message Params {
 }
 ```
 
-<!-- TODO: describe the PostHandler -->
+## PostHandler for intercepting IBC headers
 
-<!-- TODO: hooks -->
-
-## Interaction with consumer chains under phase 1 integration
-
-<!-- TODO: mermaid flowchart for the interaction -->
-
-In phase 1 integration, Babylon maintains headers for a consumer chain via the
-IBC light client protocol. The IBC header chain of the consumer chain is
-checkpointed by Bitcoin via Babylon, thus achieves Bitcoin security.
-
-Babylon utilizes IBC light client protocol for the phase 1 integration.
-Specifically, the IBC relayer keeps relaying the consumer chain's headers to
-Babylon via IBC protocol's `MsgUpdateClient`
-[endpoint](https://github.com/cosmos/ibc-go/blob/v8.0.0/proto/ibc/core/client/v1/tx.proto#L20-L21),
-and the Zone Concierge module uses a `PostHandler` to handle the IBC header
-timely. This does not involve any IBC connection or channel between Babylon and
-a consumer chain.
-
-The `PostHandler` is defined at
+The Zone Concierge module implements a
+[PostHandler](https://docs.cosmos.network/v0.50/learn/advanced/baseapp#runtx-antehandler-runmsgs-posthandler)
+`IBCHeaderDecorator` to intercept headers sent to the [IBC client
+module](https://github.com/cosmos/ibc-go/tree/v8.0.0/modules/core/02-client).
+The `IBCHeaderDecorator` PostHandler is defined at
 [x/zoneconcierge/keeper/header_handler.go](./keeper/header_handler.go), and
 works as follows.
 
-1. If the consumer chain hosting the header is not known to Babylon, initialize
-   `ChainInfo` storage for the consumer chain.
+1. If the PoS blockchain hosting the header is not known to Babylon, initialize
+   `ChainInfo` storage for the PoS blockchain.
 2. If the header is on a fork, insert the header to the fork storage and update
    `ChainInfo`.
 3. If the header is canonical, insert the header to the canonical chain storage
    and update `ChainInfo`.
 
-## Interaction with consumer chains under phase 2 integration
+## Hooks
 
-<!-- TODO: mermaid flowchart for the interaction -->
+The Zone Concierge module subscribes to the Epoching module's `AfterEpochEnds`
+[hook](../epoching/types/hooks.go) for indexing the epochs when receiving
+headers from PoS blockchains, and the Checkpointing module's
+`AfterRawCheckpointFinalized` [hook](../checkpointing/types/hooks.go) for phase
+2 integration.
 
-In phase 2 integration, Babylon does everything in phase 1, and will send BTC
-timestamps of headers back to each consumer chain. Each consumer chain can
-verify the BTC timestamp and ensure that each header is finalized by Bitcoin,
-thus obtaining Bitcoin security. To do phase 2 integration, one needs to deploy
-a Babylon smart contract on the consumer chain, and start an IBC relayer between
-Babylon and the Babylon contract on the consumer chain. It does not require any
-change to the consumer chain's code.
+### Indexing headers upon `AfterEpochEnds`
 
-The BTC timestamps will allow a consumer chain to make use of BTC timestamps for
-different use cases, such as BTC-assisted fast unbonding.
+The `AfterEpochEnds` hook is triggered upon an epoch is ended, i.e., the last
+block in this epoch has been committed by CometBFT. Upon `AfterEpochEnds`, the
+Zone Concierge will save the current `ChainInfo` to the `EpochChainInfo` storage
+for each PoS blockchain.
 
-The BTC timestamp is defined in the structure `BTCTimestamp`. It includes a
-header and a set of proofs that the header is finalized by Bitcoin.
+### Sending BTC timestamps upon `AfterRawCheckpointFinalized`
+
+The `AfterRawCheckpointFinalized` hook is triggered upon a checkpoint becoming
+*finalized*, i.e., Bitcoin transactions of the checkpoint become `w`-deep in
+Bitcoin's canonical chain, where `w` is the `checkpoint_finalization_timeout`
+[parameter](../../proto/babylon/btccheckpoint/v1/params.proto) in the
+[BTCCheckpoint](../btccheckpoint/) module.
+
+Upon `AfterRawCheckpointFinalized`, the Zone Concierge module will prepare and
+send a BTC timestamp to each PoS blockchain. The BTC timestamp is
+[defined](../../proto/babylon/zoneconcierge/v1/packet.proto) as the structure
+`BTCTimestamp`. It includes a header and a set of proofs that the header is
+checkpointed by Bitcoin.
 
 <!-- TODO: diagram depicting BTC timestamp -->
 
 ```protobuf
-// BTCTimestamp is a BTC timestamp that carries information of a BTC-finalised epoch
+// BTCTimestamp is a BTC timestamp that carries information of a BTC-finalized epoch
 // It includes a number of BTC headers, a raw checkpoint, an epoch metadata, and 
 // a CZ header if there exists CZ headers checkpointed to this epoch.
-// Upon a newly finalised epoch in Babylon, Babylon will send a BTC timestamp to each
+// Upon a newly finalized epoch in Babylon, Babylon will send a BTC timestamp to each
 // PoS blockchain that has phase-2 integration with Babylon via IBC.
 message BTCTimestamp {
   // header is the last CZ header in the finalized Babylon epoch
@@ -299,7 +356,7 @@ message BTCTimestamp {
   // btc_headers is BTC headers between
   // - the block AFTER the common ancestor of BTC tip at epoch `lastFinalizedEpoch-1` and BTC tip at epoch `lastFinalizedEpoch`
   // - BTC tip at epoch `lastFinalizedEpoch`
-  // where `lastFinalizedEpoch` is the last finalised epoch in Babylon
+  // where `lastFinalizedEpoch` is the last finalized epoch in Babylon
   repeated babylon.btclightclient.v1.BTCHeaderInfo btc_headers = 2;
 
   /*
@@ -319,11 +376,11 @@ message BTCTimestamp {
 }
 
 // ProofFinalizedChainInfo is a set of proofs that attest a chain info is
-// BTC-finalised
+// BTC-finalized
 message ProofFinalizedChainInfo {
   /*
     The following fields include proofs that attest the chain info is
-    BTC-finalised
+    BTC-finalized
   */
   // proof_cz_header_in_epoch is the proof that the CZ header is timestamped
   // within a certain epoch
@@ -337,47 +394,95 @@ message ProofFinalizedChainInfo {
 }
 ```
 
-Upon a Babylon epoch is finalized, Babylon will send an IBC packet including a
-`BTCTimestamp` to each consumer chain doing phase 2/3 integration with Babylon.
-The logic upon each finalized epoch is defined at
-[x/zoneconcierge/keeper/ibc_packet_btc_timestamp.go](./keeper/ibc_packet_btc_timestamp.go)
-and works as follows.
+Upon `AfterRawCheckpointFinalized` is triggered, the Zone Concierge module will
+send an IBC packet including a `BTCTimestamp` to each PoS blockchain doing phase
+2/3 integration with Babylon. The logic is defined at
+[x/zoneconcierge/keeper/hooks.go](./keeper/hooks.go) and works as follows.
 
 1. Find all open IBC channels with Babylon's Zone Concierge module. The
-   counterparty at each IBC channel is a consumer chain.
-2. Get all canonical BTC headers received during the time of finalizing the last
-  epoch. Specifically, 2.1. Find the tip `h'` of BTC light client when the
-  second last epoch becomes finalized. 2.2. Find the tip `h` of BTC light client
-  when the last epoch becomes finalized. 2.3. If `h'` and `h` are on the same
-  chain, then the canonical BTC headers are headers from `h'` to `h`. 2.4. If
-  `h'` and `h` are on different forks, then the canonical BTC headers start from
-  their last common ancestor to `h`.
-3. For each of these IBC channels: 3.1. Find the `ChainID` of the counterparty
-  chain (i.e., the consumer chain) in the IBC channel 3.2. Get the `ChainInfo`
-  of the `ChainID` at the last finalized epoch. 3.3. Get the metadata of the
-  last finalized epoch and its corresponding raw checkpoint. 3.4. Generate the
-  proof that the last consumer chain's canonical header is committed to the
-  epoch's metadata. 3.5. Generate the proof that the epoch is sealed, i.e.,
-  receives a BLS multisignature generated by validators with >2/3 total voting
-  power at the last finalized epoch. 3.6. Generate the proof that the epoch's
-  checkpoint is submitted, i.e., encoded in transactions on Bitcoin. 3.7.
-  Assemble all the above as `BTCTimestamp`, and send it to the IBC channel in an
-  IBC packet.
+   counterparty at each IBC channel is a PoS blockchain.
+2. Get all BTC headers to be sent in BTC timestamps. Specifically,
+   1. Find the segment of BTC headers sent upon last time
+      `AfterRawCheckpointFinalized` is triggered.
+   2. If all BTC headers in the segment are no longer canonical, the BTC headers
+      to be sent will be the last `w+1` ones in the BTC light client, where
+      where `w` is the `checkpoint_finalization_timeout`
+      [parameter](../../proto/babylon/btccheckpoint/v1/params.proto) in the
+      [BTCCheckpoint](../btccheckpoint/) module.
+   3. Otherwise, the BTC headers to be sent will be from the latest header that
+      is still canonical in the segment to the current tip of the BTC light
+      client.
+3. For each of these IBC channels:
+   1. Find the `ChainID` of the counterparty chain (i.e., the PoS blockchain) in
+      the IBC channel.
+   2. Get the `ChainInfo` of the `ChainID` at the last finalized epoch.
+   3. Get the metadata of the last finalized epoch and its corresponding raw
+      checkpoint.
+   4. Generate the proof that the last PoS blockchain's canonical header is
+      committed to the epoch's metadata.
+   5. Generate the proof that the epoch is sealed, i.e., receives a BLS
+      multisignature generated by validators with >2/3 total voting power at the
+      last finalized epoch.
+   6. Generate the proof that the epoch's checkpoint is submitted, i.e., encoded
+      in transactions on Bitcoin.
+   7. Assemble all the above and the BTC headers obtained in step 2 as
+      `BTCTimestamp`, and send it to the IBC channel in an IBC packet.
 
-[Babylon contract](https://github.com/babylonchain/babylon-contract) is a
-CosmWasm smart contract for phase 2 integration. It can be deployed to a
-blockchain supporting CosmWasm smart contracts, connects with Babylon's Zone
-Concierge module via an IBC channel, and receives BTC timestamps from Babylon to
-help the consumer chain get Bitcoin security.
+## Interaction with PoS blockchains under phase 1 integration
+
+<!-- TODO: mermaid flowchart for the interaction -->
+
+In phase 1 integration, Babylon maintains headers for a PoS blockchain via the
+IBC light client protocol. The IBC light client of the PoS blockchain is
+checkpointed by Bitcoin via Babylon, thus achieves Bitcoin security.
+
+Babylon utilizes [IBC light client
+protocol](https://github.com/cosmos/ibc/tree/main/spec/client/ics-007-tendermint-client)
+for receiving headers from other PoS blockchains. The IBC headers are
+encapsulated in IBC protocol's `MsgUpdateClient`
+[message](https://github.com/cosmos/ibc-go/blob/v8.0.0/proto/ibc/core/client/v1/tx.proto#L20-L21),
+and is sent to the [IBC client
+module](https://github.com/cosmos/ibc-go/tree/v8.0.0/modules/core/02-client) by
+an [IBC
+relayer](https://github.com/cosmos/ibc/blob/main/spec/relayer/ics-018-relayer-algorithms/README.md).
+The `IBCHeaderDecorator` PostHandler intercepts the headers and index their
+positions in `ChainInfo` storage, as per
+[here](#indexing-headers-upon-afterepochends). This effectively checkpoints the
+headers of PoS blockchains, completing the phased 1 integration.
+
+## Interaction with PoS blockchains under phase 2 integration
+
+<!-- TODO: mermaid flowchart for the interaction -->
+
+In phase 2 integration, Babylon does everything in phase 1, and will send BTC
+timestamps of headers back to each PoS blockchain. Each PoS blockchain can
+verify the BTC timestamp and ensure that each header is finalized by Bitcoin,
+thus obtaining Bitcoin security. The BTC timestamps will allow a PoS blockchain
+to make use of BTC timestamps for different use cases, such as BTC-assisted fast
+unbonding.
+
+The phase 2 integration does not require any change to the PoS blockchain's
+code. Rather, it only needs to deploy a [Babylon
+contract](https://github.com/babylonchain/babylon-contract) on the PoS
+blockchain, and start an IBC relayer between Babylon and the Babylon contract on
+the PoS blockchain. The Babylon contract can be deployed to a blockchain
+supporting [CosmWasm](https://github.com/CosmWasm/cosmwasm) smart contracts,
+connects with Babylon's Zone Concierge module via an IBC channel, and receives
+BTC timestamps from Babylon to help the PoS blockchain get Bitcoin security.
+
+Upon a Babylon epoch is finalized, i.e., upon `AfterRawCheckpointFinalized` is
+triggered, Babylon will send an IBC packet including a `BTCTimestamp` to each
+PoS blockchain doing phase 2/3 integration with Babylon, as per
+[here](#sending-btc-timestamps-upon-afterrawcheckpointfinalized).
 
 Note that Zone Concierge provides 1-to-all connection, where where the Zone
 Concierge module establishes an IBC channel with each of multiple consumer
 chains. Zone Concierge will send an BTC timestamp to each of these consumer
-chains upon an epoch is finalised.
+chains upon an epoch is finalized.
 
 ## Queries
 
 The Zone Concierge module only has one message `MsgUpdateParams` for updating
 the module parameters via a governance proposal. It provides a set of queries
-about the status of checkpointed consumer chains, listed at
+about the status of checkpointed PoS blockchains, listed at
 [docs.babylonchain.io](https://docs.babylonchain.io/docs/developer-guides/grpcrestapi#tag/ZoneConcierge).

--- a/x/zoneconcierge/README.md
+++ b/x/zoneconcierge/README.md
@@ -45,11 +45,11 @@ These headers receive Bitcoin timestamps together with the Babylon blockchain, t
 ### Problem Statement
 
 Babylon aims at providing Bitcoin security to other PoS blockchains.
-To this end, Babylon needs to checkpoint itself to Bitcoin, and checkpoint other PoS blockchains to itself.
-The {Epoching, Checkpointing, BTCCheckpoint, BTCLightclient} modules jointly provide the functionality of checkpointing Babylon to Bitcoin.
-The Zone Concierge module and the IBC modules jointly provide the functionality of checkpointing PoS blockchains to Babylon.
+To this end, Babylon checkpoints itself to Bitcoin, and checkpoints other PoS blockchains to itself.
+The {[Epoching](../epoching/), [Checkpointing](../checkpointing/), [BTCCheckpoint](../btccheckpoint/), [BTCLightclient](../btclightclient/)} modules jointly provide the functionality of checkpointing Babylon to Bitcoin.
+The Zone Concierge module and the [IBC modules](https://github.com/cosmos/ibc-go) jointly provide the functionality of checkpointing PoS blockchains to Babylon.
 
-In order to checkpoint PoS blockchains to Babylon, Babylon needs to receive and verify headers of PoS blockchains, in particular, the canonical and fork headers that have a quorum certificate, i.e., a set of signatures from validators with > 2/3 voting power.
+In order to checkpoint PoS blockchains to Babylon, Babylon needs to receive and verify headers of PoS blockchains, in particular, the canonical and fork headers that have a *quorum certificate* (a set of signatures from validators with > 2/3 total voting power).
 Checkpointing canonical headers allows Babylon to act as a canonical chain oracle.
 Checkpointing fork headers allows Babylon to identify dishonest majority attacks and slash equivocating validators.
 
@@ -71,11 +71,11 @@ under the following assumptions:
 The Zone Concierge module is responsible for checkpointing headers of PoS blockchains.
 Specifically, the Zone Concierge module
 
-- leverages IBC light clients for receiving and verifying headers from PoS blockchains;
+- leverages IBC light clients for checkpointing PoS blockchains;
 - intercepts and indexes headers from PoS blockchains; and
 - provides proofs that a header is finalized by Bitcoin.
 
-**IBC Light Client for Checkpointing PoS blockchains.** Babylon leverages the IBC light client protocol to receive and verify headers of PoS blockchains, ensuring the following security properties when the PoS blockchain has more than 2/3 honest voting power and there exists at least 1 honest relayer.
+**Leveraging IBC light clients for checkpointing PoS blockchains.** Babylon leverages the IBC light client protocol to receive and verify headers of PoS blockchains, ensuring the following security properties when the PoS blockchain has more than 2/3 honest voting power and there exists at least 1 honest relayer.
 
 - **Safety:** The IBC light client is consistent with the PoS blockchain.
 - **Liveness:** The IBC light client keeps growing.
@@ -230,7 +230,6 @@ message Params {
       [ (gogoproto.moretags) = "yaml:\"ibc_packet_timeout_seconds\"" ];
 }
 ```
-
 
 <!-- TODO: describe the PostHandler -->
 


### PR DESCRIPTION
This PR provides a second revision of ZoneConcierge module's documentation, including

- a new "concepts" section for describing the motivation and overall design of the module.
- move "hooks" and "posthandlers" sections to new sections since they are a part of module spec
- update the spec of phase2 integration according to #413 
- proofreading and rewrite some parts