### PR TITLE
E2e test improvements

### DIFF
--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -12,7 +12,7 @@ ARG LEDGER_ENABLED="false"
 ARG COSMOS_BUILD_OPTIONS=""
 
 # Install cli tools for building and final image
-RUN apt update && apt install -y make git bash gcc curl jq
+RUN apt-get update && apt-get install -y make git bash gcc curl jq
 
 # Build
 WORKDIR /go/src/github.com/babylonchain/babylon
@@ -35,12 +35,12 @@ RUN LEDGER_ENABLED=$LEDGER_ENABLED \
 FROM debian:bookworm-slim AS run
 # Create a user
 RUN addgroup --gid 1137 --system babylon && adduser --uid 1137 --gid 1137 --system --home /home/babylon babylon
-RUN apt update && apt install -y bash curl jq wget
+RUN apt-get update && apt-get install -y bash curl jq wget
 
 # Label should match your github repo
 LABEL org.opencontainers.image.source="https://github.com/babylonchain/babylond:${VERSION}"
 
-# Install Libraries
+# Install libraries
 # Cosmwasm - Download correct libwasmvm version
 COPY --from=build-env /go/src/github.com/babylonchain/babylon/go.mod /tmp
 RUN WASMVM_VERSION=$(grep github.com/CosmWasm/wasmvm /tmp/go.mod | cut -d' ' -f2) && \

--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -42,7 +42,7 @@ RUN LEDGER_ENABLED=$LEDGER_ENABLED \
 
 FROM debian:bookworm-slim AS run
 # Create a user
-RUN addgroup --gid 1137 --system babylon && adduser --uid 1137 --system --group babylon
+RUN addgroup --gid 1137 --system babylon && adduser --uid 1137 --gid 1137 --system --home /home/babylon babylon
 RUN apt update && apt install -y bash curl jq
 
 # Label should match your github repo

--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -7,8 +7,6 @@ ARG TARGETPLATFORM="linux/amd64"
 # Version to build. Default is empty
 ARG VERSION
 
-# Use muslc for static libs
-ARG BUILD_TAGS="muslc"
 ARG LEDGER_ENABLED="false"
 # Cosmos build options
 ARG COSMOS_BUILD_OPTIONS=""
@@ -30,16 +28,16 @@ RUN if [ -n "${VERSION}" ]; then \
 
 # Cosmwasm - Download correct libwasmvm version
 RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
-        -O /lib/libwasmvm_muslc.a && \
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm.$(uname -m).so \
+        -O /lib/libwasmvm.$(uname -m).so && \
     # verify checksum
     wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
-    sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep libwasmvm_muslc.$(uname -m) | cut -d ' ' -f 1)
+    sha256sum /lib/libwasmvm.$(uname -m).so | grep $(cat /tmp/checksums.txt | grep libwasmvm.$(uname -m) | cut -d ' ' -f 1)
 
 RUN LEDGER_ENABLED=$LEDGER_ENABLED \
     BUILD_TAGS=$BUILD_TAGS \
     COSMOS_BUILD_OPTIONS=$COSMOS_BUILD_OPTIONS \
-    LINK_STATICALLY=true \
+    LINK_STATICALLY=false \
     make build
 
 FROM debian:bookworm-slim AS run
@@ -53,6 +51,7 @@ LABEL org.opencontainers.image.source="https://github.com/babylonchain/babylond:
 # Install Libraries
 # COPY --from=build-env /usr/lib/libgcc_s.so.1 /lib/
 # COPY --from=build-env /lib/ld-musl*.so.1* /lib
+COPY --from=build-env /lib/libwasmvm.*.so /lib/
 
 COPY --from=build-env /go/src/github.com/babylonchain/babylon/build/babylond /bin/babylond
 

--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS build-env
+FROM golang:1.21 AS build-env
 
 # Customize to your build env
 
@@ -14,8 +14,7 @@ ARG LEDGER_ENABLED="false"
 ARG COSMOS_BUILD_OPTIONS=""
 
 # Install cli tools for building and final image
