### PR TITLE
bench: benchmarking finality module

### DIFF
--- a/x/btcstaking/keeper/bench_test.go
+++ b/x/btcstaking/keeper/bench_test.go
@@ -90,9 +90,8 @@ func benchBeginBlock(b *testing.B, numFPs int, numDelsUnderFP int) {
 	}
 }
 
-func BenchmarkBeginBlock_10_1(b *testing.B)  { benchBeginBlock(b, 10, 1) }
-func BenchmarkBeginBlock_10_10(b *testing.B) { benchBeginBlock(b, 10, 10) }
-
+func BenchmarkBeginBlock_10_1(b *testing.B)    { benchBeginBlock(b, 10, 1) }
+func BenchmarkBeginBlock_10_10(b *testing.B)   { benchBeginBlock(b, 10, 10) }
 func BenchmarkBeginBlock_10_100(b *testing.B)  { benchBeginBlock(b, 10, 100) }
 func BenchmarkBeginBlock_100_1(b *testing.B)   { benchBeginBlock(b, 100, 1) }
 func BenchmarkBeginBlock_100_10(b *testing.B)  { benchBeginBlock(b, 100, 10) }

--- a/x/finality/keeper/bench_test.go
+++ b/x/finality/keeper/bench_test.go
@@ -1,0 +1,69 @@
+package keeper_test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/babylonchain/babylon/testutil/datagen"
+	keepertest "github.com/babylonchain/babylon/testutil/keeper"
+	bbn "github.com/babylonchain/babylon/types"
+	"github.com/babylonchain/babylon/x/finality/keeper"
+	"github.com/babylonchain/babylon/x/finality/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func benchmarkCommitPubRandList(b *testing.B, numPubRand uint64) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+
+	bsKeeper := types.NewMockBTCStakingKeeper(ctrl)
+	fKeeper, ctx := keepertest.FinalityKeeper(b, bsKeeper, nil)
+	ms := keeper.NewMsgServerImpl(*fKeeper)
+
+	// create a random finality provider
+	btcSK, btcPK, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(b, err)
+	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(btcPK)
+	fpBTCPKBytes := fpBTCPK.MustMarshal()
+
+	// register the finality provider
+	bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
+
+	// Start the CPU profiler
+	cpuProfileFile := fmt.Sprintf("/tmp/finality-commit-pub-rand-%d-cpu.pprof", numPubRand)
+	f, err := os.Create(cpuProfileFile)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	if err := pprof.StartCPUProfile(f); err != nil {
+		b.Fatal(err)
+	}
+	defer pprof.StopCPUProfile()
+
+	// Reset timer before the benchmark loop starts
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer() // Stop the timer to exclude measurement on GenRandomMsgCommitPubRandList
+
+		startHeight := 1 + numPubRand*uint64(i)
+		_, msg, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight, numPubRand)
+		require.NoError(b, err)
+
+		b.StartTimer() // Start the timer again to measure CommitPubRandList
+
+		_, err = ms.CommitPubRandList(ctx, msg)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkCommitPubRandList_100(b *testing.B)   { benchmarkCommitPubRandList(b, 100) }
+func BenchmarkCommitPubRandList_1000(b *testing.B)  { benchmarkCommitPubRandList(b, 1000) }
+func BenchmarkCommitPubRandList_10000(b *testing.B) { benchmarkCommitPubRandList(b, 10000) }

--- a/x/finality/keeper/public_randomness_bench_test.go
+++ b/x/finality/keeper/public_randomness_bench_test.go
@@ -51,13 +51,13 @@ func benchmarkCommitPubRandList(b *testing.B, numPubRand uint64) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		b.StopTimer() // Stop the timer to exclude measurement on GenRandomMsgCommitPubRandList
+		b.StopTimer()
 
 		startHeight := 1 + numPubRand*uint64(i)
 		_, msg, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight, numPubRand)
 		require.NoError(b, err)
 
-		b.StartTimer() // Start the timer again to measure CommitPubRandList
+		b.StartTimer()
 
 		_, err = ms.CommitPubRandList(ctx, msg)
 		require.NoError(b, err)

