### PR TITLE
Refactor adding covenant signatures

### DIFF
--- a/x/btcstaking/keeper/btc_delegators.go
+++ b/x/btcstaking/keeper/btc_delegators.go
@@ -54,46 +54,6 @@ func (k Keeper) AddBTCDelegation(ctx context.Context, btcDel *types.BTCDelegatio
 	return nil
 }
 
-// updateBTCDelegation updates an existing BTC delegation w.r.t. finality provider BTC PK, delegator BTC PK,
-// and staking tx hash by using a given function
-func (k Keeper) updateBTCDelegation(
-	ctx context.Context,
-	stakingTxHashStr string,
-	modifyFn func(*types.BTCDelegation) error,
-) error {
-	// get the BTC delegation
-	btcDel, err := k.GetBTCDelegation(ctx, stakingTxHashStr)
-	if err != nil {
-		return err
-	}
-
-	// apply modification
-	if err := modifyFn(btcDel); err != nil {
-		return err
-	}
-
-	// we only need to update the actual BTC delegation object here, without touching
-	// the BTC delegation index
-	k.setBTCDelegation(ctx, btcDel)
-	return nil
-}
-
-func (k Keeper) AddUndelegationToBTCDelegation(
-	ctx context.Context,
-	stakingTxHash string,
-	ud *types.BTCUndelegation,
-) error {
-	addUndelegation := func(btcDel *types.BTCDelegation) error {
-		if btcDel.BtcUndelegation != nil {
-			return fmt.Errorf("the BTC delegation with staking tx hash %s already has valid undelegation object", stakingTxHash)
-		}
-		btcDel.BtcUndelegation = ud
-		return nil
-	}
-
-	return k.updateBTCDelegation(ctx, stakingTxHash, addUndelegation)
-}
-
 // hasBTCDelegatorDelegations checks if the given BTC delegator has any BTC delegations under a given finality provider
 func (k Keeper) hasBTCDelegatorDelegations(ctx context.Context, fpBTCPK *bbn.BIP340PubKey, delBTCPK *bbn.BIP340PubKey) bool {
 	fpBTCPKBytes := fpBTCPK.MustMarshal()

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -401,6 +401,16 @@ func (ms msgServer) AddCovenantSigs(goCtx context.Context, req *types.MsgAddCove
 		return nil, types.ErrInvalidCovenantPK.Wrapf("covenant pk: %s", req.Pk.MarshalHex())
 	}
 
+	if btcDel.IsSignedByCovMember(req.Pk) || btcDel.BtcUndelegation.IsSignedByCovMember(req.Pk) {
+		ms.Logger(ctx).Debug("Received duplicated covenant signature", "covenant pk", req.Pk.MarshalHex())
+		return &types.MsgAddCovenantSigsResponse{}, nil
+	}
+
+	if btcDel.HasCovenantQuorums(params.CovenantQuorum) {
+		ms.Logger(ctx).Debug("Received covenant signature after achieving quorum", "covenant pk", req.Pk.MarshalHex())
+		return &types.MsgAddCovenantSigsResponse{}, nil
+	}
+
 	// Note: we assume the order of adaptor sigs is matched to the
 	// order of finality providers in the delegation
 	// TODO: ensure the order for restaking, currently, we only have one finality provider
@@ -424,7 +434,7 @@ func (ms msgServer) AddCovenantSigs(goCtx context.Context, req *types.MsgAddCove
 		// this fails, it is a programming error
 		panic(err)
 	}
-	err = btcDel.SlashingTx.EncVerifyAdaptorSignatures(
+	parsedSlashingAdaptorSignatures, err := btcDel.SlashingTx.ParseEncVerifyAdaptorSignatures(
 		stakingInfo.StakingOutput,
 		slashingSpendInfo,
 		req.Pk,
@@ -485,7 +495,7 @@ func (ms msgServer) AddCovenantSigs(goCtx context.Context, req *types.MsgAddCove
 		// this fails, it is a programming error
 		panic(err)
 	}
-	err = btcDel.BtcUndelegation.SlashingTx.EncVerifyAdaptorSignatures(
+	parsedUnbondingSlashingAdaptorSignatures, err := btcDel.BtcUndelegation.SlashingTx.ParseEncVerifyAdaptorSignatures(
 		unbondingOutput,
 		unbondingSlashingSpendInfo,
 		req.Pk,
@@ -496,17 +506,11 @@ func (ms msgServer) AddCovenantSigs(goCtx context.Context, req *types.MsgAddCove
 		return nil, types.ErrInvalidCovenantSig.Wrapf("err: %v", err)
 	}
 
-	// all good, add signatures to BTC delegation/undelegation and set it back to KVStore
-	if err := ms.AddCovenantSigsToBTCDelegation(
-		ctx,
-		req.StakingTxHash,
-		req.Pk,
-		req.SlashingTxSigs,
-		req.UnbondingTxSig,
-		req.SlashingUnbondingTxSigs,
-	); err != nil {
-		return nil, types.ErrInvalidCovenantSig.Wrapf("failed to add covenant signatures to BTC delegation: %v", err)
-	}
+	// All is fine add recieved signatures to the BTC delegation and BtcUndelegation
+	btcDel.AddCovenantSigs(req.Pk, parsedSlashingAdaptorSignatures, params.CovenantQuorum)
+	btcDel.BtcUndelegation.AddCovenantSigs(req.Pk, req.UnbondingTxSig, parsedUnbondingSlashingAdaptorSignatures, params.CovenantQuorum)
+
+	ms.setBTCDelegation(ctx, btcDel)
 
 	// notify subscriber
 	if err := ctx.EventManager().EmitTypedEvent(&types.EventActivateBTCDelegation{BtcDel: btcDel}); err != nil {

--- a/x/btcstaking/types/btc_delegation.go
+++ b/x/btcstaking/types/btc_delegation.go
@@ -198,14 +198,23 @@ func (d *BTCDelegation) IsSignedByCovMember(covPk *bbn.BIP340PubKey) bool {
 // AddCovenantSigs adds signatures on the slashing tx from the given
 // covenant, where each signature is an adaptor signature encrypted by
 // each finality provider's PK this BTC delegation restakes to
-func (d *BTCDelegation) AddCovenantSigs(covPk *bbn.BIP340PubKey, sigs []asig.AdaptorSignature, quorum uint32) {
-	adaptorSigs := make([][]byte, 0, len(sigs))
-	for _, s := range sigs {
+// It is up to the caller to ensure that given adaptor signatures are valid or
+// that they were not added before
+func (d *BTCDelegation) AddCovenantSigs(
+	covPk *bbn.BIP340PubKey,
+	stakingSlashingSigs []asig.AdaptorSignature,
+	unbondingSig *bbn.BIP340Signature,
+	unbondingSlashingSigs []asig.AdaptorSignature,
+) {
+	adaptorSigs := make([][]byte, 0, len(stakingSlashingSigs))
+	for _, s := range stakingSlashingSigs {
 		adaptorSigs = append(adaptorSigs, s.MustMarshal())
 	}
 	covSigs := &CovenantAdaptorSignatures{CovPk: covPk, AdaptorSigs: adaptorSigs}
 
 	d.CovenantSigs = append(d.CovenantSigs, covSigs)
+	// add unbonding sig and unbonding slashing adaptor sig
+	d.BtcUndelegation.addCovenantSigs(covPk, unbondingSig, unbondingSlashingSigs)
 }
 
 // GetStakingInfo returns the staking info of the BTC delegation

--- a/x/btcstaking/types/btc_delegation.go
+++ b/x/btcstaking/types/btc_delegation.go
@@ -198,16 +198,7 @@ func (d *BTCDelegation) IsSignedByCovMember(covPk *bbn.BIP340PubKey) bool {
 // AddCovenantSigs adds signatures on the slashing tx from the given
 // covenant, where each signature is an adaptor signature encrypted by
 // each finality provider's PK this BTC delegation restakes to
-func (d *BTCDelegation) AddCovenantSigs(covPk *bbn.BIP340PubKey, sigs []asig.AdaptorSignature, quorum uint32) error {
-	// we can ignore the covenant sig if quorum is already reached
-	if d.HasCovenantQuorums(quorum) {
-		return nil
-	}
-
-	if d.IsSignedByCovMember(covPk) {
-		return nil
-	}
-
+func (d *BTCDelegation) AddCovenantSigs(covPk *bbn.BIP340PubKey, sigs []asig.AdaptorSignature, quorum uint32) {
 	adaptorSigs := make([][]byte, 0, len(sigs))
 	for _, s := range sigs {
 		adaptorSigs = append(adaptorSigs, s.MustMarshal())
@@ -215,8 +206,6 @@ func (d *BTCDelegation) AddCovenantSigs(covPk *bbn.BIP340PubKey, sigs []asig.Ada
 	covSigs := &CovenantAdaptorSignatures{CovPk: covPk, AdaptorSigs: adaptorSigs}
 
 	d.CovenantSigs = append(d.CovenantSigs, covSigs)
-
-	return nil
 }
 
 // GetStakingInfo returns the staking info of the BTC delegation

--- a/x/btcstaking/types/btc_slashing_tx.go
+++ b/x/btcstaking/types/btc_slashing_tx.go
@@ -206,8 +206,8 @@ func (tx *BTCSlashingTx) ParseEncVerifyAdaptorSignatures(
 	sigs [][]byte,
 ) ([]asig.AdaptorSignature, error) {
 	var adaptorSigs []asig.AdaptorSignature = make([]asig.AdaptorSignature, len(sigs))
-	for i, s := range sigs {
-		sig := s
+	for i := range sigs {
+		sig := sigs[i]
 		adaptorSig, err := asig.NewAdaptorSignatureFromBytes(sig)
 		if err != nil {
 			return nil, err

--- a/x/btcstaking/types/btc_undelegation.go
+++ b/x/btcstaking/types/btc_undelegation.go
@@ -72,16 +72,7 @@ func (ud *BTCUndelegation) AddCovenantSigs(
 	unbondingSig *bbn.BIP340Signature,
 	slashingSigs []asig.AdaptorSignature,
 	quorum uint32,
-) error {
-	// we can ignore the covenant slashing sig if quorum is already reached
-	if ud.HasCovenantQuorums(quorum) {
-		return nil
-	}
-
-	if ud.IsSignedByCovMember(covPk) {
-		return nil
-	}
-
+) {
 	covUnbondingSigInfo := &SignatureInfo{Pk: covPk, Sig: unbondingSig}
 	ud.CovenantUnbondingSigList = append(ud.CovenantUnbondingSigList, covUnbondingSigInfo)
 
@@ -91,6 +82,4 @@ func (ud *BTCUndelegation) AddCovenantSigs(
 	}
 	slashingSigsInfo := &CovenantAdaptorSignatures{CovPk: covPk, AdaptorSigs: adaptorSigs}
 	ud.CovenantSlashingSigs = append(ud.CovenantSlashingSigs, slashingSigsInfo)
-
-	return nil
 }

--- a/x/btcstaking/types/btc_undelegation.go
+++ b/x/btcstaking/types/btc_undelegation.go
@@ -67,11 +67,12 @@ func (ud *BTCUndelegation) GetCovSlashingAdaptorSig(
 // a list of adaptor signatures on the unbonding slashing tx, each encrypted
 // by a finality provider's PK this BTC delegation restakes to, from the given
 // covenant
-func (ud *BTCUndelegation) AddCovenantSigs(
+// It is up to the caller to ensure that given adaptor signatures are valid or
+// that they were not added before
+func (ud *BTCUndelegation) addCovenantSigs(
 	covPk *bbn.BIP340PubKey,
 	unbondingSig *bbn.BIP340Signature,
 	slashingSigs []asig.AdaptorSignature,
-	quorum uint32,
 ) {
 	covUnbondingSigInfo := &SignatureInfo{Pk: covPk, Sig: unbondingSig}
 	ud.CovenantUnbondingSigList = append(ud.CovenantUnbondingSigList, covUnbondingSigInfo)


### PR DESCRIPTION
Small non-breaking refactor of adding covenant signatures, also fixes some issues when processing covenant signatures message. Up until now:

- for every received covenant signatures message, we retrieved delegation from database two times: once at the beginning of processing message, and the second time when saving it to database (as our save was actually save-modify-write). 
Just to put that in context, for 100k delegation, this is 100k not necessary random database reads. Or actually more, as even  when we already reached quorum, and we were ignoring incoming covenant signatures, we still retrieved delegation second time from database just to not apply any changes to it.
- even though we ignored received signatures if quorum was already reached we emitted `&types.EventActivateBTCDelegation{BtcDel: btcDel}` event
- when quorum has already been reached or covenant member already voted we have gone through whole message processing, to just ignore all the results at the end.