-RUN apk add --update --no-cache make git bash gcc linux-headers eudev-dev ncurses-dev openssh curl jq
-RUN apk add --no-cache musl-dev
+RUN apt update && apt install -y make git bash gcc curl jq
 
 # Build
 WORKDIR /go/src/github.com/babylonchain/babylon
@@ -43,10 +42,10 @@ RUN LEDGER_ENABLED=$LEDGER_ENABLED \
     LINK_STATICALLY=true \
     make build
 
-FROM alpine:3.14 AS run
+FROM debian:bookworm-slim AS run
 # Create a user
-RUN addgroup --gid 1137 -S babylon && adduser --uid 1137 -S babylon -G babylon
-RUN apk add bash curl jq
+RUN addgroup --gid 1137 --system babylon && adduser --uid 1137 --system --group babylon
+RUN apt update && apt install -y bash curl jq
 
 # Label should match your github repo
 LABEL org.opencontainers.image.source="https://github.com/babylonchain/babylond:${VERSION}"

--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -26,14 +26,6 @@ RUN if [ -n "${VERSION}" ]; then \
         git checkout -f ${VERSION}; \
     fi
 
-# Cosmwasm - Download correct libwasmvm version
-RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm.$(uname -m).so \
-        -O /lib/libwasmvm.$(uname -m).so && \
-    # verify checksum
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
-    sha256sum /lib/libwasmvm.$(uname -m).so | grep $(cat /tmp/checksums.txt | grep libwasmvm.$(uname -m) | cut -d ' ' -f 1)
-
 RUN LEDGER_ENABLED=$LEDGER_ENABLED \
     BUILD_TAGS=$BUILD_TAGS \
     COSMOS_BUILD_OPTIONS=$COSMOS_BUILD_OPTIONS \
@@ -43,19 +35,26 @@ RUN LEDGER_ENABLED=$LEDGER_ENABLED \
 FROM debian:bookworm-slim AS run
 # Create a user
 RUN addgroup --gid 1137 --system babylon && adduser --uid 1137 --gid 1137 --system --home /home/babylon babylon
-RUN apt update && apt install -y bash curl jq
+RUN apt update && apt install -y bash curl jq wget
 
 # Label should match your github repo
 LABEL org.opencontainers.image.source="https://github.com/babylonchain/babylond:${VERSION}"
 
 # Install Libraries
-# COPY --from=build-env /usr/lib/libgcc_s.so.1 /lib/
-# COPY --from=build-env /lib/ld-musl*.so.1* /lib
-COPY --from=build-env /lib/libwasmvm.*.so /lib/
+# Cosmwasm - Download correct libwasmvm version
+COPY --from=build-env /go/src/github.com/babylonchain/babylon/go.mod /tmp
+RUN WASMVM_VERSION=$(grep github.com/CosmWasm/wasmvm /tmp/go.mod | cut -d' ' -f2) && \
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm.$(uname -m).so \
+        -O /lib/libwasmvm.$(uname -m).so && \
+    # verify checksum
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
+    sha256sum /lib/libwasmvm.$(uname -m).so | grep $(cat /tmp/checksums.txt | grep libwasmvm.$(uname -m) | cut -d ' ' -f 1)
+RUN rm -f /tmp/go.mod
 
 COPY --from=build-env /go/src/github.com/babylonchain/babylon/build/babylond /bin/babylond
 
 # Set home directory and user
 WORKDIR /home/babylon
 RUN chown -R babylon /home/babylon
+RUN chmod g+s /home/babylon
 USER babylon

--- a/test/e2e/btc_staking_e2e_test.go
+++ b/test/e2e/btc_staking_e2e_test.go
@@ -500,7 +500,12 @@ func (s *BTCStakingTestSuite) Test5SubmitStakerUnbonding() {
 	// wait for a block so that above txs take effect
 	nonValidatorNode.WaitForNextBlock()
 
-	unbondedDels := nonValidatorNode.QueryUnbondedDelegations()
+	// Wait for unbonded delegations to be created
+	var unbondedDels []*bstypes.BTCDelegation
+	s.Eventually(func() bool {
+		unbondedDels = nonValidatorNode.QueryUnbondedDelegations()
+		return len(unbondedDels) > 0
+	}, time.Minute, time.Second*2)
 	s.Len(unbondedDels, 1)
 	s.Equal(stakingTxHash, unbondedDels[0].MustGetStakingTxHash())
 }

