### PR TITLE
btcstaking: optimise iterative access to BTC delegations

### DIFF
--- a/x/btcstaking/abci.go
+++ b/x/btcstaking/abci.go
@@ -13,17 +13,7 @@ import (
 func BeginBlocker(ctx context.Context, k keeper.Keeper) error {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
 
-	// index BTC height at the current height
-	k.IndexBTCHeight(ctx)
-	// record voting power table at the current height
-	k.RecordVotingPowerTable(ctx)
-	// if BTC staking is activated, record reward distribution cache at the current height
-	// TODO: consider merging RecordVotingPowerTable and RecordRewardDistCache so that we
-	// only need to perform one full scan over finality providers/delegations
-	if k.IsBTCStakingActivated(ctx) {
-		k.RecordRewardDistCache(ctx)
-	}
-	return nil
+	return k.BeginBlocker(ctx)
 }
 
 func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, error) {

--- a/x/btcstaking/keeper/incentive.go
+++ b/x/btcstaking/keeper/incentive.go
@@ -48,6 +48,7 @@ func (k Keeper) RecordRewardDistCache(ctx context.Context) {
 		// the finality provider's distribution info
 		fpDistInfo := types.NewFinalityProviderDistInfo(fp)
 		btcDelIter := k.btcDelegatorStore(ctx, fpBTCPK).Iterator(nil, nil)
+		defer btcDelIter.Close()
 		for ; btcDelIter.Valid(); btcDelIter.Next() {
 			// unmarshal
 			var btcDelIndex types.BTCDelegatorDelegationIndex
@@ -62,7 +63,6 @@ func (k Keeper) RecordRewardDistCache(ctx context.Context) {
 				fpDistInfo.AddBTCDel(btcDel, btcTipHeight, wValue, covenantQuorum)
 			}
 		}
-		btcDelIter.Close()
 
 		// try to add this finality provider distribution info to reward distribution cache
 		rdc.AddFinalityProviderDistInfo(fpDistInfo)

--- a/x/btcstaking/keeper/incentive_test.go
+++ b/x/btcstaking/keeper/incentive_test.go
@@ -87,7 +87,8 @@ func FuzzRecordRewardDistCache(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.BeginBlocker(ctx)
+		err = keeper.BeginBlocker(ctx)
+		require.NoError(t, err)
 
 		// assert reward distribution cache is correct
 		rdc, err := keeper.GetRewardDistCache(ctx, babylonHeight)

--- a/x/btcstaking/keeper/incentive_test.go
+++ b/x/btcstaking/keeper/incentive_test.go
@@ -87,8 +87,7 @@ func FuzzRecordRewardDistCache(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.IndexBTCHeight(ctx)
-		keeper.RecordRewardDistCache(ctx)
+		keeper.BeginBlocker(ctx)
 
 		// assert reward distribution cache is correct
 		rdc, err := keeper.GetRewardDistCache(ctx, babylonHeight)

--- a/x/btcstaking/keeper/keeper.go
+++ b/x/btcstaking/keeper/keeper.go
@@ -54,6 +54,11 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
+// BeginBlocker is invoked upon `BeginBlock` of the system. The function
+// iterates over all BTC delegations under non-slashed finality providers
+// to 1) record the voting power table for the current height, and 2) record
+// the reward distribution cache used for distributing rewards once the block
+// is finalised by finality providers.
 func (k Keeper) BeginBlocker(ctx context.Context) error {
 	// index BTC height at the current height
 	k.IndexBTCHeight(ctx)

--- a/x/btcstaking/keeper/keeper.go
+++ b/x/btcstaking/keeper/keeper.go
@@ -75,13 +75,13 @@ func (k Keeper) BeginBlocker(ctx context.Context) error {
 
 	k.IterateActiveFPsAndBTCDelegations(
 		ctx,
-		func(fp *types.FinalityProvider, btcDel *types.BTCDelegation) {
+		func(fp *types.FinalityProvider, btcDel *types.BTCDelegation) bool {
 			fpBTCPKHex := fp.BtcPk.MarshalHex()
 
 			// record active finality providers
 			power := btcDel.VotingPower(btcTipHeight, wValue, covenantQuorum)
 			if power == 0 {
-				return // skip if no voting power
+				return true // skip if no voting power
 			}
 			fpPowerMap[fpBTCPKHex] += power
 
@@ -91,6 +91,7 @@ func (k Keeper) BeginBlocker(ctx context.Context) error {
 			}
 			// append BTC delegation
 			fpDistMap[fpBTCPKHex].AddBTCDel(btcDel, btcTipHeight, wValue, covenantQuorum)
+			return true
 		},
 	)
 

--- a/x/btcstaking/keeper/keeper.go
+++ b/x/btcstaking/keeper/keeper.go
@@ -1,8 +1,10 @@
 package keeper
 
 import (
-	corestoretypes "cosmossdk.io/core/store"
+	"context"
 	"fmt"
+
+	corestoretypes "cosmossdk.io/core/store"
 
 	"cosmossdk.io/log"
 	"github.com/babylonchain/babylon/x/btcstaking/types"
@@ -50,4 +52,69 @@ func NewKeeper(
 
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
+}
+
+func (k Keeper) BeginBlocker(ctx context.Context) error {
+	// index BTC height at the current height
+	k.IndexBTCHeight(ctx)
+
+	covenantQuorum := k.GetParams(ctx).CovenantQuorum
+	btcTipHeight, err := k.GetCurrentBTCHeight(ctx)
+	if err != nil {
+		panic(err) // only possible upon programming error
+	}
+	wValue := k.btccKeeper.GetParams(ctx).CheckpointFinalizationTimeout
+
+	// prepare for recording finality providers with positive voting power
+	// key is the finality provider's FP BTC PK hex, and value is the
+	// voting power
+	fpPowerMap := map[string]uint64{}
+	// prepare for recording finality providers and their BTC delegations
+	// for rewards
+	fpDistMap := map[string]*types.FinalityProviderDistInfo{}
+
+	k.IterateActiveFPsAndBTCDelegations(
+		ctx,
+		func(fp *types.FinalityProvider, btcDel *types.BTCDelegation) {
+			fpBTCPKHex := fp.BtcPk.MarshalHex()
+
+			// record active finality providers
+			power := btcDel.VotingPower(btcTipHeight, wValue, covenantQuorum)
+			if power == 0 {
+				return // skip if no voting power
+			}
+			if _, ok := fpPowerMap[fpBTCPKHex]; ok {
+				fpPowerMap[fpBTCPKHex] += power
+			} else {
+				fpPowerMap[fpBTCPKHex] = power
+			}
+
+			// create fp dist info if not exist
+			if _, ok := fpDistMap[fpBTCPKHex]; !ok {
+				fpDistMap[fpBTCPKHex] = types.NewFinalityProviderDistInfo(fp)
+			}
+			// append BTC delegation
+			fpDistMap[fpBTCPKHex].AddBTCDel(btcDel, btcTipHeight, wValue, covenantQuorum)
+		},
+	)
+
+	// return directly if there is no active finality provider
+	if len(fpPowerMap) == 0 {
+		return nil
+	}
+
+	// get top N finality providers and set their voting power to KV store
+	k.setCurrentTopNVotingPower(ctx, fpPowerMap)
+
+	// create reward distribution cache
+	rdc := types.NewRewardDistCache()
+	for _, fpDistInfo := range fpDistMap {
+		// try to add this finality provider distribution info to reward distribution cache
+		rdc.AddFinalityProviderDistInfo(fpDistInfo)
+	}
+
+	// all good, set the reward distribution cache of the current height
+	k.setRewardDistCache(ctx, uint64(sdk.UnwrapSDKContext(ctx).HeaderInfo().Height), rdc)
+
+	return nil
 }

--- a/x/btcstaking/keeper/keeper.go
+++ b/x/btcstaking/keeper/keeper.go
@@ -104,9 +104,9 @@ func (k Keeper) BeginBlocker(ctx context.Context) error {
 
 	// create reward distribution cache
 	rdc := types.NewRewardDistCache()
-	for _, fpDistInfo := range fpDistMap {
+	for fpBTCPKHex := range fpDistMap {
 		// try to add this finality provider distribution info to reward distribution cache
-		rdc.AddFinalityProviderDistInfo(fpDistInfo)
+		rdc.AddFinalityProviderDistInfo(fpDistMap[fpBTCPKHex])
 	}
 
 	// all good, set the reward distribution cache of the current height

--- a/x/btcstaking/keeper/keeper.go
+++ b/x/btcstaking/keeper/keeper.go
@@ -83,11 +83,7 @@ func (k Keeper) BeginBlocker(ctx context.Context) error {
 			if power == 0 {
 				return // skip if no voting power
 			}
-			if _, ok := fpPowerMap[fpBTCPKHex]; ok {
-				fpPowerMap[fpBTCPKHex] += power
-			} else {
-				fpPowerMap[fpBTCPKHex] = power
-			}
+			fpPowerMap[fpBTCPKHex] += power
 
 			// create fp dist info if not exist
 			if _, ok := fpDistMap[fpBTCPKHex]; !ok {

--- a/x/btcstaking/keeper/voting_power_table.go
+++ b/x/btcstaking/keeper/voting_power_table.go
@@ -15,7 +15,7 @@ import (
 
 // IterateActiveFPsAndBTCDelegations iterates over all finality providers that are not slashed,
 // and their BTC delegations
-func (k Keeper) IterateActiveFPsAndBTCDelegations(ctx context.Context, handler func(fp *types.FinalityProvider, btcDel *types.BTCDelegation)) {
+func (k Keeper) IterateActiveFPsAndBTCDelegations(ctx context.Context, handler func(fp *types.FinalityProvider, btcDel *types.BTCDelegation) bool) {
 	// filter out all finality providers with positive voting power
 	fpIter := k.finalityProviderStore(ctx).Iterator(nil, nil)
 	defer fpIter.Close()
@@ -56,7 +56,10 @@ func (k Keeper) IterateActiveFPsAndBTCDelegations(ctx context.Context, handler f
 						panic(err) // only programming error is possible
 					}
 					btcDel := k.getBTCDelegation(ctx, *stakingTxHash)
-					handler(fp, btcDel)
+					shouldContinue := handler(fp, btcDel)
+					if !shouldContinue {
+						break
+					}
 				}
 			}
 		}()

--- a/x/btcstaking/keeper/voting_power_table_test.go
+++ b/x/btcstaking/keeper/voting_power_table_test.go
@@ -86,8 +86,8 @@ func FuzzVotingPowerTable(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 0}).Times(1)
-		keeper.IndexBTCHeight(ctx)
-		keeper.RecordVotingPowerTable(ctx)
+		keeper.BeginBlocker(ctx)
+
 		for i := uint64(0); i < numFps; i++ {
 			power := keeper.GetVotingPower(ctx, *fps[i].BtcPk, babylonHeight)
 			require.Zero(t, power)
@@ -99,8 +99,8 @@ func FuzzVotingPowerTable(f *testing.F) {
 		babylonHeight += datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.IndexBTCHeight(ctx)
-		keeper.RecordVotingPowerTable(ctx)
+		keeper.BeginBlocker(ctx)
+
 		for i := uint64(0); i < numFpsWithVotingPower; i++ {
 			power := keeper.GetVotingPower(ctx, *fps[i].BtcPk, babylonHeight)
 			require.Equal(t, numBTCDels*stakingValue, power)
@@ -138,8 +138,8 @@ func FuzzVotingPowerTable(f *testing.F) {
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 2}).Times(1)
 		// index height and record power table
-		keeper.IndexBTCHeight(ctx)
-		keeper.RecordVotingPowerTable(ctx)
+		keeper.BeginBlocker(ctx)
+
 		// check if the slashed finality provider's voting power becomes zero
 		for i := uint64(0); i < numFpsWithVotingPower; i++ {
 			power := keeper.GetVotingPower(ctx, *fps[i].BtcPk, babylonHeight)
@@ -171,8 +171,8 @@ func FuzzVotingPowerTable(f *testing.F) {
 		babylonHeight += datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 999}).Times(1)
-		keeper.IndexBTCHeight(ctx)
-		keeper.RecordVotingPowerTable(ctx)
+		keeper.BeginBlocker(ctx)
+
 		for _, fp := range fps {
 			power := keeper.GetVotingPower(ctx, *fp.BtcPk, babylonHeight)
 			require.Zero(t, power)
@@ -261,8 +261,7 @@ func FuzzVotingPowerTable_ActiveFinalityProviders(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.IndexBTCHeight(ctx)
-		keeper.RecordVotingPowerTable(ctx)
+		keeper.BeginBlocker(ctx)
 
 		//  only finality providers in expectedActiveFpsMap have voting power
 		for _, fp := range fpsWithMeta {
@@ -357,8 +356,7 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.IndexBTCHeight(ctx)
-		keeper.RecordVotingPowerTable(ctx)
+		keeper.BeginBlocker(ctx)
 
 		// get maps of active/inactive finality providers
 		activeFpsMap := map[string]uint64{}
@@ -402,8 +400,7 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 		babylonHeight += 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.IndexBTCHeight(ctx)
-		keeper.RecordVotingPowerTable(ctx)
+		keeper.BeginBlocker(ctx)
 
 		// ensure that the activated finality provider now has entered the active finality provider set
 		// i.e., has voting power

--- a/x/btcstaking/keeper/voting_power_table_test.go
+++ b/x/btcstaking/keeper/voting_power_table_test.go
@@ -86,7 +86,8 @@ func FuzzVotingPowerTable(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 0}).Times(1)
-		keeper.BeginBlocker(ctx)
+		err = keeper.BeginBlocker(ctx)
+		require.NoError(t, err)
 
 		for i := uint64(0); i < numFps; i++ {
 			power := keeper.GetVotingPower(ctx, *fps[i].BtcPk, babylonHeight)
@@ -99,7 +100,8 @@ func FuzzVotingPowerTable(f *testing.F) {
 		babylonHeight += datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.BeginBlocker(ctx)
+		err = keeper.BeginBlocker(ctx)
+		require.NoError(t, err)
 
 		for i := uint64(0); i < numFpsWithVotingPower; i++ {
 			power := keeper.GetVotingPower(ctx, *fps[i].BtcPk, babylonHeight)
@@ -138,7 +140,8 @@ func FuzzVotingPowerTable(f *testing.F) {
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 2}).Times(1)
 		// index height and record power table
-		keeper.BeginBlocker(ctx)
+		err = keeper.BeginBlocker(ctx)
+		require.NoError(t, err)
 
 		// check if the slashed finality provider's voting power becomes zero
 		for i := uint64(0); i < numFpsWithVotingPower; i++ {
@@ -171,7 +174,8 @@ func FuzzVotingPowerTable(f *testing.F) {
 		babylonHeight += datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 999}).Times(1)
-		keeper.BeginBlocker(ctx)
+		err = keeper.BeginBlocker(ctx)
+		require.NoError(t, err)
 
 		for _, fp := range fps {
 			power := keeper.GetVotingPower(ctx, *fp.BtcPk, babylonHeight)
@@ -261,7 +265,8 @@ func FuzzVotingPowerTable_ActiveFinalityProviders(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.BeginBlocker(ctx)
+		err = keeper.BeginBlocker(ctx)
+		require.NoError(t, err)
 
 		//  only finality providers in expectedActiveFpsMap have voting power
 		for _, fp := range fpsWithMeta {
@@ -356,7 +361,8 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.BeginBlocker(ctx)
+		err = keeper.BeginBlocker(ctx)
+		require.NoError(t, err)
 
 		// get maps of active/inactive finality providers
 		activeFpsMap := map[string]uint64{}
@@ -400,7 +406,8 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 		babylonHeight += 1
 		ctx = datagen.WithCtxHeight(ctx, babylonHeight)
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 1}).Times(1)
-		keeper.BeginBlocker(ctx)
+		err = keeper.BeginBlocker(ctx)
+		require.NoError(t, err)
 
 		// ensure that the activated finality provider now has entered the active finality provider set
 		// i.e., has voting power

--- a/x/finality/keeper/keeper.go
+++ b/x/finality/keeper/keeper.go
@@ -1,8 +1,9 @@
 package keeper
 
 import (
-	corestoretypes "cosmossdk.io/core/store"
 	"fmt"
+
+	corestoretypes "cosmossdk.io/core/store"
 
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -27,7 +28,6 @@ type (
 func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeService corestoretypes.KVStoreService,
-
 	btctakingKeeper types.BTCStakingKeeper,
 	incentiveKeeper types.IncentiveKeeper,
 	authority string,

--- a/x/finality/types/expected_keepers.go
+++ b/x/finality/types/expected_keepers.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+
 	bstypes "github.com/babylonchain/babylon/x/btcstaking/types"
 )
 
@@ -12,7 +13,6 @@ type BTCStakingKeeper interface {
 	GetVotingPower(ctx context.Context, fpBTCPK []byte, height uint64) uint64
 	GetVotingPowerTable(ctx context.Context, height uint64) map[string]uint64
 	GetBTCStakingActivatedHeight(ctx context.Context) (uint64, error)
-	RecordRewardDistCache(ctx context.Context)
 	GetRewardDistCache(ctx context.Context, height uint64) (*bstypes.RewardDistCache, error)
 	RemoveRewardDistCache(ctx context.Context, height uint64)
 }

--- a/x/finality/types/mocked_keepers.go
+++ b/x/finality/types/mocked_keepers.go
@@ -122,18 +122,6 @@ func (mr *MockBTCStakingKeeperMockRecorder) HasFinalityProvider(ctx, fpBTCPK int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasFinalityProvider", reflect.TypeOf((*MockBTCStakingKeeper)(nil).HasFinalityProvider), ctx, fpBTCPK)
 }
 
-// RecordRewardDistCache mocks base method.
-func (m *MockBTCStakingKeeper) RecordRewardDistCache(ctx context.Context) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RecordRewardDistCache", ctx)
-}
-
-// RecordRewardDistCache indicates an expected call of RecordRewardDistCache.
-func (mr *MockBTCStakingKeeperMockRecorder) RecordRewardDistCache(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordRewardDistCache", reflect.TypeOf((*MockBTCStakingKeeper)(nil).RecordRewardDistCache), ctx)
-}
-
 // RemoveRewardDistCache mocks base method.
 func (m *MockBTCStakingKeeper) RemoveRewardDistCache(ctx context.Context, height uint64) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR optimises the access on iterating all BTC delegations, including

- introducing `IterateActiveFPsAndBTCDelegations` that iterates over all BTC delagtions under non-slashed finality providers. It takes a handler function as input in order to be generic to any usage of iterating BTC delegations.
- merging the computation of voting power table and reward distribution cache by using `IterateActiveFPsAndBTCDelegations`. This reduces DB footprint of `BeginBlock` of BTC staking module by ~half.

This PR gives a speedup and CPU/memory foorprint reduction of 2x for BTC staking module's `BeginBlock`. After this PR, with 10k BTC delegations, `BeginBlock` takes ~0.006s in benchmarking tests.

```log
// current `dev`
BenchmarkBeginBlock_10_100-16               1707          12924721 ns/op         8420903 B/op     193448 allocs/op
// this PR
BenchmarkBeginBlock_10_100-16               4009          5902829 ns/op         3977645 B/op      90454 allocs/op
```

TODOs:
- [x] running benchmarks to verify performance improvment