--- a/x/finality/keeper/tallying_bench_test.go
+++ b/x/finality/keeper/tallying_bench_test.go
@@ -1,0 +1,87 @@
+package keeper_test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/babylonchain/babylon/testutil/datagen"
+	keepertest "github.com/babylonchain/babylon/testutil/keeper"
+	bbn "github.com/babylonchain/babylon/types"
+	bstypes "github.com/babylonchain/babylon/x/btcstaking/types"
+	"github.com/babylonchain/babylon/x/finality/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func benchmarkTallyBlocks(b *testing.B, numFPs int) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+
+	bsKeeper := types.NewMockBTCStakingKeeper(ctrl)
+	iKeeper := types.NewMockIncentiveKeeper(ctrl)
+	fKeeper, ctx := keepertest.FinalityKeeper(b, bsKeeper, iKeeper)
+
+	// activate BTC staking protocol at a random height
+	activatedHeight := uint64(1)
+	// add mock queries to GetBTCStakingActivatedHeight
+	ctx = datagen.WithCtxHeight(ctx, uint64(activatedHeight))
+	bsKeeper.EXPECT().GetBTCStakingActivatedHeight(gomock.Any()).Return(activatedHeight, nil).AnyTimes()
+
+	// simulate fp set
+	fpSet := map[string]uint64{}
+	for i := 0; i < numFPs; i++ {
+		votedFpPK, err := datagen.GenRandomBIP340PubKey(r)
+		require.NoError(b, err)
+		fpSet[votedFpPK.MarshalHex()] = 1
+	}
+	bsKeeper.EXPECT().GetVotingPowerTable(gomock.Any(), gomock.Any()).Return(fpSet).AnyTimes()
+
+	// TODO: test incentive
+	bsKeeper.EXPECT().GetRewardDistCache(gomock.Any(), gomock.Any()).Return(bstypes.NewRewardDistCache(), nil).AnyTimes()
+	iKeeper.EXPECT().RewardBTCStaking(gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
+	bsKeeper.EXPECT().RemoveRewardDistCache(gomock.Any(), gomock.Any()).Return().AnyTimes()
+	// Start the CPU profiler
+	cpuProfileFile := fmt.Sprintf("/tmp/finality-tally-blocks-%d-cpu.pprof", numFPs)
+	f, err := os.Create(cpuProfileFile)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	if err := pprof.StartCPUProfile(f); err != nil {
+		b.Fatal(err)
+	}
+	defer pprof.StopCPUProfile()
+
+	// Reset timer before the benchmark loop starts
+	b.ResetTimer()
+
+	// tally a block
+	for i := int(activatedHeight); i < b.N; i++ {
+		height := uint64(i)
+		// index blocks
+		fKeeper.SetBlock(ctx, &types.IndexedBlock{
+			Height:    height,
+			AppHash:   datagen.GenRandomByteArray(r, 32),
+			Finalized: false,
+		})
+		// give votes to the block
+		for fpPKHex := range fpSet {
+			votedFpPK, err := bbn.NewBIP340PubKeyFromHex(fpPKHex)
+			require.NoError(b, err)
+			votedSig, err := bbn.NewSchnorrEOTSSig(datagen.GenRandomByteArray(r, 32))
+			require.NoError(b, err)
+			fKeeper.SetSig(ctx, height, votedFpPK, votedSig)
+		}
+
+		fKeeper.TallyBlocks(ctx)
+	}
+}
+
+func BenchmarkTallyBlocks_10(b *testing.B)  { benchmarkTallyBlocks(b, 10) }
+func BenchmarkTallyBlocks_50(b *testing.B)  { benchmarkTallyBlocks(b, 50) }
+func BenchmarkTallyBlocks_100(b *testing.B) { benchmarkTallyBlocks(b, 100) }

