### PR TITLE
fix: fix flaky test `FuzzFinalityProviderPowerAtHeight`

### DIFF
--- a/x/btcstaking/keeper/grpc_query_test.go
+++ b/x/btcstaking/keeper/grpc_query_test.go
@@ -296,7 +296,7 @@ func FuzzFinalityProviderPowerAtHeight(f *testing.F) {
 
 		// case where the voting power store is not updated in
 		// the given height
-		requestHeight := datagen.RandomIntOtherThan(r, int(randomHeight), 100) + 1
+		requestHeight := randomHeight + datagen.RandomInt(r, 10) + 1
 		req2 := &types.QueryFinalityProviderPowerAtHeightRequest{
 			FpBtcPkHex: fp.BtcPk.MarshalHex(),
 			Height:     requestHeight,


### PR DESCRIPTION
Fixes #562

`FuzzFinalityProviderPowerAtHeight` is flaky because `requestHeight` might still be same as `randomHeight`. This happens in https://github.com/babylonchain/babylon/pull/571 as well

Fuzzed locally to verify the fix works