### PR TITLE
chore: Remove leftover signer config

### DIFF
--- a/cmd/babylond/cmd/custom_babylon_config.go
+++ b/cmd/babylond/cmd/custom_babylon_config.go
@@ -7,12 +7,6 @@ import (
 	bbn "github.com/babylonchain/babylon/types"
 )
 
-const (
-	defaultKeyName       = ""
-	defaultGasPrice      = "0.01ubbn"
-	defaultGasAdjustment = 1.5
-)
-
 type BtcConfig struct {
 	Network string `mapstructure:"network"`
 }
@@ -23,36 +17,19 @@ func defaultBabylonBtcConfig() BtcConfig {
 	}
 }
 
-func defaultSignerConfig() SignerConfig {
-	return SignerConfig{
-		KeyName:       defaultKeyName,
-		GasPrice:      defaultGasPrice,
-		GasAdjustment: defaultGasAdjustment,
-	}
-}
-
-type SignerConfig struct {
-	KeyName       string  `mapstructure:"key-name"`
-	GasPrice      string  `mapstructure:"gas-price"`
-	GasAdjustment float64 `mapstructure:"gas-adjustment"`
-}
-
 type BabylonAppConfig struct {
 	serverconfig.Config `mapstructure:",squash"`
 
 	Wasm wasmtypes.WasmConfig `mapstructure:"wasm"`
 
 	BtcConfig BtcConfig `mapstructure:"btc-config"`
-
-	SignerConfig SignerConfig `mapstructure:"signer-config"`
 }
 
 func DefaultBabylonConfig() *BabylonAppConfig {
 	return &BabylonAppConfig{
-		Config:       *serverconfig.DefaultConfig(),
-		Wasm:         wasmtypes.DefaultWasmConfig(),
-		BtcConfig:    defaultBabylonBtcConfig(),
-		SignerConfig: defaultSignerConfig(),
+		Config:    *serverconfig.DefaultConfig(),
+		Wasm:      wasmtypes.DefaultWasmConfig(),
+		BtcConfig: defaultBabylonBtcConfig(),
 	}
 }
 
@@ -67,14 +44,5 @@ func DefaultBabylonTemplate() string {
 # Configures which bitcoin network should be used for checkpointing
 # valid values are: [mainnet, testnet, simnet, signet, regtest]
 network = "{{ .BtcConfig.Network }}"
-
-[signer-config]
-
-# Configures which key that the BLS signer uses to sign BLS-sig transactions
-key-name = "{{ .SignerConfig.KeyName }}"
-# Configures the gas-price that the signer would like to pay
-gas-price = "{{ .SignerConfig.GasPrice }}"
-# Configures the adjustment of the gas cost of estimation
-gas-adjustment = "{{ .SignerConfig.GasAdjustment }}"
 `
 }

--- a/cmd/babylond/cmd/root.go
+++ b/cmd/babylond/cmd/root.go
@@ -141,7 +141,7 @@ func initAppConfig() (string, interface{}) {
 	//   own app.toml to override, or use this default value.
 	//
 	// In app, we set the min gas prices to 0.
-	babylonConfig.MinGasPrices = "0bbn"
+	babylonConfig.MinGasPrices = "0ubbn"
 
 	return babylonTemplate, babylonConfig
 }

--- a/cmd/babylond/cmd/testnet.go
+++ b/cmd/babylond/cmd/testnet.go
@@ -233,7 +233,6 @@ func InitTestnet(
 			_ = os.RemoveAll(outputDir)
 			return err
 		}
-		babylonConfig.SignerConfig.KeyName = nodeDirName
 
 		// generate validator keys
 		nodeIDs[i], valKeys[i], err = datagen.InitializeNodeValidatorFiles(nodeConfig, addr)

--- a/test/e2e/initialization/node.go
+++ b/test/e2e/initialization/node.go
@@ -134,7 +134,6 @@ func (n *internalNode) createAppConfig(nodeConfig *NodeConfig) {
 	appConfig.MinGasPrices = fmt.Sprintf("%s%s", MinGasPrice, BabylonDenom)
 	appConfig.StateSync.SnapshotInterval = nodeConfig.SnapshotInterval
 	appConfig.StateSync.SnapshotKeepRecent = nodeConfig.SnapshotKeepRecent
-	appConfig.SignerConfig.KeyName = ValidatorWalletName
 	appConfig.BtcConfig.Network = string(bbn.BtcSimnet)
 	appConfig.GRPC.Enable = true
 	appConfig.GRPC.Address = "0.0.0.0:9090"


### PR DESCRIPTION
This was used for the BLS signer process. Don't think it's being used anywhere else.