### PR TITLE
Fix bip322 pop

### DIFF
--- a/crypto/bip322/bip322_test.go
+++ b/crypto/bip322/bip322_test.go
@@ -15,13 +15,11 @@ import (
 )
 
 var (
-	net                   = &chaincfg.TestNet3Params
-	emptyBytes            = []byte("")
-	helloWorldBytes       = []byte("Hello World")
-	emptyBytesSig, _      = base64.StdEncoding.DecodeString("AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=")
-	helloWorldBytesSig, _ = base64.StdEncoding.DecodeString("AkcwRAIgZRfIY3p7/DoVTty6YZbWS71bc5Vct9p9Fia83eRmw2QCICK/ENGfwLtptFluMGs2KsqoNSk89pO7F29zJLUx9a/sASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=")
-	testAddr              = "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l"
-	testAddrDecoded, _    = btcutil.DecodeAddress(testAddr, net)
+	net                = &chaincfg.TestNet3Params
+	emptyBytes         = []byte("")
+	helloWorldBytes    = []byte("Hello World")
+	testAddr           = "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l"
+	testAddrDecoded, _ = btcutil.DecodeAddress(testAddr, net)
 )
 
 // test vectors at https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki#message-hashing

--- a/crypto/bip322/bip322_test.go
+++ b/crypto/bip322/bip322_test.go
@@ -76,15 +76,12 @@ func FuzzBip322ValidP2WPKHSignature(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
 		r := rand.New(rand.NewSource(seed))
 		privkey, err := btcec.NewPrivateKey()
-		pubKey := privkey.PubKey()
 		require.NoError(t, err)
 		dataLen := r.Int31n(200) + 1
 		dataToSign := datagen.GenRandomByteArray(r, uint64(dataLen))
-		witness, err := bip322.SignWithP2WPKHAddress(dataToSign, privkey, net)
+		address, witness, err := bip322.SignWithP2WPKHAddress(dataToSign, privkey, net)
 		require.NoError(t, err)
 		witnessDecoded, err := bip322.SimpleSigToWitness(witness)
-		require.NoError(t, err)
-		address, err := bip322.PubkeyToP2WPKHAddress(pubKey, net)
 		require.NoError(t, err)
 
 		err = bip322.Verify(
@@ -102,15 +99,12 @@ func FuzzBip322ValidP2TrSpendSignature(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
 		r := rand.New(rand.NewSource(seed))
 		privkey, err := btcec.NewPrivateKey()
-		pubKey := privkey.PubKey()
 		require.NoError(t, err)
 		dataLen := r.Int31n(200) + 1
 		dataToSign := datagen.GenRandomByteArray(r, uint64(dataLen))
-		witness, err := bip322.SignWithP2TrSpendAddress(dataToSign, privkey, net)
+		address, witness, err := bip322.SignWithP2TrSpendAddress(dataToSign, privkey, net)
 		require.NoError(t, err)
 		witnessDecoded, err := bip322.SimpleSigToWitness(witness)
-		require.NoError(t, err)
-		address, err := bip322.PubKeyToP2TrSpendAddress(pubKey, net)
 		require.NoError(t, err)
 
 		err = bip322.Verify(

--- a/crypto/bip322/witness.go
+++ b/crypto/bip322/witness.go
@@ -70,7 +70,7 @@ func readScript(r io.Reader, pver uint32, maxAllowed uint32, fieldName string) (
 // - For each element of the stack
 //   - The first byte specifies how many bytes it contains
 //   - The rest are the bytes of the element
-func simpleSigToWitness(sig []byte) ([][]byte, error) {
+func SimpleSigToWitness(sig []byte) ([][]byte, error) {
 	// For each input, the witness is encoded as a stack
 	// with one or more items. Therefore, we first read a
 	// varint which encodes the number of stack items.

--- a/crypto/bip322/witness.go
+++ b/crypto/bip322/witness.go
@@ -103,3 +103,32 @@ func simpleSigToWitness(sig []byte) ([][]byte, error) {
 
 	return witnessStack, nil
 }
+
+// serialization of witness copied from btcd
+func writeTxWitness(
+	w io.Writer,
+	wit [][]byte,
+) error {
+	// pver is always 0 (at least in btcd)
+	err := wire.WriteVarInt(w, 0, uint64(len(wit)))
+	if err != nil {
+		return err
+	}
+	for _, item := range wit {
+		err = wire.WriteVarBytes(w, 0, item)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func SerializeWitness(w wire.TxWitness) ([]byte, error) {
+	var buf bytes.Buffer
+
+	if err := writeTxWitness(&buf, w); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/x/btcstaking/types/pop.go
+++ b/x/btcstaking/types/pop.go
@@ -162,6 +162,11 @@ func (pop *ProofOfPossession) VerifyBIP322(babylonPK cryptotypes.PubKey, bip340P
 		return nil
 	}
 
+	// For proof of possesion we only support two types of addresses:
+	// - p2wpkh address
+	// - bip86 taproot addresses
+	// The main reason is that this is only
+
 	// rule 1: verify(sig=bip322Sig.Sig, address=bip322Sig.Address, msg=pop.BabylonSig)?
 	// TODO: temporary solution for MVP purposes.
 	// Eventually we need to use tmhash.Sum(pop.BabylonSig) rather than bbnSigHashHexBytes

--- a/x/btcstaking/types/pop.go
+++ b/x/btcstaking/types/pop.go
@@ -18,11 +18,11 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
 
-type CheckStakerKey func(stakerKey *bbn.BIP340PubKey) error
+type checkStakerKey func(stakerKey *bbn.BIP340PubKey) error
 
-type Bip322Sign func(sg []byte,
+type bip322Sign[A btcutil.Address] func(sg []byte,
 	privKey *btcec.PrivateKey,
-	net *chaincfg.Params) (btcutil.Address, []byte, error)
+	net *chaincfg.Params) (A, []byte, error)
 
 // NewPoP generates a new proof of possession that sk_Babylon and sk_BTC are held by the same person
 // a proof of possession contains two signatures:
@@ -94,11 +94,11 @@ func babylonSigToHexHash(babylonSig []byte) []byte {
 	return babylonSigHashHexBytes
 }
 
-func newPoPWithBIP322Sig(
+func newPoPWithBIP322Sig[A btcutil.Address](
 	babylonSK cryptotypes.PrivKey,
 	btcSK *btcec.PrivateKey,
 	net *chaincfg.Params,
-	bip322SignFn Bip322Sign,
+	bip322SignFn bip322Sign[A],
 ) (*ProofOfPossession, error) {
 	pop := ProofOfPossession{
 		BtcSigType: BTCSigType_BIP322,
@@ -115,7 +115,7 @@ func newPoPWithBIP322Sig(
 
 	// TODO: temporary solution for MVP purposes.
 	// Eventually we need to use tmhash.Sum(pop.BabylonSig) rather than bbnSigHashHexBytes
-	// ref: https://github.com/babylonchain/babylon-private/issues/80
+	// ref: https://github.com/babylonchain/babylon/issues/433
 	bbnSigHashHexBytes := babylonSigToHexHash(pop.BabylonSig)
 
 	address, witnessSignture, err := bip322SignFn(
@@ -228,14 +228,24 @@ func (pop *ProofOfPossession) VerifyBIP340(babylonPK cryptotypes.PubKey, bip340P
 	return nil
 }
 
-func checkAddressAndWitness(address btcutil.Address, witness wire.TxWitness, net *chaincfg.Params) (CheckStakerKey, error) {
+// isSupportedAddressAndWitness checks whether provided address and witness are
+// valid for proof of possession verification.
+// Currently the only supported options are:
+// 1. p2wpkh address which should only 2 elements in witness: signature and public key
+// 2. p2tr address which should only 1 element in witness: signature i.e p2tr key spend
+// If validation succeeds, it returns a function which can be used to check whether
+// bip340PK corresponds to verified address.
+func isSupportedAddressAndWitness(
+	address btcutil.Address,
+	witness wire.TxWitness,
+	net *chaincfg.Params) (checkStakerKey, error) {
 	script, err := txscript.PayToAddrScript(address)
 
 	if err != nil {
 		return nil, err
 	}
 
-	// pay to taproot key spending path have only signaure in witness
+	// pay to taproot key spending path have only signature in witness
 	if txscript.IsPayToTaproot(script) && len(witness) == 1 {
 		return func(stakerKey *bbn.BIP340PubKey) error {
 			btcKey, err := stakerKey.ToBTCPK()
@@ -250,11 +260,11 @@ func checkAddressAndWitness(address btcutil.Address, witness wire.TxWitness, net
 				return err
 			}
 
-			if bytes.Equal(keyAddress.ScriptAddress(), address.ScriptAddress()) {
-				return nil
-			} else {
+			if !bytes.Equal(keyAddress.ScriptAddress(), address.ScriptAddress()) {
 				return fmt.Errorf("bip322Sig.Address does not correspond to bip340PK")
 			}
+
+			return nil
 		}, nil
 	}
 
@@ -275,11 +285,12 @@ func checkAddressAndWitness(address btcutil.Address, witness wire.TxWitness, net
 				return err
 			}
 
-			if bytes.Equal(keyFromWitnessBytess, stakerKeyEncoded) {
-				return nil
-			} else {
+			if !bytes.Equal(keyFromWitnessBytess, stakerKeyEncoded) {
 				return fmt.Errorf("bip322Sig.Address does not correspond to bip340PK")
 			}
+
+			return nil
+
 		}, nil
 	}
 
@@ -288,9 +299,10 @@ func checkAddressAndWitness(address btcutil.Address, witness wire.TxWitness, net
 
 // VerifyBIP322 verifies the validity of PoP where Bitcoin signature is in BIP-322
 // after decoding pop.BtcSig to bip322Sig which contains sig and address,
-// 1. verify(sig=bip322Sig.Sig, address=bip322Sig.Address, msg=pop.BabylonSig)?
-// 2. verify(sig=pop.BabylonSig, pubkey=babylonPK, msg=bip340PK)?
-// 3. verify pop.Address corresponds to bip340PK in the given network
+// 1. verify whether bip322 address and witness are valid for proof of possession verification
+// 2. verify(sig=bip322Sig.Sig, address=bip322Sig.Address, msg=pop.BabylonSig)?
+// 3. verify(sig=pop.BabylonSig, pubkey=babylonPK, msg=bip340PK)?
+// 4. verify pop.Address corresponds to bip340PK in the given network
 func (pop *ProofOfPossession) VerifyBIP322(babylonPK cryptotypes.PubKey, bip340PK *bbn.BIP340PubKey, net *chaincfg.Params) error {
 	if pop.BtcSigType != BTCSigType_BIP322 {
 		return fmt.Errorf("the Bitcoin signature in this proof of possession is not using BIP-322 encoding")
@@ -308,18 +320,19 @@ func (pop *ProofOfPossession) VerifyBIP322(babylonPK cryptotypes.PubKey, bip340P
 	}
 
 	btcAddress, err := btcutil.DecodeAddress(bip322Sig.Address, net)
-
 	if err != nil {
 		return err
 	}
 
-	stakerKeyMatchesBtcAddressFn, err := checkAddressAndWitness(btcAddress, witness, net)
-
+	// we check whether address and witness are valid for proof of possession verification
+	// before verifying bip322 signature. This is require to avoid cases in which
+	// we receive some long running btc script to execute (like taproot script with 100 signatures)
+	stakerKeyMatchesBtcAddressFn, err := isSupportedAddressAndWitness(btcAddress, witness, net)
 	if err != nil {
 		return err
 	}
 
-	// for proof of possesion, we only support two types of cases:
+	// for proof of possession, we only support two types of cases:
 	// 1. address is p2wpkh address
 	// 2. address is p2tr address and we are dealing with bip86 (https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki)
 	// key spending path.
@@ -329,7 +342,7 @@ func (pop *ProofOfPossession) VerifyBIP322(babylonPK cryptotypes.PubKey, bip340P
 	// rule 1: verify(sig=bip322Sig.Sig, address=bip322Sig.Address, msg=pop.BabylonSig)?
 	// TODO: temporary solution for MVP purposes.
 	// Eventually we need to use tmhash.Sum(pop.BabylonSig) rather than bbnSigHashHexBytes
-	// ref: https://github.com/babylonchain/babylon-private/issues/80
+	// ref: https://github.com/babylonchain/babylon/issues/433
 	bbnSigHashHexBytes := babylonSigToHexHash(pop.BabylonSig)
 	if err := bip322.Verify(bbnSigHashHexBytes, witness, btcAddress, net); err != nil {
 		return err

--- a/x/btcstaking/types/pop_test.go
+++ b/x/btcstaking/types/pop_test.go
@@ -148,34 +148,38 @@ func FuzzPoP_BIP322_P2Tr_BIP86(f *testing.F) {
 }
 
 // TODO: Add more negative cases
-func TestValidBip322SigNotMatchingBip340PubKey(t *testing.T) {
-	r := rand.New(rand.NewSource(0))
+func FuzzPop_ValidBip322SigNotMatchingBip340PubKey(f *testing.F) {
+	datagen.AddRandomSeedsToFuzzer(f, 10)
 
-	// generate two BTC key pairs
-	btcSK, _, err := datagen.GenRandomBTCKeyPair(r)
-	require.NoError(t, err)
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
 
-	_, btcPK1, err := datagen.GenRandomBTCKeyPair(r)
-	require.NoError(t, err)
-	bip340PK1 := bbn.NewBIP340PubKeyFromBTCPK(btcPK1)
+		// generate two BTC key pairs
+		btcSK, _, err := datagen.GenRandomBTCKeyPair(r)
+		require.NoError(t, err)
 
-	// generate Babylon key pair
-	babylonSK, babylonPK, err := datagen.GenRandomSecp256k1KeyPair(r)
-	require.NoError(t, err)
+		_, btcPK1, err := datagen.GenRandomBTCKeyPair(r)
+		require.NoError(t, err)
+		bip340PK1 := bbn.NewBIP340PubKeyFromBTCPK(btcPK1)
 
-	// generate valid bip322 P2WPKH pop
-	pop, err := types.NewPoPWithBIP322P2WPKHSig(babylonSK, btcSK, net)
-	require.NoError(t, err)
+		// generate Babylon key pair
+		babylonSK, babylonPK, err := datagen.GenRandomSecp256k1KeyPair(r)
+		require.NoError(t, err)
 
-	// verify bip322 pop with incorrect staker key
-	err = pop.VerifyBIP322(babylonPK, bip340PK1, net)
-	require.Error(t, err)
+		// generate valid bip322 P2WPKH pop
+		pop, err := types.NewPoPWithBIP322P2WPKHSig(babylonSK, btcSK, net)
+		require.NoError(t, err)
 
-	// generate valid bip322 P2Tr pop
-	pop, err = types.NewPoPWithBIP322P2TRBIP86Sig(babylonSK, btcSK, net)
-	require.NoError(t, err)
+		// verify bip322 pop with incorrect staker key
+		err = pop.VerifyBIP322(babylonPK, bip340PK1, net)
+		require.Error(t, err)
 
-	// verify bip322 pop with incorrect staker key
-	err = pop.VerifyBIP322(babylonPK, bip340PK1, net)
-	require.Error(t, err)
+		// generate valid bip322 P2Tr pop
+		pop, err = types.NewPoPWithBIP322P2TRBIP86Sig(babylonSK, btcSK, net)
+		require.NoError(t, err)
+
+		// verify bip322 pop with incorrect staker key
+		err = pop.VerifyBIP322(babylonPK, bip340PK1, net)
+		require.Error(t, err)
+	})
 }

--- a/x/btcstaking/types/pop_test.go
+++ b/x/btcstaking/types/pop_test.go
@@ -9,9 +9,14 @@ import (
 	"github.com/babylonchain/babylon/x/btcstaking/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	net = &chaincfg.TestNet3Params
 )
 
 func newInvalidBIP340PoP(r *rand.Rand, babylonSK cryptotypes.PrivKey, btcSK *btcec.PrivateKey) *types.ProofOfPossession {
@@ -73,8 +78,6 @@ func FuzzPoP_BIP340(f *testing.F) {
 	})
 }
 
-// TODO: fuzz test for BIP322 PoP
-
 func FuzzPoP_ECDSA(f *testing.F) {
 	datagen.AddRandomSeedsToFuzzer(f, 10)
 
@@ -96,4 +99,83 @@ func FuzzPoP_ECDSA(f *testing.F) {
 		err = pop.VerifyECDSA(babylonPK, bip340PK)
 		require.NoError(t, err)
 	})
+}
+
+func FuzzPoP_BIP322_P2WPKH(f *testing.F) {
+	datagen.AddRandomSeedsToFuzzer(f, 10)
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+
+		// generate BTC key pair
+		btcSK, btcPK, err := datagen.GenRandomBTCKeyPair(r)
+		require.NoError(t, err)
+		bip340PK := bbn.NewBIP340PubKeyFromBTCPK(btcPK)
+
+		// generate Babylon key pair
+		babylonSK, babylonPK, err := datagen.GenRandomSecp256k1KeyPair(r)
+		require.NoError(t, err)
+
+		// generate and verify PoP, correct case
+		pop, err := types.NewPoPWithBIP322P2WPKHSig(babylonSK, btcSK, net)
+		require.NoError(t, err)
+		err = pop.VerifyBIP322(babylonPK, bip340PK, net)
+		require.NoError(t, err)
+	})
+}
+
+func FuzzPoP_BIP322_P2Tr_BIP86(f *testing.F) {
+	datagen.AddRandomSeedsToFuzzer(f, 10)
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+
+		// generate BTC key pair
+		btcSK, btcPK, err := datagen.GenRandomBTCKeyPair(r)
+		require.NoError(t, err)
+		bip340PK := bbn.NewBIP340PubKeyFromBTCPK(btcPK)
+
+		// generate Babylon key pair
+		babylonSK, babylonPK, err := datagen.GenRandomSecp256k1KeyPair(r)
+		require.NoError(t, err)
+
+		// generate and verify PoP, correct case
+		pop, err := types.NewPoPWithBIP322P2TRBIP86Sig(babylonSK, btcSK, net)
+		require.NoError(t, err)
+		err = pop.VerifyBIP322(babylonPK, bip340PK, net)
+		require.NoError(t, err)
+	})
+}
+
+// TODO: Add more negative cases
+func TestValidBip322SigNotMatchingBip340PubKey(t *testing.T) {
+	r := rand.New(rand.NewSource(0))
+
+	// generate two BTC key pairs
+	btcSK, _, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(t, err)
+
+	_, btcPK1, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(t, err)
+	bip340PK1 := bbn.NewBIP340PubKeyFromBTCPK(btcPK1)
+
+	// generate Babylon key pair
+	babylonSK, babylonPK, err := datagen.GenRandomSecp256k1KeyPair(r)
+	require.NoError(t, err)
+
+	// generate valid bip322 P2WPKH pop
+	pop, err := types.NewPoPWithBIP322P2WPKHSig(babylonSK, btcSK, net)
+	require.NoError(t, err)
+
+	// verify bip322 pop with incorrect staker key
+	err = pop.VerifyBIP322(babylonPK, bip340PK1, net)
+	require.Error(t, err)
+
+	// generate valid bip322 P2Tr pop
+	pop, err = types.NewPoPWithBIP322P2TRBIP86Sig(babylonSK, btcSK, net)
+	require.NoError(t, err)
+
+	// verify bip322 pop with incorrect staker key
+	err = pop.VerifyBIP322(babylonPK, bip340PK1, net)
+	require.Error(t, err)
 }


### PR DESCRIPTION
- add bip322 sig generation for p2tr address and p2wpkh  address
- improve types in api
- properly check that btc address used in bip322, corresponds to bip340 public key

TODO:
- [x] more tests
- [x] refactor a bit