### PR TITLE
chore: create client friendly response for BtcCheckpointInfo query

### DIFF
--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -339,19 +339,18 @@ paths:
                   epoch_number:
                     type: string
                     format: uint64
-                    title: epoch number of this checkpoint
+                    description: EpochNumber of this checkpoint.
                   best_submission_btc_block_height:
                     type: string
                     format: uint64
                     title: btc height of the best submission of the epoch
                   best_submission_btc_block_hash:
                     type: string
-                    format: byte
                     title: >-
                       hash of the btc block which determines checkpoint btc
                       block height i.e.
 
-                      youngest block of best submission
+                      youngest block of best submission Hexadecimal
                   best_submission_transactions:
                     type: array
                     items:
@@ -379,32 +378,26 @@ paths:
                             index:
                               type: integer
                               format: int64
+                              description: Index Bitcoin Transaction index in block.
                             hash:
                               type: string
-                              format: byte
+                              description: Hash BTC Header hash as hex.
                           title: >-
-                            Each provided OP_RETURN transaction can be
-                            idendtified by hash of block in
+                            TransactionKeyResponse Each provided OP_RETURN
+                            transaction can be idendtified by
 
-                            which transaction was included and transaction index
-                            in the block
+                            hash of block in which transaction was included and
+                            transaction index in the block
                         transaction:
                           type: string
-                          format: byte
-                          title: transaction is the full transaction in bytes
+                          description: transaction is the full transaction data as str hex.
                         proof:
                           type: string
-                          format: byte
                           title: >-
                             proof is the Merkle proof that this tx is included
                             in the position in `key`
-
-                            TODO: maybe it could use here better format as we
-                            already processed and
-
-                            valideated the proof?
                       title: |-
-                        TransactionInfo is the info of a tx on Bitcoin,
+                        TransactionInfoResponse is the info of a tx on Bitcoin,
                         including
                         - the position of the tx on BTC blockchain
                         - the full tx content
@@ -417,17 +410,13 @@ paths:
                       properties:
                         submitter:
                           type: string
-                          format: byte
                           description: >-
-                            TODO: this could probably be better typed
-
                             submitter is the address of the checkpoint submitter
                             to BTC, extracted from
 
                             the checkpoint itself.
                         reporter:
                           type: string
-                          format: byte
                           title: >-
                             reporter is the address of the reporter who reported
                             the submissions,
@@ -435,17 +424,17 @@ paths:
                             calculated from submission message
                             MsgInsertBTCSpvProof itself
                       title: >-
-                        CheckpointAddresses contains the addresses of the
-                        submitter and reporter of a
+                        CheckpointAddressesResponse contains the addresses of
+                        the submitter and reporter of a
 
                         given checkpoint
                     title: list of vigilantes' addresses of the best submission
-                title: >-
-                  BTCCheckpointInfo contains all data about best submission of
-                  checkpoint for
+                description: >-
+                  BTCCheckpointInfoResponse contains all data about best
+                  submission of checkpoint for
 
                   given epoch. Best submission is the submission which is deeper
-                  in btc ledger
+                  in btc ledger.
             title: |-
               QueryBtcCheckpointInfoResponse is response type for the
               Query/BtcCheckpointInfo RPC method
@@ -9680,6 +9669,107 @@ definitions:
 
       given epoch. Best submission is the submission which is deeper in btc
       ledger
+  babylon.btccheckpoint.v1.BTCCheckpointInfoResponse:
+    type: object
+    properties:
+      epoch_number:
+        type: string
+        format: uint64
+        description: EpochNumber of this checkpoint.
+      best_submission_btc_block_height:
+        type: string
+        format: uint64
+        title: btc height of the best submission of the epoch
+      best_submission_btc_block_hash:
+        type: string
+        title: >-
+          hash of the btc block which determines checkpoint btc block height
+          i.e.
+
+          youngest block of best submission Hexadecimal
+      best_submission_transactions:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              description: >-
+                key is the position (txIdx, blockHash) of this tx on BTC
+                blockchain
+
+                Although it is already a part of SubmissionKey, we store it here
+                again
+
+                to make TransactionInfo self-contained.
+
+                For example, storing the key allows TransactionInfo to not relay
+                on
+
+                the fact that TransactionInfo will be ordered in the same order
+                as
+
+                TransactionKeys in SubmissionKey.
+              type: object
+              properties:
+                index:
+                  type: integer
+                  format: int64
+                  description: Index Bitcoin Transaction index in block.
+                hash:
+                  type: string
+                  description: Hash BTC Header hash as hex.
+              title: >-
+                TransactionKeyResponse Each provided OP_RETURN transaction can
+                be idendtified by
+
+                hash of block in which transaction was included and transaction
+                index in the block
+            transaction:
+              type: string
+              description: transaction is the full transaction data as str hex.
+            proof:
+              type: string
+              title: >-
+                proof is the Merkle proof that this tx is included in the
+                position in `key`
+          title: |-
+            TransactionInfoResponse is the info of a tx on Bitcoin,
+            including
+            - the position of the tx on BTC blockchain
+            - the full tx content
+            - the Merkle proof that this tx is on the above position
+        title: the BTC checkpoint transactions of the best submission
+      best_submission_vigilante_address_list:
+        type: array
+        items:
+          type: object
+          properties:
+            submitter:
+              type: string
+              description: >-
+                submitter is the address of the checkpoint submitter to BTC,
+                extracted from
+
+                the checkpoint itself.
+            reporter:
+              type: string
+              title: >-
+                reporter is the address of the reporter who reported the
+                submissions,
+
+                calculated from submission message MsgInsertBTCSpvProof itself
+          title: >-
+            CheckpointAddressesResponse contains the addresses of the submitter
+            and reporter of a
+
+            given checkpoint
+        title: list of vigilantes' addresses of the best submission
+    description: >-
+      BTCCheckpointInfoResponse contains all data about best submission of
+      checkpoint for
+
+      given epoch. Best submission is the submission which is deeper in btc
+      ledger.
   babylon.btccheckpoint.v1.CheckpointAddresses:
     type: object
     properties:
@@ -9702,6 +9792,26 @@ definitions:
     title: >-
       CheckpointAddresses contains the addresses of the submitter and reporter
       of a
+
+      given checkpoint
+  babylon.btccheckpoint.v1.CheckpointAddressesResponse:
+    type: object
+    properties:
+      submitter:
+        type: string
+        description: >-
+          submitter is the address of the checkpoint submitter to BTC, extracted
+          from
+
+          the checkpoint itself.
+      reporter:
+        type: string
+        title: |-
+          reporter is the address of the reporter who reported the submissions,
+          calculated from submission message MsgInsertBTCSpvProof itself
+    title: >-
+      CheckpointAddressesResponse contains the addresses of the submitter and
+      reporter of a
 
       given checkpoint
   babylon.btccheckpoint.v1.Params:
@@ -9752,19 +9862,18 @@ definitions:
           epoch_number:
             type: string
             format: uint64
-            title: epoch number of this checkpoint
+            description: EpochNumber of this checkpoint.
           best_submission_btc_block_height:
             type: string
             format: uint64
             title: btc height of the best submission of the epoch
           best_submission_btc_block_hash:
             type: string
