### PR TITLE
fix: fix flaky test `FuzzWithdrawReward`

### DIFF
--- a/testutil/datagen/incentive.go
+++ b/testutil/datagen/incentive.go
@@ -62,8 +62,10 @@ func GenRandomWithdrawnCoins(r *rand.Rand, coins sdk.Coins) sdk.Coins {
 			continue
 		}
 		// a subset of the coin has been withdrawn
-		amount := coin.Amount.Uint64()
-		withdrawnAmount := RandomInt(r, int(amount)-1) + 1
+		withdrawnAmount := coin.Amount.Uint64()
+		if withdrawnAmount > 1 {
+			withdrawnAmount = RandomInt(r, int(withdrawnAmount)-1) + 1
+		}
 		withdrawnCoin := sdk.NewCoin(coin.Denom, sdkmath.NewIntFromUint64(withdrawnAmount))
 		withdrawnCoins = withdrawnCoins.Add(withdrawnCoin)
 	}


### PR DESCRIPTION
`FuzzWithdrawReward` was [flaky](https://app.circleci.com/pipelines/github/babylonchain/babylon/2019/workflows/6b2a669d-867e-446e-a218-f7d49b7090df/jobs/3399) because `amount` [here](https://github.com/babylonchain/babylon/blob/396a712297f97cd8ca225bcea81ee9b02dada991/testutil/datagen/incentive.go#L65-L66) might be 1, making `RandomInt` panic. This PR fixes it by adding a check. Fuzzed the test locally and the fix works.