### PR TITLE
fix sorting bug in multisig script

### DIFF
--- a/btcstaking/scripts_utils.go
+++ b/btcstaking/scripts_utils.go
@@ -41,12 +41,14 @@ func assembleMultiSigScript(
 // a copy of the keys sorted in lexicographical order bytes on the x-only
 // pubkey serialization.
 func sortKeys(keys []*btcec.PublicKey) []*btcec.PublicKey {
-	sort.SliceStable(keys, func(i, j int) bool {
+	sortedKeys := make([]*btcec.PublicKey, len(keys))
+	copy(sortedKeys, keys)
+	sort.SliceStable(sortedKeys, func(i, j int) bool {
 		keyIBytes := schnorr.SerializePubKey(keys[i])
 		keyJBytes := schnorr.SerializePubKey(keys[j])
 		return bytes.Compare(keyIBytes, keyJBytes) == -1
 	})
-	return keys
+	return sortedKeys
 }
 
 // prepareKeys prepares keys to be used in multisig script

--- a/btcstaking/scripts_utils.go
+++ b/btcstaking/scripts_utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	bbn "github.com/babylonchain/babylon/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/txscript"
@@ -100,9 +99,6 @@ func buildMultiSigScript(
 	if err != nil {
 		return nil, err
 	}
-
-	bip340Keys := bbn.NewBIP340PKsFromBTCPKs(sortedKeys)
-	fmt.Print(bip340Keys)
 
 	return assembleMultiSigScript(sortedKeys, threshold, withVerify)
 }

--- a/btcstaking/staking_utils_test.go
+++ b/btcstaking/staking_utils_test.go
@@ -1,0 +1,35 @@
+package btcstaking_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/babylonchain/babylon/btcstaking"
+	"github.com/babylonchain/babylon/testutil/datagen"
+	bbn "github.com/babylonchain/babylon/types"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortKeys(t *testing.T) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+
+	_, pks, err := datagen.GenRandomBTCKeyPairs(r, 10)
+	require.NoError(t, err)
+
+	sortedPKs := btcstaking.SortKeys(pks)
+
+	btcPKs := bbn.NewBIP340PKsFromBTCPKs(pks)
+	sortedBTCPKs := bbn.SortBIP340PKs(btcPKs)
+
+	// ensure sorted PKs and sorted BIP340 PKs are in reverse order
+	for i := range sortedPKs {
+		pkBytes := schnorr.SerializePubKey(sortedPKs[i])
+
+		btcPK := sortedBTCPKs[len(sortedBTCPKs)-1-i]
+		btcPKBytes := btcPK.MustMarshal()
+
+		require.Equal(t, pkBytes, btcPKBytes, "comparing %d-th key", i)
+	}
+}

--- a/testutil/bitcoin/utils.go
+++ b/testutil/bitcoin/utils.go
@@ -56,8 +56,8 @@ func AssertEngineExecution(t *testing.T, testNum int, valid bool,
 				"should be invalid: %v", testNum, dis, err)
 		}
 
-		debugBuf.WriteString(fmt.Sprintf("Stack: %v\n", vm.GetStack()))
-		debugBuf.WriteString(fmt.Sprintf("AltStack: %v\n\n", vm.GetAltStack()))
+		// debugBuf.WriteString(fmt.Sprintf("Stack: %v\n", vm.GetStack()))
+		// debugBuf.WriteString(fmt.Sprintf("AltStack: %v\n\n", vm.GetAltStack()))
 	}
 
 	// If we get to this point the unexpected case was not reached

--- a/testutil/bitcoin/utils.go
+++ b/testutil/bitcoin/utils.go
@@ -56,8 +56,8 @@ func AssertEngineExecution(t *testing.T, testNum int, valid bool,
 				"should be invalid: %v", testNum, dis, err)
 		}
 
-		// debugBuf.WriteString(fmt.Sprintf("Stack: %v\n", vm.GetStack()))
-		// debugBuf.WriteString(fmt.Sprintf("AltStack: %v\n\n", vm.GetAltStack()))
+		debugBuf.WriteString(fmt.Sprintf("Stack: %v\n", vm.GetStack()))
+		debugBuf.WriteString(fmt.Sprintf("AltStack: %v\n\n", vm.GetAltStack()))
 	}
 
 	// If we get to this point the unexpected case was not reached

--- a/x/btcstaking/types/btc_slashing_tx_test.go
+++ b/x/btcstaking/types/btc_slashing_tx_test.go
@@ -45,6 +45,10 @@ func FuzzSlashingTxWithWitness(f *testing.F) {
 		covenantSKs, covenantPKs, err := datagen.GenRandomBTCKeyPairs(r, 5)
 		require.NoError(t, err)
 		covenantQuorum := uint32(3)
+		bsParams := types.Params{
+			CovenantPks:    bbn.NewBIP340PKsFromBTCPKs(covenantPKs),
+			CovenantQuorum: covenantQuorum,
+		}
 		slashingChangeLockTime := uint16(101)
 
 		// generate staking/slashing tx
@@ -83,10 +87,6 @@ func FuzzSlashingTxWithWitness(f *testing.F) {
 		)
 		require.NoError(t, err)
 
-		bsParams := types.Params{
-			CovenantPks:    bbn.NewBIP340PKsFromBTCPKs(covenantPKs),
-			CovenantQuorum: covenantQuorum,
-		}
 		covSigs, err := types.GetOrderedCovenantSignatures(0, covenantSigs, &bsParams)
 		require.NoError(t, err)
 


### PR DESCRIPTION
This PR fixes a bug in `btcstaking/` where constructing the multi sig script will change the order of the caller's input public keys. This PR also adds a test to ensure the sorting functions used by constructing script and constructing witness give reverse results.

Question: should this be a hotfix or we can push it to `dev` for now?

Initially found by @KonradStaniec 