-            format: byte
             title: >-
               hash of the btc block which determines checkpoint btc block height
               i.e.
 
-              youngest block of best submission
+              youngest block of best submission Hexadecimal
           best_submission_transactions:
             type: array
             items:
@@ -9792,32 +9901,26 @@ definitions:
                     index:
                       type: integer
                       format: int64
+                      description: Index Bitcoin Transaction index in block.
                     hash:
                       type: string
-                      format: byte
+                      description: Hash BTC Header hash as hex.
                   title: >-
-                    Each provided OP_RETURN transaction can be idendtified by
-                    hash of block in
+                    TransactionKeyResponse Each provided OP_RETURN transaction
+                    can be idendtified by
 
-                    which transaction was included and transaction index in the
-                    block
+                    hash of block in which transaction was included and
+                    transaction index in the block
                 transaction:
                   type: string
-                  format: byte
-                  title: transaction is the full transaction in bytes
+                  description: transaction is the full transaction data as str hex.
                 proof:
                   type: string
-                  format: byte
                   title: >-
                     proof is the Merkle proof that this tx is included in the
                     position in `key`
-
-                    TODO: maybe it could use here better format as we already
-                    processed and
-
-                    valideated the proof?
               title: |-
-                TransactionInfo is the info of a tx on Bitcoin,
+                TransactionInfoResponse is the info of a tx on Bitcoin,
                 including
                 - the position of the tx on BTC blockchain
                 - the full tx content
@@ -9830,17 +9933,13 @@ definitions:
               properties:
                 submitter:
                   type: string
-                  format: byte
                   description: >-
-                    TODO: this could probably be better typed
-
                     submitter is the address of the checkpoint submitter to BTC,
                     extracted from
 
                     the checkpoint itself.
                 reporter:
                   type: string
-                  format: byte
                   title: >-
                     reporter is the address of the reporter who reported the
                     submissions,
@@ -9848,17 +9947,17 @@ definitions:
                     calculated from submission message MsgInsertBTCSpvProof
                     itself
               title: >-
-                CheckpointAddresses contains the addresses of the submitter and
-                reporter of a
+                CheckpointAddressesResponse contains the addresses of the
+                submitter and reporter of a
 
                 given checkpoint
             title: list of vigilantes' addresses of the best submission
-        title: >-
-          BTCCheckpointInfo contains all data about best submission of
+        description: >-
+          BTCCheckpointInfoResponse contains all data about best submission of
           checkpoint for
 
           given epoch. Best submission is the submission which is deeper in btc
-          ledger
+          ledger.
     title: |-
       QueryBtcCheckpointInfoResponse is response type for the
       Query/BtcCheckpointInfo RPC method
@@ -10208,6 +10307,46 @@ definitions:
       - the position of the tx on BTC blockchain
       - the full tx content
       - the Merkle proof that this tx is on the above position
+  babylon.btccheckpoint.v1.TransactionInfoResponse:
+    type: object
+    properties:
+      key:
+        description: |-
+          key is the position (txIdx, blockHash) of this tx on BTC blockchain
+          Although it is already a part of SubmissionKey, we store it here again
+          to make TransactionInfo self-contained.
+          For example, storing the key allows TransactionInfo to not relay on
+          the fact that TransactionInfo will be ordered in the same order as
+          TransactionKeys in SubmissionKey.
+        type: object
+        properties:
+          index:
+            type: integer
+            format: int64
+            description: Index Bitcoin Transaction index in block.
+          hash:
+            type: string
+            description: Hash BTC Header hash as hex.
+        title: >-
+          TransactionKeyResponse Each provided OP_RETURN transaction can be
+          idendtified by
+
+          hash of block in which transaction was included and transaction index
+          in the block
+      transaction:
+        type: string
+        description: transaction is the full transaction data as str hex.
+      proof:
+        type: string
+        title: >-
+          proof is the Merkle proof that this tx is included in the position in
+          `key`
+    title: |-
+      TransactionInfoResponse is the info of a tx on Bitcoin,
+      including
+      - the position of the tx on BTC blockchain
+      - the full tx content
+      - the Merkle proof that this tx is on the above position
   babylon.btccheckpoint.v1.TransactionKey:
     type: object
     properties:
@@ -10220,6 +10359,22 @@ definitions:
     title: |-
       Each provided OP_RETURN transaction can be idendtified by hash of block in
       which transaction was included and transaction index in the block
+  babylon.btccheckpoint.v1.TransactionKeyResponse:
+    type: object
+    properties:
+      index:
+        type: integer
+        format: int64
+        description: Index Bitcoin Transaction index in block.
+      hash:
+        type: string
+        description: Hash BTC Header hash as hex.
+    title: >-
+      TransactionKeyResponse Each provided OP_RETURN transaction can be
+      idendtified by
+
+      hash of block in which transaction was included and transaction index in
+      the block
   cosmos.base.query.v1beta1.PageRequest:
     type: object
     properties:

--- a/proto/babylon/btccheckpoint/v1/query.proto
+++ b/proto/babylon/btccheckpoint/v1/query.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package babylon.btccheckpoint.v1;
 
 import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
 import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "babylon/btccheckpoint/v1/params.proto";
