### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.8.0](https://github.com/babylonchain/babylon/tree/v0.8.0) (2024-02-08)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.8.0-rc.0...v0.8.0)
+
 ## [v0.8.0-rc.0](https://github.com/babylonchain/babylon/tree/v0.8.0-rc.0) (2024-01-22)
 
 [Full Changelog](https://github.com/babylonchain/babylon/compare/v0.7.2...v0.8.0-rc.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,526 @@
 # Changelog
+
+## [v0.8.0-rc.0](https://github.com/babylonchain/babylon/tree/v0.8.0-rc.0) (2024-01-22)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.7.2...v0.8.0-rc.0)
+
+**Closed issues:**
+
+- Dead Link in the Git "Joining the testnet"  [\#406](https://github.com/babylonchain/babylon/issues/406)
+- Broken link for testnet in the main README.md [\#403](https://github.com/babylonchain/babylon/issues/403)
+- Random failure when running integration test [\#319](https://github.com/babylonchain/babylon/issues/319)
+- Refactor BLS signer to load gas settings during initiation [\#311](https://github.com/babylonchain/babylon/issues/311)
+- Random CI failure on QueryFinalizedChainInfo [\#288](https://github.com/babylonchain/babylon/issues/288)
+
+**Merged pull requests:**
+
+- chore: add parameter sections for module docs [\#418](https://github.com/babylonchain/babylon/pull/418) ([SebastianElvis](https://github.com/SebastianElvis))
+- doc: documentation for the epoching module [\#416](https://github.com/babylonchain/babylon/pull/416) ([SebastianElvis](https://github.com/SebastianElvis))
+- fix: making zoneconcierge resilient against long BTC reorg \(again\) [\#413](https://github.com/babylonchain/babylon/pull/413) ([SebastianElvis](https://github.com/SebastianElvis))
+- BTC Staking [\#409](https://github.com/babylonchain/babylon/pull/409) ([vitsalis](https://github.com/vitsalis))
+- Fix typos  [\#405](https://github.com/babylonchain/babylon/pull/405) ([AtomicInnovation321](https://github.com/AtomicInnovation321))
+- Updated testnet link [\#404](https://github.com/babylonchain/babylon/pull/404) ([kunallimaye](https://github.com/kunallimaye))
+- README: updating discord link [\#402](https://github.com/babylonchain/babylon/pull/402) ([GakiBash](https://github.com/GakiBash))
+- README: Add medium link [\#400](https://github.com/babylonchain/babylon/pull/400) ([EdwardFanfan](https://github.com/EdwardFanfan))
+- Bump comet bft [\#399](https://github.com/babylonchain/babylon/pull/399) ([KonradStaniec](https://github.com/KonradStaniec))
+- hotfix: Barberry upgrade [\#398](https://github.com/babylonchain/babylon/pull/398) ([vitsalis](https://github.com/vitsalis))
+- Bump wasmd to stable [\#396](https://github.com/babylonchain/babylon/pull/396) ([KonradStaniec](https://github.com/KonradStaniec))
+- hotfix: fixing marshaling of MsgWrappedCreateValidator [\#394](https://github.com/babylonchain/babylon/pull/394) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: adding a flag for retrieving proofs of a FinalizedChainInfo [\#391](https://github.com/babylonchain/babylon/pull/391) ([SebastianElvis](https://github.com/SebastianElvis))
+- e2e: merge integration tests with e2e tests [\#390](https://github.com/babylonchain/babylon/pull/390) ([SebastianElvis](https://github.com/SebastianElvis))
+
+## [v0.7.2](https://github.com/babylonchain/babylon/tree/v0.7.2) (2023-06-10)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.7.1...v0.7.2)
+
+## [v0.7.1](https://github.com/babylonchain/babylon/tree/v0.7.1) (2023-05-30)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.7.0...v0.7.1)
+
+**Closed issues:**
+
+- zoneconcierge: parameterise timeout for IBC packets [\#207](https://github.com/babylonchain/babylon/issues/207)
+
+**Merged pull requests:**
+
+- hotfix: fixing marshaling of `MsgWrappedCreateValidator` [\#393](https://github.com/babylonchain/babylon/pull/393) ([SebastianElvis](https://github.com/SebastianElvis))
+
+## [v0.7.0](https://github.com/babylonchain/babylon/tree/v0.7.0) (2023-05-26)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.6.0...v0.7.0)
+
+**Closed issues:**
+
+- Nil hooks [\#214](https://github.com/babylonchain/babylon/issues/214)
+
+**Merged pull requests:**
+
+- Release v0.7.0 [\#388](https://github.com/babylonchain/babylon/pull/388) ([vitsalis](https://github.com/vitsalis))
+- zoneconcierge: adding header timestamp to IndexedHeader [\#387](https://github.com/babylonchain/babylon/pull/387) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: parameterise timeout for IBC packets [\#386](https://github.com/babylonchain/babylon/pull/386) ([SebastianElvis](https://github.com/SebastianElvis))
+- CI: Push images for dev branch commits [\#385](https://github.com/babylonchain/babylon/pull/385) ([filippos47](https://github.com/filippos47))
+- dockerfile: opt out version when building [\#384](https://github.com/babylonchain/babylon/pull/384) ([SebastianElvis](https://github.com/SebastianElvis))
+- Use fee module [\#383](https://github.com/babylonchain/babylon/pull/383) ([KonradStaniec](https://github.com/KonradStaniec))
+- Bump vulnerable docker/distribution [\#382](https://github.com/babylonchain/babylon/pull/382) ([vitsalis](https://github.com/vitsalis))
+- Bump wasmd to rc2 [\#381](https://github.com/babylonchain/babylon/pull/381) ([KonradStaniec](https://github.com/KonradStaniec))
+- Add wasm e2e test [\#380](https://github.com/babylonchain/babylon/pull/380) ([KonradStaniec](https://github.com/KonradStaniec))
+- phase2: IBC packet and logic [\#368](https://github.com/babylonchain/babylon/pull/368) ([SebastianElvis](https://github.com/SebastianElvis))
+
+## [v0.6.0](https://github.com/babylonchain/babylon/tree/v0.6.0) (2023-05-10)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.6.0rc0...v0.6.0)
+
+**Merged pull requests:**
+
+- Release v0.6.0 [\#379](https://github.com/babylonchain/babylon/pull/379) ([vitsalis](https://github.com/vitsalis))
+- Fix non-determinism in integration test [\#377](https://github.com/babylonchain/babylon/pull/377) ([KonradStaniec](https://github.com/KonradStaniec))
+- Fix consensus version in our custom modules [\#376](https://github.com/babylonchain/babylon/pull/376) ([KonradStaniec](https://github.com/KonradStaniec))
+- Add fuzz test for epoch finalization/confirmation [\#375](https://github.com/babylonchain/babylon/pull/375) ([KonradStaniec](https://github.com/KonradStaniec))
+
+## [v0.6.0rc0](https://github.com/babylonchain/babylon/tree/v0.6.0rc0) (2023-05-04)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.6.0-rc0...v0.6.0rc0)
+
+## [v0.6.0-rc0](https://github.com/babylonchain/babylon/tree/v0.6.0-rc0) (2023-05-04)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/devnet...v0.6.0-rc0)
+
+**Merged pull requests:**
+
+- use tagged branch in test contract [\#374](https://github.com/babylonchain/babylon/pull/374) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: Reduce default number of tests from 100 to 10 [\#373](https://github.com/babylonchain/babylon/pull/373) ([vitsalis](https://github.com/vitsalis))
+- feat: new rpc RawCheckpoints [\#372](https://github.com/babylonchain/babylon/pull/372) ([gusin13](https://github.com/gusin13))
+- chore: circleci: Use image with go 1.20.3 installed [\#371](https://github.com/babylonchain/babylon/pull/371) ([vitsalis](https://github.com/vitsalis))
+- Improve btccheckpointinfo rpc [\#370](https://github.com/babylonchain/babylon/pull/370) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: Add support for multiple chain ids in EpochChainsInfo API [\#369](https://github.com/babylonchain/babylon/pull/369) ([gusin13](https://github.com/gusin13))
+- Fix bug in submission btc info [\#367](https://github.com/babylonchain/babylon/pull/367) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: Bump Cosmos SDK to v0.47.2 and minor bug fix [\#366](https://github.com/babylonchain/babylon/pull/366) ([vitsalis](https://github.com/vitsalis))
+- feat: support multiple chain ids in FinalizedChainsInfo [\#365](https://github.com/babylonchain/babylon/pull/365) ([gusin13](https://github.com/gusin13))
+- chore: Update runc and docker dependencies due to security alerts [\#364](https://github.com/babylonchain/babylon/pull/364) ([vitsalis](https://github.com/vitsalis))
+- chore: Replace deprecated `rand.Seed` with dedicated datagen random generators [\#363](https://github.com/babylonchain/babylon/pull/363) ([vitsalis](https://github.com/vitsalis))
+- feat: support multiple chain ids in zoneconcierge chains info api  [\#362](https://github.com/babylonchain/babylon/pull/362) ([gusin13](https://github.com/gusin13))
+- Add last block height to finalized epoch info [\#361](https://github.com/babylonchain/babylon/pull/361) ([KonradStaniec](https://github.com/KonradStaniec))
+- Version bumps [\#358](https://github.com/babylonchain/babylon/pull/358) ([KonradStaniec](https://github.com/KonradStaniec))
+- fix: Make testnet command produce addresses bound to the host IP [\#357](https://github.com/babylonchain/babylon/pull/357) ([vitsalis](https://github.com/vitsalis))
+- Move checkpoint tag to params [\#356](https://github.com/babylonchain/babylon/pull/356) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: Use more descriptive error message for using wrapped transactions [\#355](https://github.com/babylonchain/babylon/pull/355) ([vitsalis](https://github.com/vitsalis))
+- chore: Enable building docker image with unpushed changes [\#354](https://github.com/babylonchain/babylon/pull/354) ([vitsalis](https://github.com/vitsalis))
+- Handle btc related wasm queries [\#353](https://github.com/babylonchain/babylon/pull/353) ([KonradStaniec](https://github.com/KonradStaniec))
+- fix: fix query height in `ProveEpochSealed` [\#352](https://github.com/babylonchain/babylon/pull/352) ([SebastianElvis](https://github.com/SebastianElvis))
+- fix: fixing the bug in generating proof of sealed epoch [\#351](https://github.com/babylonchain/babylon/pull/351) ([SebastianElvis](https://github.com/SebastianElvis))
+- testnet: Add flag for time between blocks [\#134](https://github.com/babylonchain/babylon/pull/134) ([vitsalis](https://github.com/vitsalis))
+
+## [devnet](https://github.com/babylonchain/babylon/tree/devnet) (2023-04-17)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/test...devnet)
+
+**Breaking changes:**
+
+- fix gas cost of insert header [\#309](https://github.com/babylonchain/babylon/pull/309) ([KonradStaniec](https://github.com/KonradStaniec))
+
+**Closed issues:**
+
+- Remove `handler.go` from modules [\#336](https://github.com/babylonchain/babylon/issues/336)
+
+**Merged pull requests:**
+
+- Add support for querying for latest finalized epoch [\#350](https://github.com/babylonchain/babylon/pull/350) ([KonradStaniec](https://github.com/KonradStaniec))
+- Use block gas limit when defining genesis [\#349](https://github.com/babylonchain/babylon/pull/349) ([KonradStaniec](https://github.com/KonradStaniec))
+- fix: Use the account specified in app.toml to sign BLS transactions [\#348](https://github.com/babylonchain/babylon/pull/348) ([vitsalis](https://github.com/vitsalis))
+- Custom bindings for smart contracts [\#347](https://github.com/babylonchain/babylon/pull/347) ([KonradStaniec](https://github.com/KonradStaniec))
+- fix: Make e2e tests work with new docker image [\#345](https://github.com/babylonchain/babylon/pull/345) ([vitsalis](https://github.com/vitsalis))
+- Migrate epoching and btccheckpointing module to new way of handling params [\#344](https://github.com/babylonchain/babylon/pull/344) ([KonradStaniec](https://github.com/KonradStaniec))
+- Feature/lint proto ci [\#343](https://github.com/babylonchain/babylon/pull/343) ([KonradStaniec](https://github.com/KonradStaniec))
+- Re-enable e2e tests [\#342](https://github.com/babylonchain/babylon/pull/342) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: Parallelize CircleCI lint build [\#341](https://github.com/babylonchain/babylon/pull/341) ([vitsalis](https://github.com/vitsalis))
+- docker: Refactor to a lightweight unified image [\#340](https://github.com/babylonchain/babylon/pull/340) ([danbryan](https://github.com/danbryan))
+- chore: set up OpenAPI [\#339](https://github.com/babylonchain/babylon/pull/339) ([fadeev](https://github.com/fadeev))
+- refactor: remove `handler.go` files from modules [\#337](https://github.com/babylonchain/babylon/pull/337) ([fadeev](https://github.com/fadeev))
+- Cleanup params in Babylon custom modules. [\#334](https://github.com/babylonchain/babylon/pull/334) ([KonradStaniec](https://github.com/KonradStaniec))
+- zoneconcierge: moving extended client keeper to Babylon repo [\#333](https://github.com/babylonchain/babylon/pull/333) ([SebastianElvis](https://github.com/SebastianElvis))
+- Use new version for our fork of ibc go [\#332](https://github.com/babylonchain/babylon/pull/332) ([KonradStaniec](https://github.com/KonradStaniec))
+- proto: fix proto-linter comments for epoching/zoneconcierge [\#331](https://github.com/babylonchain/babylon/pull/331) ([SebastianElvis](https://github.com/SebastianElvis))
+- Fix proto linter comments in btccheckpoint and monitor [\#330](https://github.com/babylonchain/babylon/pull/330) ([KonradStaniec](https://github.com/KonradStaniec))
+- proto-lint: Add comments to btclightclient and checkpointing proto files [\#329](https://github.com/babylonchain/babylon/pull/329) ([vitsalis](https://github.com/vitsalis))
+- CI: Build and push Docker image to ECR [\#328](https://github.com/babylonchain/babylon/pull/328) ([filippos47](https://github.com/filippos47))
+- Bump cosmos-sdk to stable version [\#327](https://github.com/babylonchain/babylon/pull/327) ([KonradStaniec](https://github.com/KonradStaniec))
+- Integrate wasmd [\#324](https://github.com/babylonchain/babylon/pull/324) ([KonradStaniec](https://github.com/KonradStaniec))
+- Migrate to comet bft [\#323](https://github.com/babylonchain/babylon/pull/323) ([KonradStaniec](https://github.com/KonradStaniec))
+- Update protobuf generation [\#322](https://github.com/babylonchain/babylon/pull/322) ([KonradStaniec](https://github.com/KonradStaniec))
+- Use cosmos v47 [\#320](https://github.com/babylonchain/babylon/pull/320) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: Add balance check before inserting MsgWrappedCreateValidator into the epoch message queue [\#318](https://github.com/babylonchain/babylon/pull/318) ([gitferry](https://github.com/gitferry))
+- checkpointing: stateless checks on `MsgCreateValidator` [\#316](https://github.com/babylonchain/babylon/pull/316) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: Add fuzz test of addBlsSig [\#313](https://github.com/babylonchain/babylon/pull/313) ([gitferry](https://github.com/gitferry))
+- btccheckpoint: Add information about transactions to BTCCheckpointInfo [\#312](https://github.com/babylonchain/babylon/pull/312) ([vitsalis](https://github.com/vitsalis))
+- chore: Keep a single encoding config in the application [\#308](https://github.com/babylonchain/babylon/pull/308) ([gitferry](https://github.com/gitferry))
+- feat: Checkpointing/Add fee estimation in sending BLS-sig tx [\#307](https://github.com/babylonchain/babylon/pull/307) ([gitferry](https://github.com/gitferry))
+- prepare-genesis cmd: Add flags related to inflation [\#306](https://github.com/babylonchain/babylon/pull/306) ([vitsalis](https://github.com/vitsalis))
+- fix: remove `start_epoch` and `end_epoch` parameters in APIs [\#305](https://github.com/babylonchain/babylon/pull/305) ([SebastianElvis](https://github.com/SebastianElvis))
+- Fix whitespace for Make 4.3 [\#303](https://github.com/babylonchain/babylon/pull/303) ([freshe4qa](https://github.com/freshe4qa))
+
+## [test](https://github.com/babylonchain/babylon/tree/test) (2023-03-17)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.5.0...test)
+
+**Implemented enhancements:**
+
+- Fees as a parameter for the BlsSig transaction [\#168](https://github.com/babylonchain/babylon/issues/168)
+
+**Fixed bugs:**
+
+- flaky Test: `TestRawCheckpointWithMeta_Accumulate4` [\#124](https://github.com/babylonchain/babylon/issues/124)
+
+**Closed issues:**
+
+- Use proto linter and formatter  [\#321](https://github.com/babylonchain/babylon/issues/321)
+- Lack of balance check before inserting MsgWrappedCreateValidator into the message queue [\#317](https://github.com/babylonchain/babylon/issues/317)
+- Duplicate txs queued in the same epoch show inconsistent execution result [\#314](https://github.com/babylonchain/babylon/issues/314)
+- Redundant pagination parameters in API [\#304](https://github.com/babylonchain/babylon/issues/304)
+- Chain died on block 621 [\#302](https://github.com/babylonchain/babylon/issues/302)
+- Add test for adding a BLS-sig transaction [\#279](https://github.com/babylonchain/babylon/issues/279)
+- Add logs to show the submitter of each BLS-sig transaction [\#278](https://github.com/babylonchain/babylon/issues/278)
+- zoneconcierge: API for querying submitted/confirmed chain info [\#212](https://github.com/babylonchain/babylon/issues/212)
+- Validators should stop submitting BLS-sigs when they are syncing [\#182](https://github.com/babylonchain/babylon/issues/182)
+- Accept encoding config in `InitPrivSigner` function instead of creating it. [\#174](https://github.com/babylonchain/babylon/issues/174)
+- Improving Undelegating Requests and Lifecycle [\#159](https://github.com/babylonchain/babylon/issues/159)
+
+## [v0.5.0](https://github.com/babylonchain/babylon/tree/v0.5.0) (2023-02-03)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.4.0...v0.5.0)
+
+**Breaking changes:**
+
+- Improve btc checkpoint data model [\#284](https://github.com/babylonchain/babylon/pull/284) ([KonradStaniec](https://github.com/KonradStaniec))
+
+**Fixed bugs:**
+
+- Fix vulnerability when processing bls sig transactions [\#287](https://github.com/babylonchain/babylon/pull/287) ([KonradStaniec](https://github.com/KonradStaniec))
+
+**Closed issues:**
+
+- Error results in RawCheckpointList [\#280](https://github.com/babylonchain/babylon/issues/280)
+- Creating a validator after the chain has been running for a while leads to the validator never becoming bonded. [\#275](https://github.com/babylonchain/babylon/issues/275)
+- Flaky zoneconcierge test [\#251](https://github.com/babylonchain/babylon/issues/251)
+- go 1.19 [\#227](https://github.com/babylonchain/babylon/issues/227)
+
+**Merged pull requests:**
+
+- Release v0.5.0 [\#301](https://github.com/babylonchain/babylon/pull/301) ([vitsalis](https://github.com/vitsalis))
+- zoneconcierge API: pagtinating chain IDs API [\#300](https://github.com/babylonchain/babylon/pull/300) ([SebastianElvis](https://github.com/SebastianElvis))
+- Fix: Monitor/fix reported checkpoint BTC height query bugs [\#299](https://github.com/babylonchain/babylon/pull/299) ([gitferry](https://github.com/gitferry))
+- Add Apache 2.0 licence [\#298](https://github.com/babylonchain/babylon/pull/298) ([vitsalis](https://github.com/vitsalis))
+- Clean and split up README [\#297](https://github.com/babylonchain/babylon/pull/297) ([vitsalis](https://github.com/vitsalis))
+- fix: add BLST\_PORTABLE flag before build instruction [\#295](https://github.com/babylonchain/babylon/pull/295) ([vitsalis](https://github.com/vitsalis))
+- btccheckpoint API: enriching existing APIs with `BTCCheckpointInfo` [\#294](https://github.com/babylonchain/babylon/pull/294) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: Remove checkpointing spec [\#293](https://github.com/babylonchain/babylon/pull/293) ([gitferry](https://github.com/gitferry))
+- API: add parameters to range queries and improve outputs [\#292](https://github.com/babylonchain/babylon/pull/292) ([SebastianElvis](https://github.com/SebastianElvis))
+- btccheckpoint API: range query for BTC checkpoints [\#291](https://github.com/babylonchain/babylon/pull/291) ([SebastianElvis](https://github.com/SebastianElvis))
+- btccheckpoint API: add hash to `BtcCheckpointHeightAndHash` API [\#290](https://github.com/babylonchain/babylon/pull/290) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching: range query for epochs [\#289](https://github.com/babylonchain/babylon/pull/289) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: Monitor/Add new KV and query for checkpoint reported btc height [\#286](https://github.com/babylonchain/babylon/pull/286) ([gitferry](https://github.com/gitferry))
+- zoneconcierge: proper initialisation for chain info [\#285](https://github.com/babylonchain/babylon/pull/285) ([SebastianElvis](https://github.com/SebastianElvis))
+- fix: API/Fix checkpoint list total error [\#283](https://github.com/babylonchain/babylon/pull/283) ([gitferry](https://github.com/gitferry))
+- fix: Fix pagination error of RawCheckpointList [\#282](https://github.com/babylonchain/babylon/pull/282) ([gitferry](https://github.com/gitferry))
+- Bump btcd versions to fix 2 consensus issues [\#281](https://github.com/babylonchain/babylon/pull/281) ([KonradStaniec](https://github.com/KonradStaniec))
+- fix: add HTTP URL for LastCheckpointWithStatusRequest [\#277](https://github.com/babylonchain/babylon/pull/277) ([gitferry](https://github.com/gitferry))
+- epoching/checkpointing: fuzz test for validators with zero voting power [\#276](https://github.com/babylonchain/babylon/pull/276) ([SebastianElvis](https://github.com/SebastianElvis))
+- Add simple monitor module [\#274](https://github.com/babylonchain/babylon/pull/274) ([KonradStaniec](https://github.com/KonradStaniec))
+- fix: checkpointing: Do not make the `home` flag a required one and unmarshall PubKey \(\#271\) [\#271](https://github.com/babylonchain/babylon/pull/271) ([vitsalis](https://github.com/vitsalis))
+- Fix: Increase gas in e2e test [\#270](https://github.com/babylonchain/babylon/pull/270) ([KonradStaniec](https://github.com/KonradStaniec))
+- Add integration test for zoneconcierge checkpointing [\#269](https://github.com/babylonchain/babylon/pull/269) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: refactor `FinalizedChainInfo` API [\#268](https://github.com/babylonchain/babylon/pull/268) ([SebastianElvis](https://github.com/SebastianElvis))
+- checkpointing API: add checkpoint lifecycle in `RawCheckpointWithMeta` [\#267](https://github.com/babylonchain/babylon/pull/267) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge API: find header and fork headers at a given height [\#266](https://github.com/babylonchain/babylon/pull/266) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge API: find the BTC-finalised chain info before specific CZ height [\#264](https://github.com/babylonchain/babylon/pull/264) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge API: adding total number of timestamped headers to chainInfo [\#263](https://github.com/babylonchain/babylon/pull/263) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: API for querying headers in a given epoch [\#261](https://github.com/babylonchain/babylon/pull/261) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: API for querying the chain info of a given epoch [\#260](https://github.com/babylonchain/babylon/pull/260) ([SebastianElvis](https://github.com/SebastianElvis))
+- add e2e test to CI [\#259](https://github.com/babylonchain/babylon/pull/259) ([KonradStaniec](https://github.com/KonradStaniec))
+- Bump golang to 1.19 [\#257](https://github.com/babylonchain/babylon/pull/257) ([KonradStaniec](https://github.com/KonradStaniec))
+- zoneconcierge: fix flaky test `FuzzProofEpochSealed_BLSSig` [\#256](https://github.com/babylonchain/babylon/pull/256) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: ignore out-of-order headers in ZoneConcierge [\#255](https://github.com/babylonchain/babylon/pull/255) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: API for listing the last checkpointed headers [\#254](https://github.com/babylonchain/babylon/pull/254) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: Add new query for the last checkpoint with a given status [\#253](https://github.com/babylonchain/babylon/pull/253) ([gitferry](https://github.com/gitferry))
+
+## [v0.4.0](https://github.com/babylonchain/babylon/tree/v0.4.0) (2022-12-20)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.3.0...v0.4.0)
+
+**Closed issues:**
+
+- epoching: excessive `absent validator` logs during simulation [\#75](https://github.com/babylonchain/babylon/issues/75)
+
+**Merged pull requests:**
+
+- Release v0.4.0 [\#252](https://github.com/babylonchain/babylon/pull/252) ([vitsalis](https://github.com/vitsalis))
+- zoneconcierge: typos and rename filenames [\#250](https://github.com/babylonchain/babylon/pull/250) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: Introduce more control over home directory name for localnet [\#249](https://github.com/babylonchain/babylon/pull/249) ([vitsalis](https://github.com/vitsalis))
+- zoneconcierge/epoching: proof that a header is in an epoch [\#248](https://github.com/babylonchain/babylon/pull/248) ([SebastianElvis](https://github.com/SebastianElvis))
+- Add e2e testing framework based on Osmosis [\#247](https://github.com/babylonchain/babylon/pull/247) ([KonradStaniec](https://github.com/KonradStaniec))
+- zoneconcierge: verifier for `ProofEpochSubmitted` [\#246](https://github.com/babylonchain/babylon/pull/246) ([SebastianElvis](https://github.com/SebastianElvis))
+- Add versioning based on Git names for the executable [\#245](https://github.com/babylonchain/babylon/pull/245) ([vitsalis](https://github.com/vitsalis))
+- Fix: Resolve linting errors [\#244](https://github.com/babylonchain/babylon/pull/244) ([vitsalis](https://github.com/vitsalis))
+- zoneconcierge: query inclusion proofs and add them to `ProofEpochSealed` [\#243](https://github.com/babylonchain/babylon/pull/243) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: Add kv for validator BLS key set [\#242](https://github.com/babylonchain/babylon/pull/242) ([gitferry](https://github.com/gitferry))
+- zoneconcierge: verifying BLS multisig in `ProofEpochSealed`  [\#241](https://github.com/babylonchain/babylon/pull/241) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: Unify bitmap length [\#240](https://github.com/babylonchain/babylon/pull/240) ([gitferry](https://github.com/gitferry))
+- zoneconcierge: enriching `SubmissionData` to store BTCSpvProof [\#239](https://github.com/babylonchain/babylon/pull/239) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: Move functionalities from the verifier [\#238](https://github.com/babylonchain/babylon/pull/238) ([gitferry](https://github.com/gitferry))
+- zoneconcierge: proof of a sealed epoch and make proof generation optional [\#237](https://github.com/babylonchain/babylon/pull/237) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching: API for querying the validator set of a given epoch [\#236](https://github.com/babylonchain/babylon/pull/236) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: Add voting power to BLS key set API [\#235](https://github.com/babylonchain/babylon/pull/235) ([gitferry](https://github.com/gitferry))
+- zoneconcierge: proof that a tx is in a block [\#234](https://github.com/babylonchain/babylon/pull/234) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: repurpose heartbeat mechanism to a generic function [\#233](https://github.com/babylonchain/babylon/pull/233) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: Add bls pubkey set api [\#232](https://github.com/babylonchain/babylon/pull/232) ([gitferry](https://github.com/gitferry))
+- golangci-lint [\#222](https://github.com/babylonchain/babylon/pull/222) ([faddat](https://github.com/faddat))
+
+## [v0.3.0](https://github.com/babylonchain/babylon/tree/v0.3.0) (2022-11-30)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.2.0...v0.3.0)
+
+**Breaking changes:**
+
+- Submission pruning improvements [\#204](https://github.com/babylonchain/babylon/pull/204) ([KonradStaniec](https://github.com/KonradStaniec))
+
+**Closed issues:**
+
+- zoneconcierge: Chain info indexer snapshots the latest chain info for each epoch even without any relayer [\#220](https://github.com/babylonchain/babylon/issues/220)
+
+**Merged pull requests:**
+
+- Release v0.3.0 [\#231](https://github.com/babylonchain/babylon/pull/231) ([vitsalis](https://github.com/vitsalis))
+- doc: update swagger yml file [\#230](https://github.com/babylonchain/babylon/pull/230) ([SebastianElvis](https://github.com/SebastianElvis))
+- fix: Update verification rule for btc raw checkpoints [\#229](https://github.com/babylonchain/babylon/pull/229) ([gitferry](https://github.com/gitferry))
+- zoneconcierge: API route [\#228](https://github.com/babylonchain/babylon/pull/228) ([SebastianElvis](https://github.com/SebastianElvis))
+- Bump protogen cosmos [\#226](https://github.com/babylonchain/babylon/pull/226) ([vitsalis](https://github.com/vitsalis))
+- chore: Remove starport references [\#225](https://github.com/babylonchain/babylon/pull/225) ([faddat](https://github.com/faddat))
+- bump ledger and cosmos-proto [\#223](https://github.com/babylonchain/babylon/pull/223) ([faddat](https://github.com/faddat))
+- zoneconcierge: find the earliest epoch that finalised a chain info for the API [\#221](https://github.com/babylonchain/babylon/pull/221) ([SebastianElvis](https://github.com/SebastianElvis))
+- bump deps [\#218](https://github.com/babylonchain/babylon/pull/218) ([faddat](https://github.com/faddat))
+- fix: fixed marshaling issue when enqueueing CreateValidator message and added tests [\#215](https://github.com/babylonchain/babylon/pull/215) ([gitferry](https://github.com/gitferry))
+
+## [v0.2.0](https://github.com/babylonchain/babylon/tree/v0.2.0) (2022-11-23)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/v0.1.0...v0.2.0)
+
+**Fixed bugs:**
+
+- Concurrent issue when sending BLS-sig tx in a gorouting [\#197](https://github.com/babylonchain/babylon/issues/197)
+
+**Closed issues:**
+
+- Make FromName an attribute in app.toml [\#188](https://github.com/babylonchain/babylon/issues/188)
+- Add correspondence check for genesis BLS keys and genesis txs [\#180](https://github.com/babylonchain/babylon/issues/180)
+
+**Merged pull requests:**
+
+- Release v0.2.0 [\#217](https://github.com/babylonchain/babylon/pull/217) ([vitsalis](https://github.com/vitsalis))
+- hotfix: fixing the hook issue in `app.go` [\#213](https://github.com/babylonchain/babylon/pull/213) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: debugging API `ChainInfo` [\#211](https://github.com/babylonchain/babylon/pull/211) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: add checkpoint info and epoch info to `FinalizedChainInfo` API [\#210](https://github.com/babylonchain/babylon/pull/210) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: restrict the used port for IBC [\#209](https://github.com/babylonchain/babylon/pull/209) ([SebastianElvis](https://github.com/SebastianElvis))
+- fix: Use better short description for the babylond executable [\#208](https://github.com/babylonchain/babylon/pull/208) ([vitsalis](https://github.com/vitsalis))
+- IBC: bug fixes for creating IBC channels [\#206](https://github.com/babylonchain/babylon/pull/206) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: API for listing all chain IDs [\#205](https://github.com/babylonchain/babylon/pull/205) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: fuzz tests for various indexers [\#203](https://github.com/babylonchain/babylon/pull/203) ([SebastianElvis](https://github.com/SebastianElvis))
+- fix: Resolved concurrency issue when sending BLS-sig txs [\#202](https://github.com/babylonchain/babylon/pull/202) ([gitferry](https://github.com/gitferry))
+- zoneconcierge: track latest BTC-finalised header and add the query [\#201](https://github.com/babylonchain/babylon/pull/201) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: subscribe to checkpointing/epoching's hooks, and add a new hooks [\#200](https://github.com/babylonchain/babylon/pull/200) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: Add signer key name into app custom config [\#199](https://github.com/babylonchain/babylon/pull/199) ([gitferry](https://github.com/gitferry))
+- feat: Introduce swagger docs for RPC queries  [\#198](https://github.com/babylonchain/babylon/pull/198) ([vitsalis](https://github.com/vitsalis))
+- feat: Add genesis time on genesis parameters [\#196](https://github.com/babylonchain/babylon/pull/196) ([vitsalis](https://github.com/vitsalis))
+- zoneconcierge: heartbeat IBC packet to keep relayer awake [\#195](https://github.com/babylonchain/babylon/pull/195) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: test infra for IBC and vanilla tests [\#193](https://github.com/babylonchain/babylon/pull/193) ([SebastianElvis](https://github.com/SebastianElvis))
+- Add changelog [\#192](https://github.com/babylonchain/babylon/pull/192) ([KonradStaniec](https://github.com/KonradStaniec))
+- datagen: add datagen functions for testing reporter [\#190](https://github.com/babylonchain/babylon/pull/190) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: hook onto the light client and index headers/forks [\#189](https://github.com/babylonchain/babylon/pull/189) ([SebastianElvis](https://github.com/SebastianElvis))
+- zoneconcierge: replace IBC-Go with Babylon's fork, and implement DB schemas [\#184](https://github.com/babylonchain/babylon/pull/184) ([SebastianElvis](https://github.com/SebastianElvis))
+
+## [v0.1.0](https://github.com/babylonchain/babylon/tree/v0.1.0) (2022-11-05)
+
+[Full Changelog](https://github.com/babylonchain/babylon/compare/b1645c9eea6511069c0b2ad0328d794018450eac...v0.1.0)
+
+**Implemented enhancements:**
+
+- Checkpointing: remove hardcoded FlagFee [\#160](https://github.com/babylonchain/babylon/issues/160)
+- Proper coin denomination for testnet [\#139](https://github.com/babylonchain/babylon/issues/139)
+- chore: bump Cosmos SDK dependency to `v0.46.0` [\#93](https://github.com/babylonchain/babylon/issues/93)
+- btclightclient: Store BTCHeaderInfo objects instead of BTCHeaderBytes objects [\#57](https://github.com/babylonchain/babylon/issues/57)
+
+**Fixed bugs:**
+
+- bug: Transaction submission panics due to unavailability of BTC config [\#117](https://github.com/babylonchain/babylon/issues/117)
+- epoching: simulation panicked with error message `panic: no delegation distribution info` [\#74](https://github.com/babylonchain/babylon/issues/74)
+- Epoching AnteHandler rejects genesis staking transactions [\#36](https://github.com/babylonchain/babylon/issues/36)
+- Fix handling duplicated submissions [\#163](https://github.com/babylonchain/babylon/pull/163) ([KonradStaniec](https://github.com/KonradStaniec))
+
+**Closed issues:**
+
+- Improve sending of bls transaction by checkpointing module. [\#155](https://github.com/babylonchain/babylon/issues/155)
+- Checkpointing: random BLS-sig transactions are not executed successfully [\#141](https://github.com/babylonchain/babylon/issues/141)
+- Fix integration test and blssigner denominations [\#137](https://github.com/babylonchain/babylon/issues/137)
+- Errors prompted by the static analyser in `x/btclightclient` [\#9](https://github.com/babylonchain/babylon/issues/9)
+
+**Merged pull requests:**
+
+- Release v0.1.0 [\#191](https://github.com/babylonchain/babylon/pull/191) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: add validate-genesis cmd [\#187](https://github.com/babylonchain/babylon/pull/187) ([gitferry](https://github.com/gitferry))
+- chore: add correspondence check against gentx when adding genesis BLS keys [\#186](https://github.com/babylonchain/babylon/pull/186) ([gitferry](https://github.com/gitferry))
+- chore: regtest support [\#185](https://github.com/babylonchain/babylon/pull/185) ([SebastianElvis](https://github.com/SebastianElvis))
+- Implement ADR-01 [\#183](https://github.com/babylonchain/babylon/pull/183) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: Upgrade proto generation Docker image and script [\#181](https://github.com/babylonchain/babylon/pull/181) ([vitsalis](https://github.com/vitsalis))
+- Fix accepting submission [\#179](https://github.com/babylonchain/babylon/pull/179) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: add add-genesis-bls cmd [\#178](https://github.com/babylonchain/babylon/pull/178) ([gitferry](https://github.com/gitferry))
+- fix: CI failed after merging \#175 [\#177](https://github.com/babylonchain/babylon/pull/177) ([gitferry](https://github.com/gitferry))
+- ibc: vanilla IBC module [\#176](https://github.com/babylonchain/babylon/pull/176) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: add create-genesis-bls cmd [\#175](https://github.com/babylonchain/babylon/pull/175) ([gitferry](https://github.com/gitferry))
+- Bump cosmos sdk [\#173](https://github.com/babylonchain/babylon/pull/173) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: Add prepare-genesis command [\#172](https://github.com/babylonchain/babylon/pull/172) ([vitsalis](https://github.com/vitsalis))
+- Refactor submission bitcoin status [\#170](https://github.com/babylonchain/babylon/pull/170) ([KonradStaniec](https://github.com/KonradStaniec))
+- Validate btc objects in ante-handler [\#169](https://github.com/babylonchain/babylon/pull/169) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: Use \(u\)bbn bond denominations [\#167](https://github.com/babylonchain/babylon/pull/167) ([vitsalis](https://github.com/vitsalis))
+- feat: checkpointing/improve the sending of BLS-sig tx [\#166](https://github.com/babylonchain/babylon/pull/166) ([gitferry](https://github.com/gitferry))
+- feat: checkpointing/implement WrappedCreateValidator cli [\#165](https://github.com/babylonchain/babylon/pull/165) ([gitferry](https://github.com/gitferry))
+- Move retry module from Vigilante to BBN [\#164](https://github.com/babylonchain/babylon/pull/164) ([gusin13](https://github.com/gusin13))
+- feat: checkpointing/add create-bls-key cli [\#162](https://github.com/babylonchain/babylon/pull/162) ([gitferry](https://github.com/gitferry))
+- chore: checkpointing/refactor validate basic [\#161](https://github.com/babylonchain/babylon/pull/161) ([gitferry](https://github.com/gitferry))
+- Query to get submissions for given epoch [\#158](https://github.com/babylonchain/babylon/pull/158) ([KonradStaniec](https://github.com/KonradStaniec))
+- Functionality for building custom mainnet tags [\#157](https://github.com/babylonchain/babylon/pull/157) ([vitsalis](https://github.com/vitsalis))
+- Improve integration tests [\#156](https://github.com/babylonchain/babylon/pull/156) ([KonradStaniec](https://github.com/KonradStaniec))
+- epoching: fix error of `unexpected validator in unbonding queue` [\#154](https://github.com/babylonchain/babylon/pull/154) ([SebastianElvis](https://github.com/SebastianElvis))
+- Fix ancestry error [\#153](https://github.com/babylonchain/babylon/pull/153) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: fix error msg typo of btccheckpoint [\#151](https://github.com/babylonchain/babylon/pull/151) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching/checkpointing: checkpoint-assisted unbonding [\#150](https://github.com/babylonchain/babylon/pull/150) ([SebastianElvis](https://github.com/SebastianElvis))
+- fix: Allow minimum work headers for a testnet/simnet [\#148](https://github.com/babylonchain/babylon/pull/148) ([vitsalis](https://github.com/vitsalis))
+- Add test for checkpoint submissions and state change [\#147](https://github.com/babylonchain/babylon/pull/147) ([KonradStaniec](https://github.com/KonradStaniec))
+- fix: fixed decoder for checkpoint [\#146](https://github.com/babylonchain/babylon/pull/146) ([gitferry](https://github.com/gitferry))
+- epoching: add delegator address to events [\#145](https://github.com/babylonchain/babylon/pull/145) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: checkpointing/add logs for checkpoint status change [\#144](https://github.com/babylonchain/babylon/pull/144) ([gitferry](https://github.com/gitferry))
+- epoching: delegation lifecycle [\#143](https://github.com/babylonchain/babylon/pull/143) ([SebastianElvis](https://github.com/SebastianElvis))
+- Relax tx formatter rules [\#142](https://github.com/babylonchain/babylon/pull/142) ([KonradStaniec](https://github.com/KonradStaniec))
+- epoching: bugfix of `LatestEpochMsgs` API [\#140](https://github.com/babylonchain/babylon/pull/140) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching: CLI for delegating/undelegating/redelegating requests [\#138](https://github.com/babylonchain/babylon/pull/138) ([SebastianElvis](https://github.com/SebastianElvis))
+- Revert: testnet: denom of gas price \#133  [\#136](https://github.com/babylonchain/babylon/pull/136) ([vitsalis](https://github.com/vitsalis))
+- bitcoinsim: Remove it from the repository [\#135](https://github.com/babylonchain/babylon/pull/135) ([vitsalis](https://github.com/vitsalis))
+- testnet: denom of gas price [\#133](https://github.com/babylonchain/babylon/pull/133) ([SebastianElvis](https://github.com/SebastianElvis))
+- btclightclient: create temporary method for Contains request with bytes parameter [\#132](https://github.com/babylonchain/babylon/pull/132) ([SebastianElvis](https://github.com/SebastianElvis))
+- btclightclient: Add BaseHeader query [\#130](https://github.com/babylonchain/babylon/pull/130) ([vitsalis](https://github.com/vitsalis))
+- Remove full stack deployment and irrelevant files [\#129](https://github.com/babylonchain/babylon/pull/129) ([vitsalis](https://github.com/vitsalis))
+- testnet: Add CLI args for specifying btccheckpoint and staking genesis params [\#128](https://github.com/babylonchain/babylon/pull/128) ([vitsalis](https://github.com/vitsalis))
+- Add extending btc light client chain in tests [\#127](https://github.com/babylonchain/babylon/pull/127) ([KonradStaniec](https://github.com/KonradStaniec))
+- chore: checkpointing/refactor bls-signer [\#126](https://github.com/babylonchain/babylon/pull/126) ([gitferry](https://github.com/gitferry))
+- fix: Re-introduce localnet start to enable integration tests [\#125](https://github.com/babylonchain/babylon/pull/125) ([vitsalis](https://github.com/vitsalis))
+- docker: Include vigilantes and explorer in the localnet deployment [\#123](https://github.com/babylonchain/babylon/pull/123) ([vitsalis](https://github.com/vitsalis))
+- fix: checkpointing/query epoch status count bug [\#122](https://github.com/babylonchain/babylon/pull/122) ([gitferry](https://github.com/gitferry))
+- Fixes initialisation bug [\#121](https://github.com/babylonchain/babylon/pull/121) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: checkpointing/integrate bls-sig tx into the message flow [\#120](https://github.com/babylonchain/babylon/pull/120) ([gitferry](https://github.com/gitferry))
+- epoching API: add epoch msg range queries and add timestamp to validator lifecycle [\#119](https://github.com/babylonchain/babylon/pull/119) ([SebastianElvis](https://github.com/SebastianElvis))
+- fix: bls-sig accumulating bug and added tests [\#118](https://github.com/babylonchain/babylon/pull/118) ([gitferry](https://github.com/gitferry))
+- epoching API: add timestamp to queued messages [\#116](https://github.com/babylonchain/babylon/pull/116) ([SebastianElvis](https://github.com/SebastianElvis))
+- Parameterize genesis and config through testnet command flags [\#115](https://github.com/babylonchain/babylon/pull/115) ([vitsalis](https://github.com/vitsalis))
+- Add custom query [\#114](https://github.com/babylonchain/babylon/pull/114) ([KonradStaniec](https://github.com/KonradStaniec))
+- btccheckpoint: make kDeep/wDeep as system parameters [\#113](https://github.com/babylonchain/babylon/pull/113) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: checkpointing/add typed events [\#112](https://github.com/babylonchain/babylon/pull/112) ([gitferry](https://github.com/gitferry))
+- feat: checkpointing/ add queries about epoch status [\#111](https://github.com/babylonchain/babylon/pull/111) ([gitferry](https://github.com/gitferry))
+- chore: BLS signer refactor [\#110](https://github.com/babylonchain/babylon/pull/110) ([gitferry](https://github.com/gitferry))
+- epoching API: validator lifecycle [\#109](https://github.com/babylonchain/babylon/pull/109) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching: API: epoch\_msgs/{epoch\_num} -\> all events during this epoch [\#108](https://github.com/babylonchain/babylon/pull/108) ([SebastianElvis](https://github.com/SebastianElvis))
+- btcutils: refactor for vigilante [\#107](https://github.com/babylonchain/babylon/pull/107) ([SebastianElvis](https://github.com/SebastianElvis))
+- chore: Replace all instances of bbl with bbn [\#106](https://github.com/babylonchain/babylon/pull/106) ([vitsalis](https://github.com/vitsalis))
+- Add babylon app config [\#105](https://github.com/babylonchain/babylon/pull/105) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: checkpointing/implement BLS signer [\#104](https://github.com/babylonchain/babylon/pull/104) ([gitferry](https://github.com/gitferry))
+- Add parsing correct format in btccheckpoint [\#102](https://github.com/babylonchain/babylon/pull/102) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: add genesis state for checkpointing [\#101](https://github.com/babylonchain/babylon/pull/101) ([gitferry](https://github.com/gitferry))
+- Add fuzz tests to formatter [\#100](https://github.com/babylonchain/babylon/pull/100) ([KonradStaniec](https://github.com/KonradStaniec))
+- Fix: checkpointing/epoch growth bug [\#99](https://github.com/babylonchain/babylon/pull/99) ([gitferry](https://github.com/gitferry))
+- chore: replace bbl with bbn and gitignore [\#98](https://github.com/babylonchain/babylon/pull/98) ([SebastianElvis](https://github.com/SebastianElvis))
+- FIX: checkpointing/changed PoP by signing BLS public key [\#97](https://github.com/babylonchain/babylon/pull/97) ([gitferry](https://github.com/gitferry))
+- Add initial implementation of tx formatter [\#96](https://github.com/babylonchain/babylon/pull/96) ([KonradStaniec](https://github.com/KonradStaniec))
+- BM-102: Single BTC node in docker producing blocks [\#95](https://github.com/babylonchain/babylon/pull/95) ([aakoshh](https://github.com/aakoshh))
+- Add initial test checking progress [\#94](https://github.com/babylonchain/babylon/pull/94) ([KonradStaniec](https://github.com/KonradStaniec))
+- Add tests to ci [\#90](https://github.com/babylonchain/babylon/pull/90) ([KonradStaniec](https://github.com/KonradStaniec))
+- FIX: Add checkpoint query with status [\#89](https://github.com/babylonchain/babylon/pull/89) ([gitferry](https://github.com/gitferry))
+- enable gRPC gateway routes for rest queries [\#88](https://github.com/babylonchain/babylon/pull/88) ([toliujiayi](https://github.com/toliujiayi))
+- Wire app without mocks [\#87](https://github.com/babylonchain/babylon/pull/87) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: implement bls key generation [\#86](https://github.com/babylonchain/babylon/pull/86) ([gitferry](https://github.com/gitferry))
+- Add integration tests [\#85](https://github.com/babylonchain/babylon/pull/85) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: checkpointing/implement checkpoint verification and keeper tests [\#84](https://github.com/babylonchain/babylon/pull/84) ([gitferry](https://github.com/gitferry))
+- Add btccheckpoit unit tests [\#83](https://github.com/babylonchain/babylon/pull/83) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: btclightclient: Add BTCHeaderInserted event [\#82](https://github.com/babylonchain/babylon/pull/82) ([vitsalis](https://github.com/vitsalis))
+- fix: Remove WASM config from application configuration [\#81](https://github.com/babylonchain/babylon/pull/81) ([vitsalis](https://github.com/vitsalis))
+- epoching: smaller epoch interval in simulation [\#80](https://github.com/babylonchain/babylon/pull/80) ([SebastianElvis](https://github.com/SebastianElvis))
+- FIX: Use a caching multistore in delayed staking message handler [\#79](https://github.com/babylonchain/babylon/pull/79) ([aakoshh](https://github.com/aakoshh))
+- feat: checkpointing/implement cli [\#78](https://github.com/babylonchain/babylon/pull/78) ([gitferry](https://github.com/gitferry))
+- fix: Add installation instructions and executable reference [\#77](https://github.com/babylonchain/babylon/pull/77) ([vitsalis](https://github.com/vitsalis))
+- chore: issue templates [\#76](https://github.com/babylonchain/babylon/pull/76) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: Register msg server for all modules & instructions for tx submission [\#73](https://github.com/babylonchain/babylon/pull/73) ([vitsalis](https://github.com/vitsalis))
+- feat: btclightclient: Refactor keepers based on needs of btcheckpoint module [\#72](https://github.com/babylonchain/babylon/pull/72) ([vitsalis](https://github.com/vitsalis))
+- simulation: vanilla simulation tests [\#71](https://github.com/babylonchain/babylon/pull/71) ([SebastianElvis](https://github.com/SebastianElvis))
+- Implement core btc handling logic [\#70](https://github.com/babylonchain/babylon/pull/70) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: btclightclient: gRPC query fuzz tests [\#69](https://github.com/babylonchain/babylon/pull/69) ([vitsalis](https://github.com/vitsalis))
+- epoching: simulation infra for integration testing [\#68](https://github.com/babylonchain/babylon/pull/68) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: btclightclient: Add keeper fuzz tests [\#67](https://github.com/babylonchain/babylon/pull/67) ([vitsalis](https://github.com/vitsalis))
+- epoching: fuzz tests on epoched undelegations and redelegations [\#66](https://github.com/babylonchain/babylon/pull/66) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching: refactor test infra, mock messages and sample fuzz tests [\#65](https://github.com/babylonchain/babylon/pull/65) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching: fuzz tests for slashed validator set [\#64](https://github.com/babylonchain/babylon/pull/64) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching: replace deprecated `EmitEvent` APIs with `EmitTypedEvent` ones [\#63](https://github.com/babylonchain/babylon/pull/63) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: btclightclient HeadersState keeper fuzz tests [\#61](https://github.com/babylonchain/babylon/pull/61) ([vitsalis](https://github.com/vitsalis))
+- epoching: more test infra and some fuzz tests on keeper functionalities [\#60](https://github.com/babylonchain/babylon/pull/60) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: checkpointing/aggregate BLS signatures [\#59](https://github.com/babylonchain/babylon/pull/59) ([gitferry](https://github.com/gitferry))
+- feat: btclightclient: Abstract the usage of btcd types and store BTCHeaderInfo objects [\#58](https://github.com/babylonchain/babylon/pull/58) ([vitsalis](https://github.com/vitsalis))
+- feat: Replace BTC types unit tests with fuzz tests [\#56](https://github.com/babylonchain/babylon/pull/56) ([vitsalis](https://github.com/vitsalis))
+- feat: Create datagen testutil for common random generation functions [\#55](https://github.com/babylonchain/babylon/pull/55) ([vitsalis](https://github.com/vitsalis))
+- epoching: wrapper type `Epoch` and simplify code using this type [\#54](https://github.com/babylonchain/babylon/pull/54) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: Add btclightclient events and hooks  [\#53](https://github.com/babylonchain/babylon/pull/53) ([vitsalis](https://github.com/vitsalis))
+- feat: add raw checkpoint creation [\#52](https://github.com/babylonchain/babylon/pull/52) ([gitferry](https://github.com/gitferry))
+- feat: Add accumulattive PoW functionality to btclightclient [\#51](https://github.com/babylonchain/babylon/pull/51) ([vitsalis](https://github.com/vitsalis))
+- btclightclient: Cleanup codebase and add descriptive comments [\#50](https://github.com/babylonchain/babylon/pull/50) ([vitsalis](https://github.com/vitsalis))
+- Update go to 1.18 in README [\#49](https://github.com/babylonchain/babylon/pull/49) ([vitsalis](https://github.com/vitsalis))
+- Upgrade to go 1.18 [\#48](https://github.com/babylonchain/babylon/pull/48) ([vitsalis](https://github.com/vitsalis))
+- feat: define checkpointing registration proto and state [\#46](https://github.com/babylonchain/babylon/pull/46) ([gitferry](https://github.com/gitferry))
+- BM-60: Database schema ER diagram [\#45](https://github.com/babylonchain/babylon/pull/45) ([aakoshh](https://github.com/aakoshh))
+- Revert "feat: CI: Generate a single block in build check " [\#44](https://github.com/babylonchain/babylon/pull/44) ([vitsalis](https://github.com/vitsalis))
+- Btccheckpoint oracle schema and processing [\#43](https://github.com/babylonchain/babylon/pull/43) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: Fuzz and unit tests for btclightclient types [\#42](https://github.com/babylonchain/babylon/pull/42) ([vitsalis](https://github.com/vitsalis))
+- epoching: fix genesis, param and bootstrapping [\#41](https://github.com/babylonchain/babylon/pull/41) ([SebastianElvis](https://github.com/SebastianElvis))
+- feat: Add unit tests for ValidateHeader of btcutils [\#40](https://github.com/babylonchain/babylon/pull/40) ([vitsalis](https://github.com/vitsalis))
+- feat: Add unit tests for BTCHeaderHashBytes and BTCHeaderBytes types  [\#39](https://github.com/babylonchain/babylon/pull/39) ([vitsalis](https://github.com/vitsalis))
+- Add building, testing, and testnet instructions on README  [\#38](https://github.com/babylonchain/babylon/pull/38) ([vitsalis](https://github.com/vitsalis))
+- feat: CI: Generate a single block in build check  [\#37](https://github.com/babylonchain/babylon/pull/37) ([vitsalis](https://github.com/vitsalis))
+- epoching: event and hook upon a certain threshold amount of slashed voting power [\#35](https://github.com/babylonchain/babylon/pull/35) ([SebastianElvis](https://github.com/SebastianElvis))
+- doc: add BLS key registration spec [\#34](https://github.com/babylonchain/babylon/pull/34) ([gitferry](https://github.com/gitferry))
+- feat: add hooks, events, and error types to the checkpointing module [\#33](https://github.com/babylonchain/babylon/pull/33) ([gitferry](https://github.com/gitferry))
+- epoching: state transition upon `BeginBlock` and `EndBlock` [\#32](https://github.com/babylonchain/babylon/pull/32) ([SebastianElvis](https://github.com/SebastianElvis))
+- Handle insert checkpoint [\#31](https://github.com/babylonchain/babylon/pull/31) ([KonradStaniec](https://github.com/KonradStaniec))
+- feat: Add btclightclient chain query [\#30](https://github.com/babylonchain/babylon/pull/30) ([vitsalis](https://github.com/vitsalis))
+- feat: Implement BTCHeaderBytes and BTCHeaderHashBytes types [\#29](https://github.com/babylonchain/babylon/pull/29) ([vitsalis](https://github.com/vitsalis))
+- epoching: copy/paste necessary code from staking/evidence/slashing and make modifications [\#28](https://github.com/babylonchain/babylon/pull/28) ([SebastianElvis](https://github.com/SebastianElvis))
+- checkpointing: add keeper and core state [\#27](https://github.com/babylonchain/babylon/pull/27) ([gitferry](https://github.com/gitferry))
+- FIX: btclightclient: Properly convert the input of contains to bytes [\#26](https://github.com/babylonchain/babylon/pull/26) ([vitsalis](https://github.com/vitsalis))
+- BM-32: Update diagrams for out-of-sequence checkpoint handling [\#25](https://github.com/babylonchain/babylon/pull/25) ([aakoshh](https://github.com/aakoshh))
+- FIX\(localnet\): Redirect babylond stderr to stdout [\#24](https://github.com/babylonchain/babylon/pull/24) ([vitsalis](https://github.com/vitsalis))
+- BM-31: Add CircleCI pipeline for building and testing [\#23](https://github.com/babylonchain/babylon/pull/23) ([vitsalis](https://github.com/vitsalis))
+- FIX: Failing btclightclient tests, remove unneeded ones, clean up [\#22](https://github.com/babylonchain/babylon/pull/22) ([vitsalis](https://github.com/vitsalis))
+- FIX: Replace 'unimplemented' AnteHandler panic with comment [\#21](https://github.com/babylonchain/babylon/pull/21) ([vitsalis](https://github.com/vitsalis))
+- FIX: Implement Msg interface for MsgInsertBTCSpvProof [\#20](https://github.com/babylonchain/babylon/pull/20) ([vitsalis](https://github.com/vitsalis))
+- epoching: keeper functions, queries, and testing infra [\#19](https://github.com/babylonchain/babylon/pull/19) ([SebastianElvis](https://github.com/SebastianElvis))
+- epoching: Wrapped messages and AnteHandler implementation [\#18](https://github.com/babylonchain/babylon/pull/18) ([SebastianElvis](https://github.com/SebastianElvis))
+- FIX: Stringer in RawCheckpoint and correct checkpointing module ModuleName [\#17](https://github.com/babylonchain/babylon/pull/17) ([vitsalis](https://github.com/vitsalis))
+- BM-16: feat\(epoching\): add AnteHandler `DropValidatorMsgDecorator` [\#15](https://github.com/babylonchain/babylon/pull/15) ([SebastianElvis](https://github.com/SebastianElvis))
+- BM-13: feat\(epoching\): add hooks, events and keeper functions [\#14](https://github.com/babylonchain/babylon/pull/14) ([SebastianElvis](https://github.com/SebastianElvis))
+- BM-10: Basic btcheaderoracle module [\#13](https://github.com/babylonchain/babylon/pull/13) ([vitsalis](https://github.com/vitsalis))
+- BM-17: Add basic functianalities of bls crypto [\#12](https://github.com/babylonchain/babylon/pull/12) ([gitferry](https://github.com/gitferry))
+- FIX: Resolve inconsistent BTCLightClientKeeper name [\#11](https://github.com/babylonchain/babylon/pull/11) ([vitsalis](https://github.com/vitsalis))
+- BM-15: feat\(epoching\): add protobuf messages [\#10](https://github.com/babylonchain/babylon/pull/10) ([SebastianElvis](https://github.com/SebastianElvis))
+- BM-6: Initial proposal for btc checkpoint message [\#8](https://github.com/babylonchain/babylon/pull/8) ([KonradStaniec](https://github.com/KonradStaniec))
+- FIX: Do not modify go.mod when generating proto files [\#7](https://github.com/babylonchain/babylon/pull/7) ([vitsalis](https://github.com/vitsalis))
+- BM-5: feat\(btc light client\): BTC Light Client module setup [\#6](https://github.com/babylonchain/babylon/pull/6) ([vitsalis](https://github.com/vitsalis))
+- BM-2: feat\(checkpointing\): init checkpointing module and define proto types [\#5](https://github.com/babylonchain/babylon/pull/5) ([gitferry](https://github.com/gitferry))
+- BM-6: Add initial scaffold for rawcheckpoint module [\#4](https://github.com/babylonchain/babylon/pull/4) ([KonradStaniec](https://github.com/KonradStaniec))
+- FIX: Add script that downloads third party proto dependencies [\#3](https://github.com/babylonchain/babylon/pull/3) ([vitsalis](https://github.com/vitsalis))
+- BM-3: feat\(epoching\): Epoching module setup [\#2](https://github.com/babylonchain/babylon/pull/2) ([SebastianElvis](https://github.com/SebastianElvis))
+- BM-4: Add docs/diagrams with a Makefile and a test. [\#1](https://github.com/babylonchain/babylon/pull/1) ([aakoshh](https://github.com/aakoshh))
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,14 @@ ifeq (,$(findstring nostrip,$(BABYLON_BUILD_OPTIONS)))
   BUILD_FLAGS += -trimpath
 endif
 
+# Update changelog vars
+ifneq (,$(SINCE_TAG))
+	since_tag := --since-tag $(SINCE_TAG)
+endif
+ifneq (,$(UPCOMING_TAG))
+	upcoming_tag := --upcoming-tag $(UPCOMING_TAG)
+endif
+
 all: tools build lint test
 
 # The below include contains the tools and runsim targets.
@@ -441,3 +449,8 @@ localnet-stop
 .PHONY: diagrams
 diagrams:
 	$(MAKE) -C client/docs/diagrams
+
+.PHONY: update-changelog
+update-changelog:
+	@echo ./scripts/update_changelog.sh $(since_tag) $(upcoming_tag)
+	./scripts/update_changelog.sh $(since_tag) $(upcoming_tag)

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# This is a wrapper around `github_changelog_generator` (https://github.com/github-changelog-generator)
+# to simplify / automate updating of the CHANGELOG.md file.
+#
+# Originally developed for CosmWasm cw_plus (https://github.com/CosmWasm/cw-plus) repository.
+set -o errexit -o pipefail
+
+ORIGINAL_OPTS=$*
+# Requires getopt from util-linux 2.37.4 (brew install gnu-getopt on Mac)
+OPTS=$(getopt -l "help,since-tag:,upcoming-tag:,full,token:" -o "hu:ft" -- "$@") || exit 1
+
+function print_usage() {
+    echo -e "Usage: $0 [-h|--help] [-f|--full] [--since-tag <tag>] [-u|--upcoming-tag] <tag> [-t|--token <token>]
+-h, --help               Display help
+-f, --full               Process changes since the beginning (by default: since latest git version tag)
+--since-tag <tag>        Process changes since git version tag <tag> (by default: since latest git version tag)
+-u, --upcoming-tag <tag> Add a <tag> title in CHANGELOG for the new changes
+--token <token>          Pass changelog github token <token>"
+}
+
+function remove_opt() {
+    ORIGINAL_OPTS=$(echo "$ORIGINAL_OPTS" | sed "s/\\B$1\\b//")
+}
+
+eval set -- "$OPTS"
+while true
+do
+case $1 in
+  -h|--help)
+    print_usage
+    exit 0
+    ;;
+  --since-tag)
+    shift
+    TAG="$1"
+    ;;
+  -f|--full)
+    TAG="<FULL>"
+    remove_opt $1
+    ;;
+  -u|--upcoming-tag)
+    remove_opt $1
+    shift
+    UPCOMING_TAG="$1"
+    remove_opt $1
+    ;;
+  --)
+    shift
+    break
+    ;;
+esac
+shift
+done
+
+# Get user and repo from ./.git/config
+ORIGIN_URL=$(git config --local remote.origin.url)
+GITHUB_USER=$(echo $ORIGIN_URL | sed -n 's#.*:\([^\/]*\)\/.*#\1#p')
+echo "Github user: $GITHUB_USER"
+GITHUB_REPO=$(echo $ORIGIN_URL | sed -n 's#.*/\(.*\)\.git#\1#p')
+echo "Github repo: $GITHUB_REPO"
+
+if [ -z "$TAG" ]
+then
+  # Use latest git version tag
+  TAG=$(git tag --sort=creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+  ORIGINAL_OPTS="$ORIGINAL_OPTS --since-tag $TAG"
+fi
+
+echo "Git version tag: $TAG"
+
+cp CHANGELOG.md /tmp/CHANGELOG.md.$$
+# Consolidate tag for matching changelog entries
+TAG=$(echo "$TAG" | sed -e 's/-\([A-Za-z]*\)[^A-Za-z]*/-\1/' -e 's/-$//')
+echo "Consolidated tag: $TAG"
+sed -i -n "/^## \\[${TAG}[^]]*\\]/,\$p" CHANGELOG.md
+
+github_changelog_generator -u $GITHUB_USER -p $GITHUB_REPO --base CHANGELOG.md $ORIGINAL_OPTS || cp /tmp/CHANGELOG.md.$$ CHANGELOG.md
+
+if [ -n "$UPCOMING_TAG" ]
+then
+  # Add "upcoming" version tag
+  TODAY=$(date "+%Y-%m-%d")
+  sed -i "s+\[Full Changelog\](https://github.com/$GITHUB_USER/$GITHUB_REPO/compare/\(.*\)\.\.\.HEAD)+[Full Changelog](https://github.com/$GITHUB_USER/$GITHUB_REPO/compare/$UPCOMING_TAG...HEAD)\n\n## [$UPCOMING_TAG](https://github.com/$GITHUB_USER/$GITHUB_REPO/tree/$UPCOMING_TAG) ($TODAY)\n\n[Full Changelog](https://github.com/$GITHUB_USER/$GITHUB_REPO/compare/\1...$UPCOMING_TAG)+" CHANGELOG.md
+fi
+
+rm -f /tmp/CHANGELOG.md.$$

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -76,6 +76,7 @@ TAG=$(echo "$TAG" | sed -e 's/-\([A-Za-z]*\)[^A-Za-z]*/-\1/' -e 's/-$//')
 echo "Consolidated tag: $TAG"
 sed -i -n "/^## \\[${TAG}[^]]*\\]/,\$p" CHANGELOG.md
 
+echo github_changelog_generator -u $GITHUB_USER -p $GITHUB_REPO --base CHANGELOG.md $ORIGINAL_OPTS || cp /tmp/CHANGELOG.md.$$ CHANGELOG.md
 github_changelog_generator -u $GITHUB_USER -p $GITHUB_REPO --base CHANGELOG.md $ORIGINAL_OPTS || cp /tmp/CHANGELOG.md.$$ CHANGELOG.md
 
 if [ -n "$UPCOMING_TAG" ]

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -7,15 +7,17 @@ set -o errexit -o pipefail
 
 ORIGINAL_OPTS=$*
 # Requires getopt from util-linux 2.37.4 (brew install gnu-getopt on Mac)
-OPTS=$(getopt -l "help,since-tag:,upcoming-tag:,full,token:" -o "hu:ft" -- "$@") || exit 1
+OPTS=$(getopt -l "help,release-branch:,since-tag:,upcoming-tag:,full,token:" -o "hu:ft" -- "$@") || exit 1
 
 function print_usage() {
-    echo -e "Usage: $0 [-h|--help] [-f|--full] [--since-tag <tag>] [-u|--upcoming-tag] <tag> [-t|--token <token>]
--h, --help               Display help
--f, --full               Process changes since the beginning (by default: since latest git version tag)
---since-tag <tag>        Process changes since git version tag <tag> (by default: since latest git version tag)
--u, --upcoming-tag <tag> Add a <tag> title in CHANGELOG for the new changes
---token <token>          Pass changelog github token <token>"
+    echo -e "Usage: $0 [-h|--help] [-f|--full] [--release-branch <branch>] [--since-tag <tag>] [-u|--upcoming-tag] <tag> [-t|--token <token>]
+
+-h, --help                Display help
+-f, --full                Process changes since the beginning (by default: since latest git version tag)
+--release-branch <branch> Limit pull requests to the release branch <branch>.
+--since-tag <tag>         Process changes since git version tag <tag> (by default: since latest git version tag)
+-u, --upcoming-tag <tag>  Add a <tag> title in CHANGELOG for the new changes
+--token <token>           Pass changelog github token <token>"
 }
 
 function remove_opt() {


### PR DESCRIPTION
Wrapper around `github_changelog_generator` that simplifies keeping the changelog updated.


To use it, you first need to install https://github.com/github-changelog-generator/github-changelog-generator of course.

Also, though it can be used without it, it's convenient to have a token called `CHANGELOG_GITHUB_TOKEN`, to increase the number of API requests that can you do when generating the changelog entries.

See https://github.com/github-changelog-generator/github-changelog-generator?tab=readme-ov-file#github-token for instructions on how to generate and set the token.

A convenient way to use it, is with the `-u` (upcoming) flag, to pass a version tag that that is not existing yet in the repo.
That way you can update the changelog in a release branch, before tagging the new version. And the script takes care of creating the new header / section for you.

Finally, nothing prevents you from editing a section of the changelog manually. As long as the section headers are kept consistent, the script will continue to work.

Also, you can of course still call `github_changelog_generator` directly instead. By example for passing extra parameters / setting extra flags.
The ideal thing to do here would be to add those parameters (as a passthrough) to the script, so, if you find a useful flag / parameter that you want / need to use, let me know and I'll add it to the wrapper script.