### PR TITLE
fix: Expedited min deposit should have bbn denom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             make test
   e2e-test:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:2024.01.1
     resource_class: large
     steps:
       - go/install:
@@ -52,7 +52,7 @@ jobs:
             sudo make test-e2e
   lint:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:2024.01.1
     resource_class: large
     steps:
       - go/install:
@@ -70,7 +70,7 @@ jobs:
 
   build_docker:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:2024.01.1
     resource_class: large
     steps:
       - checkout
@@ -93,7 +93,7 @@ jobs:
 
   push_docker:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:2024.01.1
       resource_class: large
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 jobs:
   build-test:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:2024.01.1
     resource_class: large
     steps:
       - go/install:

--- a/cmd/babylond/cmd/genesis.go
+++ b/cmd/babylond/cmd/genesis.go
@@ -290,6 +290,10 @@ func TestnetGenesisParams(maxActiveValidators uint32, btcConfirmationDepth uint6
 		genParams.NativeCoinMetadatas[0].Base,
 		sdkmath.NewInt(2_500_000_000),
 	))
+	genParams.GovParams.ExpeditedMinDeposit = sdk.NewCoins(sdk.NewCoin(
+		genParams.NativeCoinMetadatas[0].Base,
+		sdkmath.NewInt(2_500_000_000),
+	))
 
 	genParams.CrisisConstantFee = sdk.NewCoin(
 		genParams.NativeCoinMetadatas[0].Base,


### PR DESCRIPTION
Also change the CircleCI image as it became deprecated.