@@ -55,7 +56,7 @@ message QueryBtcCheckpointInfoRequest {
 
 // QueryBtcCheckpointInfoResponse is response type for the
 // Query/BtcCheckpointInfo RPC method
-message QueryBtcCheckpointInfoResponse { BTCCheckpointInfo info = 1; }
+message QueryBtcCheckpointInfoResponse { BTCCheckpointInfoResponse info = 1; }
 
 // QueryBtcCheckpointsInfoRequest is request type for the
 // Query/BtcCheckpointsInfo RPC method
@@ -88,4 +89,59 @@ message QueryEpochSubmissionsResponse {
   repeated SubmissionKey keys = 1;
 
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// BTCCheckpointInfoResponse contains all data about best submission of checkpoint for
+// given epoch. Best submission is the submission which is deeper in btc ledger.
+message BTCCheckpointInfoResponse {
+  // EpochNumber of this checkpoint.
+  uint64 epoch_number = 1;
+  // btc height of the best submission of the epoch
+  uint64 best_submission_btc_block_height = 2;
+  // hash of the btc block which determines checkpoint btc block height i.e.
+  // youngest block of best submission Hexadecimal
+  string best_submission_btc_block_hash = 3;
+  // the BTC checkpoint transactions of the best submission
+  repeated TransactionInfoResponse best_submission_transactions = 4;
+  // list of vigilantes' addresses of the best submission
+  repeated CheckpointAddressesResponse best_submission_vigilante_address_list = 5;
+}
+
+// TransactionInfoResponse is the info of a tx on Bitcoin,
+// including
+// - the position of the tx on BTC blockchain
+// - the full tx content
+// - the Merkle proof that this tx is on the above position
+message TransactionInfoResponse {
+  // key is the position (txIdx, blockHash) of this tx on BTC blockchain
+  // Although it is already a part of SubmissionKey, we store it here again
+  // to make TransactionInfo self-contained.
+  // For example, storing the key allows TransactionInfo to not relay on
+  // the fact that TransactionInfo will be ordered in the same order as
+  // TransactionKeys in SubmissionKey.
+  TransactionKeyResponse key = 1;
+  // transaction is the full transaction data as str hex.
+  string transaction = 2;
+  // proof is the Merkle proof that this tx is included in the position in `key`
+  string proof = 3;
+}
+
+// TransactionKeyResponse Each provided OP_RETURN transaction can be idendtified by
+// hash of block in which transaction was included and transaction index in the block
+message TransactionKeyResponse {
+  // Index Bitcoin Transaction index in block.
+  uint32 index = 1;
+  // Hash BTC Header hash as hex.
+  string hash = 2;
+}
+
+// CheckpointAddressesResponse contains the addresses of the submitter and reporter of a
+// given checkpoint
+message CheckpointAddressesResponse {
+  // submitter is the address of the checkpoint submitter to BTC, extracted from
+  // the checkpoint itself.
+  string submitter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // reporter is the address of the reporter who reported the submissions,
+  // calculated from submission message MsgInsertBTCSpvProof itself
+  string reporter = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }

--- a/x/btccheckpoint/keeper/grpc_query.go
+++ b/x/btccheckpoint/keeper/grpc_query.go
@@ -44,21 +44,17 @@ func (k Keeper) BtcCheckpointInfo(c context.Context, req *types.QueryBtcCheckpoi
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
-
 	checkpointEpoch := req.GetEpochNum()
 
 	ed := k.GetEpochData(ctx, checkpointEpoch)
-
 	ckptInfo, err := k.getCheckpointInfo(ctx, checkpointEpoch, ed)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to get lowest BTC height and hash in keys of epoch %d: %w", req.EpochNum, err)
 	}
 
-	resp := &types.QueryBtcCheckpointInfoResponse{
-		Info: ckptInfo,
-	}
-	return resp, nil
+	return &types.QueryBtcCheckpointInfoResponse{
+		Info: ckptInfo.ToResponse(),
+	}, nil
 }
 
 func (k Keeper) BtcCheckpointsInfo(ctx context.Context, req *types.QueryBtcCheckpointsInfoRequest) (*types.QueryBtcCheckpointsInfoResponse, error) {

--- a/x/btccheckpoint/types/query.go
+++ b/x/btccheckpoint/types/query.go
@@ -1,0 +1,52 @@
+package types
+
+import (
+	"encoding/hex"
+
+	"github.com/cosmos/cosmos-sdk/types"
+)
+
+// ToResponse parses a TransactionInfo into a query response tx info struct.
+func (ti *TransactionInfo) ToResponse() *TransactionInfoResponse {
+	return &TransactionInfoResponse{
+		Key:         ti.Key.ToResponse(),
+		Transaction: hex.EncodeToString(ti.Transaction),
+		Proof:       hex.EncodeToString(ti.Proof),
+	}
+}
+
+// ToResponse parses a TransactionKeyResponse into a query response tx key struct.
+func (tk *TransactionKey) ToResponse() *TransactionKeyResponse {
+	return &TransactionKeyResponse{
+		Index: tk.Index,
+		Hash:  hex.EncodeToString(*tk.Hash),
+	}
+}
+
+// ToResponse parses a CheckpointAddresses into a query response checkpoint addresses struct.
+func (ca *CheckpointAddresses) ToResponse() *CheckpointAddressesResponse {
+	return &CheckpointAddressesResponse{
+		Submitter: types.AccAddress(ca.Submitter).String(),
+		Reporter:  types.AccAddress(ca.Reporter).String(),
+	}
+}
+
+// ToResponse parses a BTCCheckpointInfo into a query response for btc checkpoint info struct.
+func (b BTCCheckpointInfo) ToResponse() *BTCCheckpointInfoResponse {
+	bestSubTxs := make([]*TransactionInfoResponse, len(b.BestSubmissionTransactions))
+	for i, tx := range b.BestSubmissionTransactions {
+		bestSubTxs[i] = tx.ToResponse()
+	}
+	bestSubVigAddrs := make([]*CheckpointAddressesResponse, len(b.BestSubmissionVigilanteAddressList))
+	for i, addrs := range b.BestSubmissionVigilanteAddressList {
+		bestSubVigAddrs[i] = addrs.ToResponse()
+	}
+
+	return &BTCCheckpointInfoResponse{
+		EpochNumber:                        b.EpochNumber,
+		BestSubmissionBtcBlockHeight:       b.BestSubmissionBtcBlockHeight,
+		BestSubmissionBtcBlockHash:         hex.EncodeToString(*b.BestSubmissionBtcBlockHash),
+		BestSubmissionTransactions:         bestSubTxs,
+		BestSubmissionVigilanteAddressList: bestSubVigAddrs,
+	}
+}

--- a/x/btccheckpoint/types/query.pb.go
+++ b/x/btccheckpoint/types/query.pb.go
@@ -6,6 +6,7 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	_ "github.com/cosmos/cosmos-proto"
 	query "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
@@ -164,7 +165,7 @@ func (m *QueryBtcCheckpointInfoRequest) GetEpochNum() uint64 {
 // QueryBtcCheckpointInfoResponse is response type for the
 // Query/BtcCheckpointInfo RPC method
 type QueryBtcCheckpointInfoResponse struct {
-	Info *BTCCheckpointInfo `protobuf:"bytes,1,opt,name=info,proto3" json:"info,omitempty"`
+	Info *BTCCheckpointInfoResponse `protobuf:"bytes,1,opt,name=info,proto3" json:"info,omitempty"`
 }
 
 func (m *QueryBtcCheckpointInfoResponse) Reset()         { *m = QueryBtcCheckpointInfoResponse{} }
@@ -200,7 +201,7 @@ func (m *QueryBtcCheckpointInfoResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryBtcCheckpointInfoResponse proto.InternalMessageInfo
 
-func (m *QueryBtcCheckpointInfoResponse) GetInfo() *BTCCheckpointInfo {
+func (m *QueryBtcCheckpointInfoResponse) GetInfo() *BTCCheckpointInfoResponse {
 	if m != nil {
 		return m.Info
 	}
@@ -419,6 +420,277 @@ func (m *QueryEpochSubmissionsResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
+// BTCCheckpointInfoResponse contains all data about best submission of checkpoint for
+// given epoch. Best submission is the submission which is deeper in btc ledger.
+type BTCCheckpointInfoResponse struct {
+	// EpochNumber of this checkpoint.
+	EpochNumber uint64 `protobuf:"varint,1,opt,name=epoch_number,json=epochNumber,proto3" json:"epoch_number,omitempty"`
+	// btc height of the best submission of the epoch
+	BestSubmissionBtcBlockHeight uint64 `protobuf:"varint,2,opt,name=best_submission_btc_block_height,json=bestSubmissionBtcBlockHeight,proto3" json:"best_submission_btc_block_height,omitempty"`
+	// hash of the btc block which determines checkpoint btc block height i.e.
+	// youngest block of best submission Hexadecimal
+	BestSubmissionBtcBlockHash string `protobuf:"bytes,3,opt,name=best_submission_btc_block_hash,json=bestSubmissionBtcBlockHash,proto3" json:"best_submission_btc_block_hash,omitempty"`
+	// the BTC checkpoint transactions of the best submission
+	BestSubmissionTransactions []*TransactionInfoResponse `protobuf:"bytes,4,rep,name=best_submission_transactions,json=bestSubmissionTransactions,proto3" json:"best_submission_transactions,omitempty"`
+	// list of vigilantes' addresses of the best submission
+	BestSubmissionVigilanteAddressList []*CheckpointAddressesResponse `protobuf:"bytes,5,rep,name=best_submission_vigilante_address_list,json=bestSubmissionVigilanteAddressList,proto3" json:"best_submission_vigilante_address_list,omitempty"`
+}
+
+func (m *BTCCheckpointInfoResponse) Reset()         { *m = BTCCheckpointInfoResponse{} }
+func (m *BTCCheckpointInfoResponse) String() string { return proto.CompactTextString(m) }
+func (*BTCCheckpointInfoResponse) ProtoMessage()    {}
+func (*BTCCheckpointInfoResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6b9a2f46ada7d854, []int{8}
+}
+func (m *BTCCheckpointInfoResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BTCCheckpointInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BTCCheckpointInfoResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BTCCheckpointInfoResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BTCCheckpointInfoResponse.Merge(m, src)
+}
+func (m *BTCCheckpointInfoResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *BTCCheckpointInfoResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_BTCCheckpointInfoResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BTCCheckpointInfoResponse proto.InternalMessageInfo
+
+func (m *BTCCheckpointInfoResponse) GetEpochNumber() uint64 {
+	if m != nil {
+		return m.EpochNumber
+	}
+	return 0
+}
+
+func (m *BTCCheckpointInfoResponse) GetBestSubmissionBtcBlockHeight() uint64 {
+	if m != nil {
+		return m.BestSubmissionBtcBlockHeight
+	}
+	return 0
+}
+
+func (m *BTCCheckpointInfoResponse) GetBestSubmissionBtcBlockHash() string {
+	if m != nil {
+		return m.BestSubmissionBtcBlockHash
+	}
+	return ""
+}
+
+func (m *BTCCheckpointInfoResponse) GetBestSubmissionTransactions() []*TransactionInfoResponse {
+	if m != nil {
+		return m.BestSubmissionTransactions
+	}
+	return nil
+}
+
+func (m *BTCCheckpointInfoResponse) GetBestSubmissionVigilanteAddressList() []*CheckpointAddressesResponse {
+	if m != nil {
+		return m.BestSubmissionVigilanteAddressList
+	}
+	return nil
+}
+
+// TransactionInfoResponse is the info of a tx on Bitcoin,
+// including
+// - the position of the tx on BTC blockchain
+// - the full tx content
+// - the Merkle proof that this tx is on the above position
+type TransactionInfoResponse struct {
+	// key is the position (txIdx, blockHash) of this tx on BTC blockchain
+	// Although it is already a part of SubmissionKey, we store it here again
+	// to make TransactionInfo self-contained.
+	// For example, storing the key allows TransactionInfo to not relay on
+	// the fact that TransactionInfo will be ordered in the same order as
+	// TransactionKeys in SubmissionKey.
+	Key *TransactionKeyResponse `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// transaction is the full transaction data as str hex.
+	Transaction string `protobuf:"bytes,2,opt,name=transaction,proto3" json:"transaction,omitempty"`
+	// proof is the Merkle proof that this tx is included in the position in `key`
+	Proof string `protobuf:"bytes,3,opt,name=proof,proto3" json:"proof,omitempty"`
+}
+
+func (m *TransactionInfoResponse) Reset()         { *m = TransactionInfoResponse{} }
+func (m *TransactionInfoResponse) String() string { return proto.CompactTextString(m) }
+func (*TransactionInfoResponse) ProtoMessage()    {}
+func (*TransactionInfoResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6b9a2f46ada7d854, []int{9}
+}
+func (m *TransactionInfoResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *TransactionInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_TransactionInfoResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *TransactionInfoResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TransactionInfoResponse.Merge(m, src)
+}
+func (m *TransactionInfoResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *TransactionInfoResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_TransactionInfoResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TransactionInfoResponse proto.InternalMessageInfo
+
+func (m *TransactionInfoResponse) GetKey() *TransactionKeyResponse {
+	if m != nil {
+		return m.Key
+	}
+	return nil
+}
+
+func (m *TransactionInfoResponse) GetTransaction() string {
+	if m != nil {
+		return m.Transaction
+	}
+	return ""
+}
+
+func (m *TransactionInfoResponse) GetProof() string {
+	if m != nil {
+		return m.Proof
+	}
+	return ""
+}
+
+// TransactionKeyResponse Each provided OP_RETURN transaction can be idendtified by
+// hash of block in which transaction was included and transaction index in the block
+type TransactionKeyResponse struct {
+	// Index Bitcoin Transaction index in block.
+	Index uint32 `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
+	// Hash BTC Header hash as hex.
+	Hash string `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
+}
+
+func (m *TransactionKeyResponse) Reset()         { *m = TransactionKeyResponse{} }
+func (m *TransactionKeyResponse) String() string { return proto.CompactTextString(m) }
+func (*TransactionKeyResponse) ProtoMessage()    {}
+func (*TransactionKeyResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6b9a2f46ada7d854, []int{10}
+}
+func (m *TransactionKeyResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *TransactionKeyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_TransactionKeyResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *TransactionKeyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TransactionKeyResponse.Merge(m, src)
+}
+func (m *TransactionKeyResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *TransactionKeyResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_TransactionKeyResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TransactionKeyResponse proto.InternalMessageInfo
+
+func (m *TransactionKeyResponse) GetIndex() uint32 {
+	if m != nil {
+		return m.Index
+	}
+	return 0
+}
+
+func (m *TransactionKeyResponse) GetHash() string {
+	if m != nil {
+		return m.Hash
+	}
+	return ""
+}
+
+// CheckpointAddressesResponse contains the addresses of the submitter and reporter of a
+// given checkpoint
+type CheckpointAddressesResponse struct {
+	// submitter is the address of the checkpoint submitter to BTC, extracted from
+	// the checkpoint itself.
+	Submitter string `protobuf:"bytes,1,opt,name=submitter,proto3" json:"submitter,omitempty"`
+	// reporter is the address of the reporter who reported the submissions,
+	// calculated from submission message MsgInsertBTCSpvProof itself
+	Reporter string `protobuf:"bytes,2,opt,name=reporter,proto3" json:"reporter,omitempty"`
+}
+
+func (m *CheckpointAddressesResponse) Reset()         { *m = CheckpointAddressesResponse{} }
+func (m *CheckpointAddressesResponse) String() string { return proto.CompactTextString(m) }
+func (*CheckpointAddressesResponse) ProtoMessage()    {}
+func (*CheckpointAddressesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6b9a2f46ada7d854, []int{11}
+}
+func (m *CheckpointAddressesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *CheckpointAddressesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_CheckpointAddressesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *CheckpointAddressesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckpointAddressesResponse.Merge(m, src)
+}
+func (m *CheckpointAddressesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *CheckpointAddressesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CheckpointAddressesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CheckpointAddressesResponse proto.InternalMessageInfo
+
+func (m *CheckpointAddressesResponse) GetSubmitter() string {
+	if m != nil {
+		return m.Submitter
+	}
+	return ""
+}
+
+func (m *CheckpointAddressesResponse) GetReporter() string {
+	if m != nil {
+		return m.Reporter
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*QueryParamsRequest)(nil), "babylon.btccheckpoint.v1.QueryParamsRequest")
 	proto.RegisterType((*QueryParamsResponse)(nil), "babylon.btccheckpoint.v1.QueryParamsResponse")
@@ -428,6 +700,10 @@ func init() {
 	proto.RegisterType((*QueryBtcCheckpointsInfoResponse)(nil), "babylon.btccheckpoint.v1.QueryBtcCheckpointsInfoResponse")
 	proto.RegisterType((*QueryEpochSubmissionsRequest)(nil), "babylon.btccheckpoint.v1.QueryEpochSubmissionsRequest")
 	proto.RegisterType((*QueryEpochSubmissionsResponse)(nil), "babylon.btccheckpoint.v1.QueryEpochSubmissionsResponse")
+	proto.RegisterType((*BTCCheckpointInfoResponse)(nil), "babylon.btccheckpoint.v1.BTCCheckpointInfoResponse")
+	proto.RegisterType((*TransactionInfoResponse)(nil), "babylon.btccheckpoint.v1.TransactionInfoResponse")
+	proto.RegisterType((*TransactionKeyResponse)(nil), "babylon.btccheckpoint.v1.TransactionKeyResponse")
+	proto.RegisterType((*CheckpointAddressesResponse)(nil), "babylon.btccheckpoint.v1.CheckpointAddressesResponse")
 }
 
 func init() {
@@ -435,46 +711,65 @@ func init() {
 }
 
 var fileDescriptor_6b9a2f46ada7d854 = []byte{
-	// 621 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x95, 0x4d, 0x6b, 0x13, 0x4f,
-	0x1c, 0xc7, 0x33, 0xf9, 0xa7, 0xa1, 0x9d, 0xff, 0x45, 0xc7, 0x1e, 0xe2, 0xb6, 0x6e, 0xe3, 0x62,
-	0x4d, 0xd1, 0x76, 0x97, 0xb4, 0x68, 0x2d, 0x8a, 0x42, 0x8a, 0x4f, 0x28, 0x5a, 0xa3, 0x5e, 0xbc,
-	0x94, 0xd9, 0x65, 0xba, 0x59, 0x9a, 0x9d, 0xd9, 0x66, 0x66, 0x83, 0x41, 0xbc, 0xe8, 0x0b, 0x50,
-	0xf0, 0x35, 0x78, 0xf3, 0xa8, 0x57, 0xc1, 0x5b, 0x8f, 0x05, 0x2f, 0x9e, 0x44, 0x12, 0x5f, 0x88,
-	0xec, 0xec, 0x34, 0x8f, 0x0e, 0x49, 0x8a, 0xb7, 0xb0, 0xf9, 0x7e, 0x7f, 0xdf, 0xcf, 0xfe, 0x1e,
-	0x12, 0x78, 0xc1, 0xc5, 0x6e, 0xab, 0xce, 0xa8, 0xe3, 0x0a, 0xcf, 0xab, 0x11, 0x6f, 0x3f, 0x62,
-	0x01, 0x15, 0x4e, 0xb3, 0xec, 0x1c, 0xc4, 0xa4, 0xd1, 0xb2, 0xa3, 0x06, 0x13, 0x0c, 0x15, 0x94,
-	0xca, 0x1e, 0x50, 0xd9, 0xcd, 0xb2, 0x31, 0xef, 0x33, 0x9f, 0x49, 0x91, 0x93, 0x7c, 0x4a, 0xf5,
-	0xc6, 0xa2, 0xcf, 0x98, 0x5f, 0x27, 0x0e, 0x8e, 0x02, 0x07, 0x53, 0xca, 0x04, 0x16, 0x01, 0xa3,
-	0x5c, 0x7d, 0x7b, 0xc9, 0x63, 0x3c, 0x64, 0xdc, 0x71, 0x31, 0x27, 0x69, 0x8c, 0xd3, 0x2c, 0xbb,
-	0x44, 0xe0, 0xb2, 0x13, 0x61, 0x3f, 0xa0, 0x52, 0xac, 0xb4, 0xcb, 0x5a, 0xbe, 0x08, 0x37, 0x70,
-	0x78, 0x5c, 0x72, 0x55, 0x2b, 0x1b, 0x24, 0x96, 0x6a, 0x6b, 0x1e, 0xa2, 0x27, 0x49, 0xec, 0x8e,
-	0x2c, 0x51, 0x25, 0x07, 0x31, 0xe1, 0xc2, 0x7a, 0x0e, 0xcf, 0x0c, 0x3c, 0xe5, 0x11, 0xa3, 0x9c,
-	0xa0, 0x9b, 0x30, 0x9f, 0x46, 0x15, 0x40, 0x11, 0xac, 0xfc, 0xbf, 0x5e, 0xb4, 0x75, 0xcd, 0xb0,
-	0x53, 0x67, 0x25, 0x77, 0xf8, 0x73, 0x29, 0x53, 0x55, 0x2e, 0xeb, 0x06, 0x3c, 0x27, 0xcb, 0x56,
-	0x84, 0xb7, 0xdd, 0x55, 0xdf, 0xa7, 0x7b, 0x4c, 0xe5, 0xa2, 0x05, 0x38, 0x47, 0x22, 0xe6, 0xd5,
-	0x76, 0x69, 0x1c, 0xca, 0x8c, 0x5c, 0x75, 0x56, 0x3e, 0x78, 0x14, 0x87, 0x16, 0x86, 0xa6, 0xce,
-	0xad, 0xf8, 0x6e, 0xc1, 0x5c, 0x40, 0xf7, 0x98, 0xa2, 0xbb, 0xac, 0xa7, 0xab, 0x3c, 0xdb, 0x1e,
-	0x2a, 0x21, 0x8d, 0x56, 0xed, 0x6f, 0x11, 0xbc, 0x9f, 0xf0, 0x0e, 0x84, 0xbd, 0xc1, 0xa8, 0xa0,
-	0x8b, 0x76, 0x3a, 0x45, 0x3b, 0x99, 0xa2, 0x9d, 0x2e, 0x8b, 0x9a, 0xa2, 0xbd, 0x83, 0x7d, 0xa2,
-	0xbc, 0xd5, 0x3e, 0xa7, 0xf5, 0x19, 0xc0, 0x25, 0x6d, 0x94, 0x7a, 0x9d, 0x7b, 0x70, 0x2e, 0xa1,
-	0xda, 0xad, 0x07, 0x5c, 0x14, 0x40, 0xf1, 0xbf, 0x69, 0xdf, 0x69, 0x36, 0x71, 0x3f, 0x0c, 0xb8,
-	0x40, 0x77, 0x07, 0xa8, 0xb3, 0x92, 0xba, 0x34, 0x96, 0x3a, 0xc5, 0x18, 0xc0, 0x7e, 0x0b, 0xe0,
-	0xa2, 0xc4, 0xbe, 0x9d, 0x4c, 0xe5, 0x69, 0xec, 0x86, 0x01, 0xe7, 0xc9, 0x3e, 0x4f, 0x32, 0xc1,
-	0xa1, 0xe6, 0x65, 0x4f, 0xdc, 0xbc, 0x8f, 0x40, 0x2d, 0xd2, 0x28, 0x85, 0x6a, 0xdd, 0x75, 0x98,
-	0xdb, 0x27, 0x2d, 0xae, 0xba, 0x56, 0xd2, 0x77, 0xad, 0x67, 0x7e, 0x40, 0x5a, 0x55, 0x69, 0xfa,
-	0x67, 0xdd, 0x5a, 0xff, 0x36, 0x03, 0x67, 0x24, 0x27, 0x7a, 0x07, 0x60, 0x3e, 0x3d, 0x09, 0xb4,
-	0xaa, 0x87, 0x19, 0xbd, 0x44, 0x63, 0x6d, 0x42, 0x75, 0x9a, 0x6e, 0xad, 0xbc, 0xf9, 0xfe, 0xfb,
-	0x43, 0xd6, 0x42, 0x45, 0x67, 0xcc, 0x8f, 0x05, 0xfa, 0x02, 0xe0, 0xe9, 0x91, 0x4b, 0x42, 0x9b,
-	0x63, 0xe2, 0x74, 0x97, 0x6b, 0x5c, 0x9b, 0xde, 0xa8, 0x90, 0xd7, 0x24, 0x72, 0x09, 0x2d, 0xeb,
-	0x91, 0x5f, 0x75, 0x57, 0xea, 0x35, 0xfa, 0x04, 0x20, 0x1a, 0xbd, 0x19, 0x34, 0x55, 0x7e, 0xff,
-	0x45, 0x1b, 0x5b, 0x27, 0x70, 0x2a, 0xf4, 0xf3, 0x12, 0x7d, 0x01, 0x9d, 0xd5, 0xa2, 0xa3, 0xaf,
-	0x00, 0x9e, 0x1a, 0xde, 0x52, 0x74, 0x75, 0x4c, 0xa4, 0xe6, 0xb8, 0x8c, 0xcd, 0xa9, 0x7d, 0x0a,
-	0x74, 0x4b, 0x82, 0x6e, 0xa0, 0xf2, 0x44, 0x3d, 0x76, 0x78, 0xaf, 0x44, 0xe5, 0xf1, 0x61, 0xdb,
-	0x04, 0x47, 0x6d, 0x13, 0xfc, 0x6a, 0x9b, 0xe0, 0x7d, 0xc7, 0xcc, 0x1c, 0x75, 0xcc, 0xcc, 0x8f,
-	0x8e, 0x99, 0x79, 0x71, 0xc5, 0x0f, 0x44, 0x2d, 0x76, 0x6d, 0x8f, 0x85, 0xc7, 0x65, 0xbd, 0x1a,
-	0x0e, 0x68, 0x37, 0xe3, 0xe5, 0x50, 0x8a, 0x68, 0x45, 0x84, 0xbb, 0x79, 0xf9, 0xc7, 0xb3, 0xf1,
-	0x27, 0x00, 0x00, 0xff, 0xff, 0x19, 0x16, 0x59, 0xdc, 0x6f, 0x07, 0x00, 0x00,
+	// 920 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0xcf, 0x6f, 0xdc, 0x44,
+	0x18, 0xcd, 0x24, 0x9b, 0x28, 0xfb, 0x05, 0x24, 0x18, 0x22, 0xd8, 0x6c, 0x82, 0xbb, 0xb5, 0x68,
+	0x13, 0x41, 0x63, 0xb3, 0x09, 0x6d, 0xa9, 0x40, 0x48, 0xb8, 0xa2, 0x2d, 0x02, 0x41, 0x71, 0x0b,
+	0x07, 0x2e, 0xd6, 0xd8, 0x99, 0xd8, 0xa3, 0xec, 0x7a, 0x5c, 0xcf, 0x6c, 0xd4, 0x15, 0xe2, 0x02,
+	0x27, 0xc4, 0x01, 0x24, 0xc4, 0x9f, 0xc0, 0x8d, 0x63, 0xb9, 0x22, 0x71, 0xab, 0xc4, 0xa5, 0x82,
+	0x0b, 0x27, 0x84, 0x12, 0xfe, 0x10, 0xe4, 0xf1, 0xec, 0xef, 0x4c, 0x77, 0x37, 0xe2, 0xb6, 0xb6,
+	0xdf, 0xfb, 0xde, 0x9b, 0xf7, 0xcd, 0xcc, 0xb7, 0xf0, 0x4a, 0x48, 0xc2, 0x6e, 0x8b, 0xa7, 0x6e,
+	0x28, 0xa3, 0x28, 0xa1, 0xd1, 0x51, 0xc6, 0x59, 0x2a, 0xdd, 0xe3, 0xa6, 0xfb, 0xa0, 0x43, 0xf3,
+	0xae, 0x93, 0xe5, 0x5c, 0x72, 0x5c, 0xd3, 0x28, 0x67, 0x04, 0xe5, 0x1c, 0x37, 0xeb, 0xeb, 0x31,
+	0x8f, 0xb9, 0x02, 0xb9, 0xc5, 0xaf, 0x12, 0x5f, 0xdf, 0x88, 0xb8, 0x68, 0x73, 0x11, 0x94, 0x1f,
+	0xca, 0x07, 0xfd, 0x69, 0x2b, 0xe6, 0x3c, 0x6e, 0x51, 0x97, 0x64, 0xcc, 0x25, 0x69, 0xca, 0x25,
+	0x91, 0x8c, 0xa7, 0xbd, 0xaf, 0xaf, 0x96, 0x58, 0x37, 0x24, 0x82, 0x96, 0x0e, 0xdc, 0xe3, 0x66,
+	0x48, 0x25, 0x69, 0xba, 0x19, 0x89, 0x59, 0xaa, 0xc0, 0x1a, 0x7b, 0xc9, 0x68, 0x3d, 0x23, 0x39,
+	0x69, 0xf7, 0x4a, 0x5e, 0x31, 0xc2, 0x46, 0x17, 0xa3, 0xd0, 0xf6, 0x3a, 0xe0, 0x4f, 0x0a, 0xd9,
+	0xbb, 0xaa, 0x84, 0x4f, 0x1f, 0x74, 0xa8, 0x90, 0xf6, 0xa7, 0xf0, 0xc2, 0xc8, 0x5b, 0x91, 0xf1,
+	0x54, 0x50, 0xfc, 0x0e, 0xac, 0x94, 0x52, 0x35, 0xd4, 0x40, 0x3b, 0x6b, 0x7b, 0x0d, 0xc7, 0x94,
+	0x93, 0x53, 0x32, 0xbd, 0xca, 0xe3, 0xbf, 0x2f, 0x2c, 0xf8, 0x9a, 0x65, 0xbf, 0x0d, 0x2f, 0xab,
+	0xb2, 0x9e, 0x8c, 0x6e, 0xf6, 0xd1, 0xef, 0xa7, 0x87, 0x5c, 0xeb, 0xe2, 0x4d, 0xa8, 0xd2, 0x8c,
+	0x47, 0x49, 0x90, 0x76, 0xda, 0x4a, 0xa3, 0xe2, 0xaf, 0xaa, 0x17, 0x1f, 0x75, 0xda, 0x36, 0x03,
+	0xcb, 0xc4, 0xd6, 0xfe, 0x6e, 0x43, 0x85, 0xa5, 0x87, 0x5c, 0xbb, 0xdb, 0x37, 0xbb, 0xf3, 0xee,
+	0xdf, 0x3c, 0xbb, 0x84, 0xaf, 0x0a, 0xd8, 0xc9, 0x59, 0x52, 0x62, 0xd8, 0xe9, 0x2d, 0x80, 0x41,
+	0x83, 0xb4, 0xe0, 0x65, 0x47, 0x77, 0xbe, 0xe8, 0xa6, 0x53, 0xee, 0x27, 0xdd, 0x4d, 0xe7, 0x2e,
+	0x89, 0xa9, 0xe6, 0xfa, 0x43, 0x4c, 0xfb, 0x11, 0x82, 0x0b, 0x46, 0x29, 0xbd, 0xac, 0x3b, 0x50,
+	0x2d, 0x5c, 0x05, 0x2d, 0x26, 0x64, 0x0d, 0x35, 0x96, 0x76, 0xd6, 0xf6, 0x5e, 0x9b, 0x67, 0x6d,
+	0xab, 0x05, 0xfb, 0x43, 0x26, 0x24, 0xbe, 0x3d, 0xe2, 0x7a, 0x51, 0xb9, 0xde, 0x9e, 0xea, 0x5a,
+	0x47, 0x33, 0x6c, 0xfb, 0x6b, 0x04, 0x5b, 0xca, 0xf6, 0x7b, 0x45, 0x77, 0xee, 0x75, 0xc2, 0x36,
+	0x13, 0xa2, 0xd8, 0xd7, 0xb3, 0x74, 0x72, 0x2c, 0xbc, 0xc5, 0x73, 0x87, 0xf7, 0x13, 0xd2, 0x1b,
+	0x6a, 0xd2, 0x85, 0x8e, 0xee, 0x2d, 0xa8, 0x1c, 0xd1, 0xae, 0xd0, 0xa9, 0x6d, 0x9b, 0x53, 0x1b,
+	0x90, 0x3f, 0xa0, 0x5d, 0x5f, 0x91, 0xfe, 0xbf, 0xb4, 0x7e, 0x5f, 0x82, 0x0d, 0xe3, 0x96, 0xc3,
+	0x17, 0xe1, 0x99, 0x7e, 0x54, 0x21, 0xcd, 0x75, 0x5a, 0x6b, 0xbd, 0xb4, 0x42, 0x9a, 0xe3, 0x5b,
+	0xd0, 0x08, 0xa9, 0x90, 0x81, 0xe8, 0xbb, 0x0c, 0x42, 0x19, 0x05, 0x61, 0x8b, 0x47, 0x47, 0x41,
+	0x42, 0x59, 0x9c, 0x48, 0xe5, 0xaf, 0xe2, 0x6f, 0x15, 0xb8, 0xc1, 0x62, 0x3c, 0x19, 0x79, 0x05,
+	0xe8, 0x8e, 0xc2, 0x60, 0x0f, 0xac, 0xa7, 0xd4, 0x21, 0x22, 0xa9, 0x2d, 0x35, 0xd0, 0x4e, 0xd5,
+	0xaf, 0x1b, 0xaa, 0x10, 0x91, 0x60, 0x01, 0x5b, 0xe3, 0x35, 0x64, 0x4e, 0x52, 0x41, 0x22, 0x75,
+	0xb1, 0xd5, 0x2a, 0x2a, 0xea, 0xa6, 0x39, 0xea, 0xfb, 0x03, 0xf4, 0xc8, 0xd1, 0x1b, 0x13, 0x1d,
+	0x82, 0x09, 0xfc, 0x0d, 0x82, 0xcb, 0xe3, 0xaa, 0xc7, 0x2c, 0x66, 0x2d, 0x92, 0x4a, 0x1a, 0x90,
+	0x83, 0x83, 0x9c, 0x0a, 0x51, 0x1e, 0x90, 0x65, 0xa5, 0x7f, 0xd5, 0xac, 0x3f, 0x68, 0xc3, 0xbb,
+	0x25, 0x8f, 0xf6, 0xf7, 0x8b, 0x6f, 0x8f, 0x7a, 0xf8, 0xac, 0x27, 0xa1, 0x91, 0xc5, 0x21, 0xb2,
+	0x7f, 0x44, 0xf0, 0x92, 0x61, 0x0d, 0xd8, 0x83, 0xa5, 0x23, 0xda, 0xd5, 0xf7, 0xc1, 0xeb, 0x33,
+	0x65, 0x50, 0xec, 0xb7, 0x9e, 0x7c, 0x41, 0xc6, 0x0d, 0x58, 0x1b, 0x0a, 0x54, 0xf5, 0xb5, 0xea,
+	0x0f, 0xbf, 0xc2, 0xeb, 0xb0, 0x9c, 0xe5, 0x9c, 0x1f, 0xea, 0x6e, 0x95, 0x0f, 0xb6, 0x07, 0x2f,
+	0x9e, 0x5d, 0xb6, 0xc0, 0xb3, 0xf4, 0x80, 0x3e, 0x54, 0xbe, 0x9e, 0xf5, 0xcb, 0x07, 0x8c, 0xa1,
+	0xa2, 0x5a, 0x5e, 0x0a, 0xa8, 0xdf, 0xf6, 0xb7, 0x08, 0x36, 0x9f, 0x92, 0x0f, 0xbe, 0x06, 0x55,
+	0xd5, 0x01, 0x29, 0xf5, 0x46, 0xad, 0x7a, 0xb5, 0x3f, 0x1e, 0xed, 0xae, 0xeb, 0x43, 0xa1, 0x09,
+	0xf7, 0x64, 0xce, 0xd2, 0xd8, 0x1f, 0x40, 0xf1, 0x1b, 0xb0, 0x9a, 0xd3, 0x8c, 0xe7, 0x05, 0x6d,
+	0x71, 0x0a, 0xad, 0x8f, 0xdc, 0xfb, 0x6d, 0x19, 0x96, 0xd5, 0xf9, 0xc6, 0xdf, 0x21, 0x58, 0x29,
+	0x47, 0x0a, 0xbe, 0x62, 0x4e, 0x75, 0x72, 0x92, 0xd5, 0x77, 0x67, 0x44, 0x97, 0xeb, 0xb3, 0x77,
+	0xbe, 0xfa, 0xf3, 0xdf, 0x1f, 0x16, 0x6d, 0xdc, 0x70, 0xa7, 0x0c, 0x5b, 0xfc, 0x0b, 0x82, 0xe7,
+	0x27, 0x26, 0x11, 0xbe, 0x3e, 0x45, 0xce, 0x34, 0xf9, 0xea, 0x6f, 0xce, 0x4f, 0xd4, 0x96, 0x77,
+	0x95, 0xe5, 0x6d, 0x7c, 0xc9, 0x6c, 0xf9, 0x8b, 0xfe, 0xfd, 0xf2, 0x25, 0xfe, 0x19, 0x01, 0x9e,
+	0x9c, 0x35, 0x78, 0x2e, 0xfd, 0xe1, 0x49, 0x58, 0xbf, 0x71, 0x0e, 0xa6, 0xb6, 0x7e, 0x51, 0x59,
+	0xdf, 0xc4, 0x1b, 0x46, 0xeb, 0xf8, 0x57, 0x04, 0xcf, 0x8d, 0xdf, 0xee, 0xf8, 0xda, 0x14, 0x49,
+	0xc3, 0x50, 0xaa, 0x5f, 0x9f, 0x9b, 0xa7, 0x8d, 0xde, 0x50, 0x46, 0xf7, 0x71, 0x73, 0xa6, 0x8c,
+	0xdd, 0xc1, 0x25, 0x25, 0xbc, 0x8f, 0x1f, 0x9f, 0x58, 0xe8, 0xc9, 0x89, 0x85, 0xfe, 0x39, 0xb1,
+	0xd0, 0xf7, 0xa7, 0xd6, 0xc2, 0x93, 0x53, 0x6b, 0xe1, 0xaf, 0x53, 0x6b, 0xe1, 0xf3, 0xab, 0x31,
+	0x93, 0x49, 0x27, 0x74, 0x22, 0xde, 0xee, 0x95, 0x8d, 0x12, 0xc2, 0xd2, 0xbe, 0xc6, 0xc3, 0x31,
+	0x15, 0xd9, 0xcd, 0xa8, 0x08, 0x57, 0xd4, 0x1f, 0xb7, 0xfd, 0xff, 0x02, 0x00, 0x00, 0xff, 0xff,
+	0x2e, 0xd4, 0x53, 0xae, 0xca, 0x0a, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -965,6 +1260,195 @@ func (m *QueryEpochSubmissionsResponse) MarshalToSizedBuffer(dAtA []byte) (int, 
 	return len(dAtA) - i, nil
 }
 
+func (m *BTCCheckpointInfoResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BTCCheckpointInfoResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BTCCheckpointInfoResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.BestSubmissionVigilanteAddressList) > 0 {
+		for iNdEx := len(m.BestSubmissionVigilanteAddressList) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.BestSubmissionVigilanteAddressList[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if len(m.BestSubmissionTransactions) > 0 {
+		for iNdEx := len(m.BestSubmissionTransactions) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.BestSubmissionTransactions[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.BestSubmissionBtcBlockHash) > 0 {
+		i -= len(m.BestSubmissionBtcBlockHash)
+		copy(dAtA[i:], m.BestSubmissionBtcBlockHash)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.BestSubmissionBtcBlockHash)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.BestSubmissionBtcBlockHeight != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.BestSubmissionBtcBlockHeight))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.EpochNumber != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.EpochNumber))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TransactionInfoResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TransactionInfoResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TransactionInfoResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Proof) > 0 {
+		i -= len(m.Proof)
+		copy(dAtA[i:], m.Proof)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Proof)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Transaction) > 0 {
+		i -= len(m.Transaction)
+		copy(dAtA[i:], m.Transaction)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Transaction)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Key != nil {
+		{
+			size, err := m.Key.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TransactionKeyResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TransactionKeyResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TransactionKeyResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Hash) > 0 {
+		i -= len(m.Hash)
+		copy(dAtA[i:], m.Hash)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Hash)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Index != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.Index))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *CheckpointAddressesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CheckpointAddressesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CheckpointAddressesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Reporter) > 0 {
+		i -= len(m.Reporter)
+		copy(dAtA[i:], m.Reporter)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Reporter)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Submitter) > 0 {
+		i -= len(m.Submitter)
+		copy(dAtA[i:], m.Submitter)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Submitter)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -1083,6 +1567,91 @@ func (m *QueryEpochSubmissionsResponse) Size() (n int) {
 	}
 	if m.Pagination != nil {
 		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *BTCCheckpointInfoResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.EpochNumber != 0 {
+		n += 1 + sovQuery(uint64(m.EpochNumber))
+	}
+	if m.BestSubmissionBtcBlockHeight != 0 {
+		n += 1 + sovQuery(uint64(m.BestSubmissionBtcBlockHeight))
+	}
+	l = len(m.BestSubmissionBtcBlockHash)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	if len(m.BestSubmissionTransactions) > 0 {
+		for _, e := range m.BestSubmissionTransactions {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	if len(m.BestSubmissionVigilanteAddressList) > 0 {
+		for _, e := range m.BestSubmissionVigilanteAddressList {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *TransactionInfoResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Key != nil {
+		l = m.Key.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	l = len(m.Transaction)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	l = len(m.Proof)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *TransactionKeyResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Index != 0 {
+		n += 1 + sovQuery(uint64(m.Index))
+	}
+	l = len(m.Hash)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *CheckpointAddressesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Submitter)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	l = len(m.Reporter)
+	if l > 0 {
 		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
@@ -1355,7 +1924,7 @@ func (m *QueryBtcCheckpointInfoResponse) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Info == nil {
-				m.Info = &BTCCheckpointInfo{}
+				m.Info = &BTCCheckpointInfoResponse{}
 			}
 			if err := m.Info.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1791,6 +2360,559 @@ func (m *QueryEpochSubmissionsResponse) Unmarshal(dAtA []byte) error {
 			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BTCCheckpointInfoResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BTCCheckpointInfoResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BTCCheckpointInfoResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EpochNumber", wireType)
+			}
+			m.EpochNumber = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.EpochNumber |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BestSubmissionBtcBlockHeight", wireType)
+			}
+			m.BestSubmissionBtcBlockHeight = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BestSubmissionBtcBlockHeight |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BestSubmissionBtcBlockHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BestSubmissionBtcBlockHash = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BestSubmissionTransactions", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BestSubmissionTransactions = append(m.BestSubmissionTransactions, &TransactionInfoResponse{})
+			if err := m.BestSubmissionTransactions[len(m.BestSubmissionTransactions)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BestSubmissionVigilanteAddressList", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BestSubmissionVigilanteAddressList = append(m.BestSubmissionVigilanteAddressList, &CheckpointAddressesResponse{})
+			if err := m.BestSubmissionVigilanteAddressList[len(m.BestSubmissionVigilanteAddressList)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TransactionInfoResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TransactionInfoResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TransactionInfoResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Key == nil {
+				m.Key = &TransactionKeyResponse{}
+			}
+			if err := m.Key.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Transaction", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Transaction = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Proof", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Proof = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TransactionKeyResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TransactionKeyResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TransactionKeyResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Index", wireType)
+			}
+			m.Index = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Index |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Hash = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CheckpointAddressesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CheckpointAddressesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CheckpointAddressesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Submitter", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Submitter = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Reporter", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Reporter = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
- At `QueryBtcCheckpointInfo` return `BTCCheckpointInfoResponse` instead of `BTCCheckpointInfo`