--- a/x/finality/keeper/tallying_bench_test.go
+++ b/x/finality/keeper/tallying_bench_test.go
@@ -62,7 +62,11 @@ func benchmarkTallyBlocks(b *testing.B, numFPs int) {
 
 	// tally a block
 	for i := int(activatedHeight); i < b.N; i++ {
+		b.StopTimer()
+
 		height := uint64(i)
+		// increment height in ctx
+		ctx = datagen.WithCtxHeight(ctx, height)
 		// index blocks
 		fKeeper.SetBlock(ctx, &types.IndexedBlock{
 			Height:    height,
@@ -77,6 +81,8 @@ func benchmarkTallyBlocks(b *testing.B, numFPs int) {
 			require.NoError(b, err)
 			fKeeper.SetSig(ctx, height, votedFpPK, votedSig)
 		}
+
+		b.StartTimer()
 
 		fKeeper.TallyBlocks(ctx)
 	}

--- a/x/finality/keeper/votes_bench_test.go
+++ b/x/finality/keeper/votes_bench_test.go
@@ -1,0 +1,84 @@
+package keeper_test
+
+import (
+	"math/rand"
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"cosmossdk.io/core/header"
+	"github.com/babylonchain/babylon/testutil/datagen"
+	keepertest "github.com/babylonchain/babylon/testutil/keeper"
+	bbn "github.com/babylonchain/babylon/types"
+	"github.com/babylonchain/babylon/x/finality/keeper"
+	"github.com/babylonchain/babylon/x/finality/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func benchmarkAddFinalitySig(b *testing.B) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+
+	bsKeeper := types.NewMockBTCStakingKeeper(ctrl)
+	fKeeper, ctx := keepertest.FinalityKeeper(b, bsKeeper, nil)
+	ms := keeper.NewMsgServerImpl(*fKeeper)
+
+	// create a random finality provider
+	btcSK, btcPK, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(b, err)
+	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(btcPK)
+	fpBTCPKBytes := fpBTCPK.MustMarshal()
+	fp, err := datagen.GenRandomFinalityProviderWithBTCSK(r, btcSK)
+	require.NoError(b, err)
+
+	// register the finality provider
+	bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
+	bsKeeper.EXPECT().GetFinalityProvider(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(fp, nil).AnyTimes()
+	// mock voting power
+	bsKeeper.EXPECT().GetVotingPower(gomock.Any(), gomock.Eq(fpBTCPKBytes), gomock.Any()).Return(uint64(1)).AnyTimes()
+
+	// commit enough public randomness
+	srList, msg, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, 0, 100000)
+	require.NoError(b, err)
+	_, err = ms.CommitPubRandList(ctx, msg)
+	require.NoError(b, err)
+
+	// Start the CPU profiler
+	cpuProfileFile := "/tmp/finality-submit-finality-sig-cpu.pprof"
+	f, err := os.Create(cpuProfileFile)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	if err := pprof.StartCPUProfile(f); err != nil {
+		b.Fatal(err)
+	}
+	defer pprof.StopCPUProfile()
+
+	// Reset timer before the benchmark loop starts
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+
+		height := uint64(i)
+
+		// generate a vote
+		sr := srList[height]
+		blockHash := datagen.GenRandomByteArray(r, 32)
+		signer := datagen.GenRandomAccount().Address
+		msg, err := types.NewMsgAddFinalitySig(signer, btcSK, sr, height, blockHash)
+		require.NoError(b, err)
+		ctx = ctx.WithHeaderInfo(header.Info{Height: int64(height), AppHash: blockHash})
+
+		b.StartTimer()
+
+		_, err = ms.AddFinalitySig(ctx, msg)
+		require.Error(b, err)
+	}
+}
+
+func BenchmarkAddFinalitySig(b *testing.B) { benchmarkAddFinalitySig(b) }

--- a/x/finality/keeper/votes_bench_test.go
+++ b/x/finality/keeper/votes_bench_test.go
@@ -41,6 +41,7 @@ func benchmarkAddFinalitySig(b *testing.B) {
 	bsKeeper.EXPECT().GetVotingPower(gomock.Any(), gomock.Eq(fpBTCPKBytes), gomock.Any()).Return(uint64(1)).AnyTimes()
 
 	// commit enough public randomness
+	// TODO: generalise commit public randomness to allow arbitrary benchtime
 	srList, msg, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, 0, 100000)
 	require.NoError(b, err)
 	_, err = ms.CommitPubRandList(ctx, msg)


### PR DESCRIPTION
This PR introduces benchmark tests for key operations in the finality module.

## Methodlogy

The goal is to identify performance bottlenecks and the corresponding issues in the normal operation of finality module, in a quick and dirty way. The PR suspects the following potential performance hotspots:

- committing randomness
- adding finality signatures
- tallying blocks

Thus this PR introduces 3 groups of benchmark tests:

- `BenchmarkCommitPubRandList`: repeatedly submits a given number of public randomness
- `BenchmarkAddFinalitySig`: repeatedly submits 1 finality signature
- `BenchmarkTallyBlocks`: repeatedly tallies blocks with a given number of finality providers

## Results

The overall result is that the above scenarios do not have performance issues.

### BenchmarkCommitPubRandList

```log
BenchmarkCommitPubRandList_10000-16          100         801347895 ns/op        160114001 B/op    331502 allocs/op
```

Committing 10000 public randomness costs 0.8s. That is, assuming 50 finality providers concurrently commit 2000 public randomness, then the execution time is 0.8s. This might be acceptable for now.

[commit-pub-rand.pdf](https://github.com/babylonchain/babylon/files/14135065/commit-pub-rand.pdf)

The profiling shows that operations that rely on iterators (`IsFirstPubRand` and `GetLastPubRand`) are hotspots. If we start optimising committing randomness then these could be the start.

### BenchmarkAddFinalitySig

```log
BenchmarkAddFinalitySig-16         77073            153013 ns/op            7082 B/op         50 allocs/op
```

Adding each finality signature takes only 0.00015s. So assuming we have 50 finality providers then each block will take 0.0075s to process all finality signatures. This is acceptable.

[add-finality-sig.pdf](https://github.com/babylonchain/babylon/files/14135112/add-finality-sig.pdf)

The profiling shows that verifying a EOTS signature is the hotspot. Verifying EOTS signature is inevitable, so optimising this might require optimising the EOTS implementation. No immediate actionable item here.

### BenchmarkTallyBlocks

```log
BenchmarkTallyBlocks_100-16          835           3484018 ns/op           43353 B/op        453 allocs/op
```

Tallying a block with 100 votes takes only 0.0035s. This is acceptable.

[tally.pdf](https://github.com/babylonchain/babylon/files/14135439/tally.pdf)

The profiling result excludes the execution overhead of tallying a block, meaning that tallying's execution overhead is negligible.

## TODOs

The benchmarking and profiling are not perfect because the BTC staking module is mocked. That means the overhead of accessing the database of BTC staking module is not considered in above results. Thus a TODO is to replace the mocked BTC staking module with a real one. Nevertheless, the results are expected to be similar with above, because only the finlaity providers and their voting power are accessed, and these are rather small.