### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ document about its design and implementation.
 ## Joining the testnet
 
 Please follow the instructions on the [User
-Guides](https://docs.babylonchain.io/docs/user-guides/).
+Guides](https://docs.babylonchain.io/docs/user-guides/overview).
 
 ## Contributing
 


### PR DESCRIPTION
Link to a broken user guide document is fixed. it was https://docs.babylonchain.io/docs/user-guides and now is https://docs.babylonchain.io/docs/user-guides/overview