### PR TITLE
Unmarshalling perf

### DIFF
--- a/types/btc_schnorr_sig.go
+++ b/types/btc_schnorr_sig.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/hex"
-	"errors"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 )
@@ -69,15 +68,6 @@ func (sig BIP340Signature) MarshalTo(data []byte) (int, error) {
 }
 
 func (sig *BIP340Signature) Unmarshal(data []byte) error {
-	newSig := BIP340Signature(data)
-
-	// ensure that the bytes can be transformed to a *schnorr.Signature object
-	// this includes all format checks
-	_, err := newSig.ToBTCSig()
-	if err != nil {
-		return errors.New("bytes cannot be converted to a *schnorr.Signature object")
-	}
-
 	*sig = data
 	return nil
 }

--- a/x/btcstaking/types/btc_slashing_tx.go
+++ b/x/btcstaking/types/btc_slashing_tx.go
@@ -63,12 +63,6 @@ func (tx BTCSlashingTx) MarshalTo(data []byte) (int, error) {
 
 func (tx *BTCSlashingTx) Unmarshal(data []byte) error {
 	*tx = data
-
-	// ensure data can be decoded to a tx
-	if _, err := tx.ToMsgTx(); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/x/btcstaking/types/msg.go
+++ b/x/btcstaking/types/msg.go
@@ -73,9 +73,21 @@ func (m *MsgCreateBTCDelegation) ValidateBasic() error {
 	if m.SlashingTx == nil {
 		return fmt.Errorf("empty slashing tx")
 	}
+
+	if _, err := m.SlashingTx.ToMsgTx(); err != nil {
+		return fmt.Errorf("invalid slashing tx: %w", err)
+	}
+
 	if m.DelegatorSlashingSig == nil {
 		return fmt.Errorf("empty delegator signature")
 	}
+
+	_, err := m.DelegatorSlashingSig.ToBTCSig()
+
+	if err != nil {
+		return fmt.Errorf("invalid delegator slashing signature: %w", err)
+	}
+
 	if _, err := sdk.AccAddressFromBech32(m.Signer); err != nil {
 		return err
 	}
@@ -111,6 +123,17 @@ func (m *MsgCreateBTCDelegation) ValidateBasic() error {
 	if m.DelegatorUnbondingSlashingSig == nil {
 		return fmt.Errorf("empty delegator signature")
 	}
+
+	if _, err := m.UnbondingSlashingTx.ToMsgTx(); err != nil {
+		return fmt.Errorf("invalid unbonding slashing tx: %w", err)
+	}
+
+	_, err = m.DelegatorUnbondingSlashingSig.ToBTCSig()
+
+	if err != nil {
+		return fmt.Errorf("invalid delegator unbonding slashing signature: %w", err)
+	}
+
 	unbondingTxMsg, err := bbn.NewBTCTxFromBytes(m.UnbondingTx)
 	if err != nil {
 		return err
@@ -145,6 +168,13 @@ func (m *MsgAddCovenantSigs) ValidateBasic() error {
 	if m.UnbondingTxSig == nil {
 		return fmt.Errorf("empty covenant signature")
 	}
+
+	_, err := m.UnbondingTxSig.ToBTCSig()
+
+	if err != nil {
+		return fmt.Errorf("invalid covenant unbonding signature: %w", err)
+	}
+
 	if m.SlashingUnbondingTxSigs == nil {
 		return fmt.Errorf("empty covenant signature")
 	}
@@ -159,6 +189,12 @@ func (m *MsgBTCUndelegate) ValidateBasic() error {
 
 	if m.UnbondingTxSig == nil {
 		return fmt.Errorf("empty signature from the delegator")
+	}
+
+	_, err := m.UnbondingTxSig.ToBTCSig()
+
+	if err != nil {
+		return fmt.Errorf("invalid delegator unbonding signature: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Pr in spirit of - https://github.com/babylonchain/babylon/pull/441

Latest flamegraphs from load testing shown that, deserialzing btc transaction and signatures takes most time in code paths which retrieve a lot of delegations. This pr removes some unnecessary checks from db perspective.

This is not proper solution, but it can be some kind of stop-gap if we we would need around 20% perf boost (based on begin block benchmarks). It is also backward compatbile with current testnet and all the programs so this is easy gain. 