### PR TITLE
fix: fix non-determinism in voting power rotation

### DIFF
--- a/x/btcstaking/keeper/power_dist_change.go
+++ b/x/btcstaking/keeper/power_dist_change.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"sort"
 
 	"cosmossdk.io/store/prefix"
 	bbn "github.com/babylonchain/babylon/types"
@@ -193,7 +194,15 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 		process new BTC delegations under new finality providers in activeBTCDels
 	*/
 	// TODO: fix non-determinism here
-	for fpBTCPKHex, fpActiveBTCDels := range activeBTCDels {
+	fpBTCPKHexList := []string{}
+	for fpBTCPKHex := range activeBTCDels {
+		fpBTCPKHexList = append(fpBTCPKHexList, fpBTCPKHex)
+	}
+	sort.SliceStable(fpBTCPKHexList, func(i, j int) bool {
+		return fpBTCPKHexList[i] < fpBTCPKHexList[j]
+	})
+
+	for _, fpBTCPKHex := range fpBTCPKHexList {
 		// get the finality provider and initialise its dist info
 		fpBTCPK, err := bbn.NewBIP340PubKeyFromHex(fpBTCPKHex)
 		if err != nil {
@@ -206,6 +215,7 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 		fpDistInfo := types.NewFinalityProviderDistInfo(newFP)
 
 		// add each BTC delegation
+		fpActiveBTCDels := activeBTCDels[fpBTCPKHex]
 		for _, d := range fpActiveBTCDels {
 			fpDistInfo.AddBTCDel(d)
 		}

--- a/x/btcstaking/keeper/power_dist_change.go
+++ b/x/btcstaking/keeper/power_dist_change.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/davecgh/go-spew/spew"
 )
 
 /* power distribution update */
@@ -52,9 +51,7 @@ func (k Keeper) UpdatePowerDist(ctx context.Context) {
 
 	// reconcile old voting power distribution cache and new events
 	// to construct the new distribution
-	newDc := k.processAllPowerDistUpdateEvents(ctx, dc, events, maxActiveFps)
-
-	spew.Println("DEBUGGGGG newDc", newDc)
+	newDc := k.ProcessAllPowerDistUpdateEvents(ctx, dc, events, maxActiveFps)
 
 	// record voting power and cache for this height
 	k.recordVotingPowerAndCache(ctx, newDc, maxActiveFps)
@@ -93,13 +90,13 @@ func (k Keeper) recordMetrics(dc *types.VotingPowerDistCache, maxActiveFps uint3
 	// TODO: record number of BTC delegations under different status
 }
 
-// processAllPowerDistUpdateEvents processes all events that affect
+// ProcessAllPowerDistUpdateEvents processes all events that affect
 // voting power distribution and returns a new distribution cache.
 // The following events will affect the voting power distribution:
 // - newly active BTC delegations
 // - newly unbonded BTC delegations
 // - slashed finality providers
-func (k Keeper) processAllPowerDistUpdateEvents(
+func (k Keeper) ProcessAllPowerDistUpdateEvents(
 	ctx context.Context,
 	dc *types.VotingPowerDistCache,
 	events []*types.EventPowerDistUpdate,
@@ -195,6 +192,7 @@ func (k Keeper) processAllPowerDistUpdateEvents(
 	/*
 		process new BTC delegations under new finality providers in activeBTCDels
 	*/
+	// TODO: fix non-determinism here
 	for fpBTCPKHex, fpActiveBTCDels := range activeBTCDels {
 		// get the finality provider and initialise its dist info
 		fpBTCPK, err := bbn.NewBIP340PubKeyFromHex(fpBTCPKHex)

--- a/x/btcstaking/keeper/power_dist_change.go
+++ b/x/btcstaking/keeper/power_dist_change.go
@@ -194,7 +194,7 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 		process new BTC delegations under new finality providers in activeBTCDels
 	*/
 	// sort new finality providers in activeBTCDels to ensure determinism
-	fpBTCPKHexList := []string{}
+	fpBTCPKHexList := make([]string, 0, len(activeBTCDels))
 	for fpBTCPKHex := range activeBTCDels {
 		fpBTCPKHexList = append(fpBTCPKHexList, fpBTCPKHex)
 	}

--- a/x/btcstaking/keeper/power_dist_change.go
+++ b/x/btcstaking/keeper/power_dist_change.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/davecgh/go-spew/spew"
 )
 
 /* power distribution update */
@@ -52,6 +53,8 @@ func (k Keeper) UpdatePowerDist(ctx context.Context) {
 	// reconcile old voting power distribution cache and new events
 	// to construct the new distribution
 	newDc := k.processAllPowerDistUpdateEvents(ctx, dc, events, maxActiveFps)
+
+	spew.Println("DEBUGGGGG newDc", newDc)
 
 	// record voting power and cache for this height
 	k.recordVotingPowerAndCache(ctx, newDc, maxActiveFps)

--- a/x/btcstaking/keeper/power_dist_change.go
+++ b/x/btcstaking/keeper/power_dist_change.go
@@ -193,7 +193,7 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 	/*
 		process new BTC delegations under new finality providers in activeBTCDels
 	*/
-	// TODO: fix non-determinism here
+	// sort new finality providers in activeBTCDels to ensure determinism
 	fpBTCPKHexList := []string{}
 	for fpBTCPKHex := range activeBTCDels {
 		fpBTCPKHexList = append(fpBTCPKHexList, fpBTCPKHex)
@@ -201,7 +201,7 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 	sort.SliceStable(fpBTCPKHexList, func(i, j int) bool {
 		return fpBTCPKHexList[i] < fpBTCPKHexList[j]
 	})
-
+	// for each new finality provider, apply the new BTC delegations to the new dist cache
 	for _, fpBTCPKHex := range fpBTCPKHexList {
 		// get the finality provider and initialise its dist info
 		fpBTCPK, err := bbn.NewBIP340PubKeyFromHex(fpBTCPKHex)


### PR DESCRIPTION
There is a non-determinism bug in voting power rotation, where we iterate over the `activeBTCDels` map, which is not deterministic. This PR fixes the bug by first sorting the keys before iterating over them.

- Reproduce: https://github.com/babylonchain/babylon/tree/3d4b194e020aea069c372b33528a4d12f6e88c1f
- Fix and fuzz test: https://github.com/babylonchain/babylon/tree/ed65719b9d1825a3eb1992b56e2c8d8eecc74957