--- a/test/e2e/configurer/chain/chain.go
+++ b/test/e2e/configurer/chain/chain.go
@@ -152,7 +152,7 @@ func (c *Config) SendIBC(dstChain *Config, recipient string, token sdk.Coin) {
 
 // GetDefaultNode returns the default node of the chain.
 // The default node is the first one created. Returns error if no
-// ndoes created.
+// nodes created.
 func (c *Config) GetDefaultNode() (*NodeConfig, error) {
 	return c.GetNodeAtIndex(defaultNodeIndex)
 }

--- a/test/e2e/configurer/chain/commands.go
+++ b/test/e2e/configurer/chain/commands.go
@@ -215,9 +215,9 @@ func (n *NodeConfig) WasmExecute(contract, execMsg, from string) {
 	n.LogActionF("successfully executed")
 }
 
-// NOTE: this command will withdraw the reward of the address associated with the tx signer `from`
+// WithdrawReward will withdraw the rewards of the address associated with the tx signer `from`
 func (n *NodeConfig) WithdrawReward(sType, from string) {
-	n.LogActionF("withdraw reward of type %s for tx signer %s", sType, from)
+	n.LogActionF("withdraw rewards of type %s for tx signer %s", sType, from)
 	cmd := []string{"babylond", "tx", "incentive", "withdraw-reward", sType, fmt.Sprintf("--from=%s", from)}
 	n.LogActionF(strings.Join(cmd, " "))
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)

--- a/test/e2e/configurer/chain/commands.go
+++ b/test/e2e/configurer/chain/commands.go
@@ -35,9 +35,9 @@ func (n *NodeConfig) GetWallet(walletName string) string {
 	return walletAddr
 }
 
-// TODO for now all commands are not used and left here as an example
 // QueryParams extracts the params for a given subspace and key. This is done generically via json to avoid having to
 // specify the QueryParamResponse type (which may not exist for all params).
+// TODO for now all commands are not used and left here as an example
 func (n *NodeConfig) QueryParams(subspace, key string, result any) {
 	cmd := []string{"babylond", "query", "params", "subspace", subspace, key, "--output=json"}
 

--- a/test/e2e/configurer/chain/commands.go
+++ b/test/e2e/configurer/chain/commands.go
@@ -48,7 +48,7 @@ func (n *NodeConfig) QueryParams(subspace, key string, result any) {
 	require.NoError(n.t, err)
 }
 
-func (n *NodeConfig) SendIBCTransfer(dstChain *Config, from, recipient, memo string, token sdk.Coin) {
+func (n *NodeConfig) SendIBCTransfer(from, recipient, memo string, token sdk.Coin) {
 	n.LogActionF("IBC sending %s from %s to %s. memo: %s", token.Amount.String(), from, recipient, memo)
 
 	cmd := []string{"babylond", "tx", "ibc-transfer", "transfer", "transfer", "channel-0", recipient, token.String(), fmt.Sprintf("--from=%s", from), "--memo", memo}

--- a/test/e2e/configurer/chain/commands_btcstaking.go
+++ b/test/e2e/configurer/chain/commands_btcstaking.go
@@ -107,7 +107,7 @@ func (n *NodeConfig) AddCovenantSigs(covPK *bbn.BIP340PubKey, stakingTxHash stri
 	cmd := []string{"babylond", "tx", "btcstaking", "add-covenant-sigs", covPKHex, stakingTxHash}
 
 	// slashing signatures
-	slashingSigStrList := []string{}
+	var slashingSigStrList []string
 	for _, sig := range slashingSigs {
 		slashingSigStrList = append(slashingSigStrList, hex.EncodeToString(sig))
 	}
@@ -116,7 +116,7 @@ func (n *NodeConfig) AddCovenantSigs(covPK *bbn.BIP340PubKey, stakingTxHash stri
 
 	// on-demand unbonding stuff
 	cmd = append(cmd, unbondingSig.ToHexStr())
-	unbondingSlashingSigStrList := []string{}
+	var unbondingSlashingSigStrList []string
 	for _, sig := range unbondingSlashingSigs {
 		unbondingSlashingSigStrList = append(unbondingSlashingSigStrList, hex.EncodeToString(sig))
 	}
@@ -130,7 +130,7 @@ func (n *NodeConfig) AddCovenantSigs(covPK *bbn.BIP340PubKey, stakingTxHash stri
 
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)
-	n.LogActionF("successfully added covenant sigatures")
+	n.LogActionF("successfully added covenant signatures")
 }
 
 func (n *NodeConfig) CommitPubRandList(fpBTCPK *bbn.BIP340PubKey, startHeight uint64, pubRandList []bbn.SchnorrPubRand, sig *bbn.BIP340Signature) {

--- a/test/e2e/configurer/chain/node.go
+++ b/test/e2e/configurer/chain/node.go
@@ -31,7 +31,7 @@ type NodeConfig struct {
 	setupTime time.Time
 }
 
-// NewNodeConfig returens new initialized NodeConfig.
+// NewNodeConfig returns new initialized NodeConfig.
 func NewNodeConfig(t *testing.T, initNode *initialization.Node, initConfig *initialization.NodeConfig, chainId string, containerManager *containers.Manager) *NodeConfig {
 	return &NodeConfig{
 		Node:             *initNode,
@@ -118,7 +118,7 @@ func (n *NodeConfig) LatestBlockNumber() uint64 {
 	return uint64(status.SyncInfo.LatestBlockHeight)
 }
 
-func (n *NodeConfig) WaitForCondition(doneCondition func() bool, errormsg string) {
+func (n *NodeConfig) WaitForCondition(doneCondition func() bool, errorMsg string) {
 	for i := 0; i < waitUntilrepeatMax; i++ {
 		if !doneCondition() {
 			time.Sleep(waitUntilRepeatPauseTime)
@@ -126,7 +126,7 @@ func (n *NodeConfig) WaitForCondition(doneCondition func() bool, errormsg string
 		}
 		return
 	}
-	n.t.Errorf("node %s timed out waiting for condition. Msg: %s", n.Name, errormsg)
+	n.t.Errorf("node %s timed out waiting for condition. Msg: %s", n.Name, errorMsg)
 }
 
 func (n *NodeConfig) WaitUntilBtcHeight(height uint64) {

--- a/test/e2e/ibc_transfer_e2e_test.go
+++ b/test/e2e/ibc_transfer_e2e_test.go
@@ -39,13 +39,12 @@ func (s *IBCTransferTestSuite) TearDownSuite() {
 
 func (s *IBCTransferTestSuite) Test1IBCTransfer() {
 	babylonChain := s.configurer.GetChainConfig(0)
-	czChain := s.configurer.GetChainConfig(1)
 
 	babylonNode, err := babylonChain.GetNodeAtIndex(2)
 	s.NoError(err)
 
 	sender := initialization.ValidatorWalletName
-	babylonNode.SendIBCTransfer(czChain, sender, sender, "", sdk.NewInt64Coin("ubbn", 1000))
+	babylonNode.SendIBCTransfer(sender, sender, "", sdk.NewInt64Coin("ubbn", 1000))
 
 	time.Sleep(1 * time.Minute)
 


### PR DESCRIPTION
Noticed some issues with the BTCStaking tests failing from time to time:
https://app.circleci.com/pipelines/github/babylonchain/babylon/1891/workflows/5e99488b-f864-45ad-856b-a01540cacb0c.

Turns out this is (likely / probably) a wasmer bug, with a [workaround](https://github.com/wasmerio/wasmer/issues/1568#issuecomment-1868697116) that was reported some time ago by Injective.

Changed the babylon docker image to use Debian bookworm instead of Alpine Linux. Seems to be working ~~(though not in CI)~~.

Also, did some syntax fixes, and robustness improvements of BTC Staking checks.