### PR TITLE
Improve the doc of bitcoin staking script

### DIFF
--- a/docs/staking-script.md
+++ b/docs/staking-script.md
@@ -35,12 +35,12 @@ In the entire Bitcoin staking process, two parties are involved: one is called
 the Bitcoin Staker, and the other is called the Finality Provider.
 
 - **Bitcoin Staker**: A Bitcoin Staker is a person who owns Bitcoin and chooses 
-to lock up their Bitcoin for a set period of time to earn yields.
-- **Finality Provider**: A Finality Provider is the service that provides security 
-assurance to the proof-of-stake chain.
+to lock up their Bitcoin for a set period of time to secure a PoS chain.
+- **Finality Provider**: A Finality Provider is the an entity that votes 
+in the finality round to provide security assurance to the PoS chain.
 
-The Bitcoin Staker can choose a specific Finality Provider with 
-which to lock (stake) their Bitcoins."
+The Bitcoin Staker can choose a specific Finality Provider to which 
+to they can delegate (stake) their locked Bitcoin.
 
 The key to making all these possible is special constructions of BTC
 transactions using BTC scripts.

--- a/docs/staking-script.md
+++ b/docs/staking-script.md
@@ -30,6 +30,18 @@ The protocol has the following important properties:
 7. (WIP) restakable, meaning that the same bitcoin can be staked to secure
    multiple PoS chains and earn multiple PoS yields
 
+
+In the entire Bitcoin staking process, two parties are involved: one is called 
+the Bitcoin Staker, and the other is called the Finality Provider.
+
+- **Bitcoin Staker**: A Bitcoin Staker is a person who owns Bitcoin and chooses 
+to lock up their Bitcoin for a set period of time to earn yields.
+- **Finality Provider**: A Finality Provider is the service that provides security 
+assurance to the proof-of-stake chain.
+
+The Bitcoin Staker can choose a specific Finality Provider with 
+which to lock (stake) their Bitcoins."
+
 The key to making all these possible is special constructions of BTC
 transactions using BTC scripts.
 
@@ -90,7 +102,7 @@ There are three special transaction types recognized by the Babylon chain:
 
 ### Staking Transaction
 
-A BTC holder gains voting power by creating a staking transaction. This is a
+A BTC Staker gains voting power by creating a staking transaction. This is a
 Bitcoin transaction that commits a certain amount of to-be-staked bitcoin to
 Babylon recognized BTC staking scripts. These scripts lock the stake for a
 chosen amount of BTC blocks and enable other features such as unbonding and
@@ -230,14 +242,14 @@ The main difference between the unbonding and slashing paths is the existence of
 
 This leads to following system wide repercussions:
 
-- for staking request to become active, btc holder needs to provide valid
+- for staking request to become active, btc staker needs to provide valid
   unbonding transaction in this staking request. This staking request will become
   active only when `CovenantThreshold` signatures will be received by Babylon
   chain. Lack of `FinalityProviderPk` in unbonding path, means that after
   delegation becomes active, staker can send unbodning transaction any time
   without asking finality provider for permission.
 - existence of `FinalityProviderPk` in slashing path, coupled with the fact that
-  btc holder needs to provide pre-signed slashing transaction which needs to be
+  btc staker needs to provide pre-signed slashing transaction which needs to be
   signed by covenant committee for delegation request to become active, leads to
   situation in which the only signature missing to send slashing transaction to
   btc is signature of finality provider.
@@ -264,7 +276,7 @@ Bitcoin blocks. It commits to a script of the form:
 
 where:
 
-- Staker_PK is btc holder public key
+- Staker_PK is btc staker public key
 - Timelock_Blocks is unbonding time. It must be lower or equal 65535, but larger
   than `max(MinUnbondingTime, CheckpointFinalizationTimeout)`. `MinUnbondingTime`
   and `CheckpointFinalizationTimeout` are Babylon parameters.

--- a/docs/staking-script.md
+++ b/docs/staking-script.md
@@ -39,8 +39,8 @@ to lock up their Bitcoin for a set period of time to secure a PoS chain.
 - **Finality Provider**: A Finality Provider is the an entity that votes 
 in the finality round to provide security assurance to the PoS chain.
 
-The Bitcoin Staker can choose a specific Finality Provider to which 
-to they can delegate (stake) their locked Bitcoin.
+The Bitcoin staker can choose a specific Finality Provider to delegate 
+their voting power derived from their locked Bitcoin.
 
 The key to making all these possible is special constructions of BTC
 transactions using BTC scripts.


### PR DESCRIPTION
Hello Babylon team,

I am really impressed by the work you are doing. Currently, I am investigating how Bitcoin staking transactions work and I found this document. I believe there are some improvements that can be made. Here are two points I've added:
1. A high-level introduction about who will be involved in the Bitcoin staking transaction.
2. I noticed the terms `btc holder` and `btc staker` are used interchangeably. I have standardized the terminology to `btc staker` for consistency.

Please consider these revisions.