### PR TITLE
chore: unifying usage of verification functions for btc staking txs

### DIFF
--- a/btcstaking/staking.go
+++ b/btcstaking/staking.go
@@ -575,28 +575,6 @@ func VerifyTransactionSigWithOutput(
 		return fmt.Errorf("funding output must not be nil")
 	}
 
-	return VerifyTransactionSigWithOutputData(
-		transaction,
-		fundingOutput.PkScript,
-		fundingOutput.Value,
-		script,
-		pubKey,
-		signature,
-	)
-}
-
-// VerifyTransactionSigWithOutputData verifies that:
-// - provided transaction has exactly one input
-// - provided signature is valid schnorr BIP340 signature
-// - provided signature is signing whole provided transaction	(SigHashDefault)
-func VerifyTransactionSigWithOutputData(
-	transaction *wire.MsgTx,
-	fundingOutputPkScript []byte,
-	fundingOutputValue int64,
-	script []byte,
-	pubKey *btcec.PublicKey,
-	signature []byte) error {
-
 	if transaction == nil {
 		return fmt.Errorf("tx to verify not be nil")
 	}
@@ -612,8 +590,8 @@ func VerifyTransactionSigWithOutputData(
 	tapLeaf := txscript.NewBaseTapLeaf(script)
 
 	inputFetcher := txscript.NewCannedPrevOutputFetcher(
-		fundingOutputPkScript,
-		fundingOutputValue,
+		fundingOutput.PkScript,
+		fundingOutput.Value,
 	)
 
 	sigHashes := txscript.NewTxSigHashes(transaction, inputFetcher)
@@ -641,14 +619,13 @@ func VerifyTransactionSigWithOutputData(
 	return nil
 }
 
-// EncVerifyTransactionSigWithOutputData verifies that:
+// EncVerifyTransactionSigWithOutput verifies that:
 // - provided transaction has exactly one input
 // - provided signature is valid adaptor signature
 // - provided signature is signing whole provided transaction (SigHashDefault)
-func EncVerifyTransactionSigWithOutputData(
+func EncVerifyTransactionSigWithOutput(
 	transaction *wire.MsgTx,
-	fundingOutputPkScript []byte,
-	fundingOutputValue int64,
+	fundingOut *wire.TxOut,
 	script []byte,
 	pubKey *btcec.PublicKey,
 	encKey *asig.EncryptionKey,
@@ -669,8 +646,8 @@ func EncVerifyTransactionSigWithOutputData(
 	tapLeaf := txscript.NewBaseTapLeaf(script)
 
 	inputFetcher := txscript.NewCannedPrevOutputFetcher(
-		fundingOutputPkScript,
-		fundingOutputValue,
+		fundingOut.PkScript,
+		fundingOut.Value,
 	)
 
 	sigHashes := txscript.NewTxSigHashes(transaction, inputFetcher)

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -314,8 +314,7 @@ func (ms msgServer) CreateBTCDelegation(goCtx context.Context, req *types.MsgCre
 	}
 
 	err = req.SlashingTx.VerifySignature(
-		stakingInfo.StakingOutput.PkScript,
-		stakingInfo.StakingOutput.Value,
+		stakingInfo.StakingOutput,
 		slashingSpendInfo.GetPkScriptPath(),
 		stakerPk,
 		req.DelegatorSlashingSig,
@@ -414,8 +413,7 @@ func (ms msgServer) CreateBTCDelegation(goCtx context.Context, req *types.MsgCre
 	}
 
 	err = req.UnbondingSlashingTx.VerifySignature(
-		unbondingInfo.UnbondingOutput.PkScript,
-		unbondingInfo.UnbondingOutput.Value,
+		unbondingInfo.UnbondingOutput,
 		unbondingSlashingSpendInfo.GetPkScriptPath(),
 		newBTCDel.BtcPk.MustToBTCPK(),
 		req.DelegatorUnbondingSlashingSig,
@@ -569,10 +567,9 @@ func (ms msgServer) AddCovenantSigs(goCtx context.Context, req *types.MsgAddCove
 		// this fails, it is a programming error
 		panic(err)
 	}
-	if err := btcstaking.VerifyTransactionSigWithOutputData(
+	if err := btcstaking.VerifyTransactionSigWithOutput(
 		unbondingMsgTx,
-		stakingInfo.StakingOutput.PkScript,
-		stakingInfo.StakingOutput.Value,
+		stakingInfo.StakingOutput,
 		unbondingSpendInfo.GetPkScriptPath(),
 		req.Pk.MustToBTCPK(),
 		*req.UnbondingTxSig,
@@ -660,10 +657,9 @@ func (ms msgServer) BTCUndelegate(goCtx context.Context, req *types.MsgBTCUndele
 		// this fails, it is a programming error
 		panic(err)
 	}
-	if err := btcstaking.VerifyTransactionSigWithOutputData(
+	if err := btcstaking.VerifyTransactionSigWithOutput(
 		unbondingMsgTx,
-		stakingInfo.StakingOutput.PkScript,
-		stakingInfo.StakingOutput.Value,
+		stakingInfo.StakingOutput,
 		unbondingSpendInfo.GetPkScriptPath(),
 		btcDel.BtcPk.MustToBTCPK(),
 		*req.UnbondingTxSig,

--- a/x/btcstaking/types/btc_delegation_test.go
+++ b/x/btcstaking/types/btc_delegation_test.go
@@ -139,8 +139,7 @@ func FuzzBTCDelegation_SlashingTx(f *testing.F) {
 				continue
 			}
 			err := btcDel.SlashingTx.EncVerifyAdaptorSignature(
-				stakingInfo.StakingOutput.PkScript,
-				stakingInfo.StakingOutput.Value,
+				stakingInfo.StakingOutput,
 				slashingSpendInfo.GetPkScriptPath(),
 				orderedCovenantPKs[i].MustToBTCPK(),
 				encKey,

--- a/x/btcstaking/types/btc_slashing_tx.go
+++ b/x/btcstaking/types/btc_slashing_tx.go
@@ -114,8 +114,7 @@ func (tx *BTCSlashingTx) Sign(
 
 // VerifySignature verifies a signature on the slashing tx signed by staker, finality provider, or covenant
 func (tx *BTCSlashingTx) VerifySignature(
-	fundingPkScript []byte,
-	fundingAmount int64,
+	fundingOut *wire.TxOut,
 	slashingPkScriptPath []byte,
 	pk *btcec.PublicKey,
 	sig *bbn.BIP340Signature,
@@ -124,10 +123,9 @@ func (tx *BTCSlashingTx) VerifySignature(
 	if err != nil {
 		return err
 	}
-	return btcstaking.VerifyTransactionSigWithOutputData(
+	return btcstaking.VerifyTransactionSigWithOutput(
 		msgTx,
-		fundingPkScript,
-		fundingAmount,
+		fundingOut,
 		slashingPkScriptPath,
 		pk,
 		*sig,
@@ -165,8 +163,7 @@ func (tx *BTCSlashingTx) EncSign(
 // EncVerifyAdaptorSignature verifies an adaptor signature on the slashing tx
 // with the finality provider's public key as encryption key
 func (tx *BTCSlashingTx) EncVerifyAdaptorSignature(
-	stakingPkScript []byte,
-	stakingAmount int64,
+	fundingOut *wire.TxOut,
 	slashingPkScriptPath []byte,
 	pk *btcec.PublicKey,
 	encKey *asig.EncryptionKey,
@@ -176,10 +173,9 @@ func (tx *BTCSlashingTx) EncVerifyAdaptorSignature(
 	if err != nil {
 		return err
 	}
-	return btcstaking.EncVerifyTransactionSigWithOutputData(
+	return btcstaking.EncVerifyTransactionSigWithOutput(
 		msgTx,
-		stakingPkScript,
-		stakingAmount,
+		fundingOut,
 		slashingPkScriptPath,
 		pk,
 		encKey,
@@ -211,8 +207,7 @@ func (tx *BTCSlashingTx) ParseEncVerifyAdaptorSignatures(
 			return nil, err
 		}
 		err = tx.EncVerifyAdaptorSignature(
-			fundingOut.PkScript,
-			fundingOut.Value,
+			fundingOut,
 			slashingSpendInfo.GetPkScriptPath(),
 			pk.MustToBTCPK(),
 			encKey,

--- a/x/btcstaking/types/btc_slashing_tx_test.go
+++ b/x/btcstaking/types/btc_slashing_tx_test.go
@@ -91,8 +91,7 @@ func FuzzSlashingTx_VerifySigAndASig(f *testing.F) {
 		covASig, err := slashingTx.EncSign(stakingTx, 0, slashingPkScriptPath, covSK, encKey)
 		require.NoError(t, err)
 		err = slashingTx.EncVerifyAdaptorSignature(
-			testStakingInfo.StakingInfo.GetPkScript(),
-			testStakingInfo.StakingInfo.StakingOutput.Value,
+			testStakingInfo.StakingInfo.StakingOutput,
 			slashingPkScriptPath,
 			covPK,
 			encKey,
@@ -104,8 +103,7 @@ func FuzzSlashingTx_VerifySigAndASig(f *testing.F) {
 		// can be verified
 		covSig := covASig.Decrypt(decKey)
 		err = slashingTx.VerifySignature(
-			testStakingInfo.StakingInfo.GetPkScript(),
-			testStakingInfo.StakingInfo.StakingOutput.Value,
+			testStakingInfo.StakingInfo.StakingOutput,
 			slashingPkScriptPath,
 			covPK,
 			bbn.NewBIP340SignatureFromBTCSig(covSig),
@@ -206,8 +204,7 @@ func FuzzSlashingTxWithWitness(f *testing.F) {
 		orderedCovenantPKs := bbn.SortBIP340PKs(bsParams.CovenantPks)
 		for i := range covSigsForFP {
 			err := slashingTx.EncVerifyAdaptorSignature(
-				testStakingInfo.StakingInfo.StakingOutput.PkScript,
-				testStakingInfo.StakingInfo.StakingOutput.Value,
+				testStakingInfo.StakingInfo.StakingOutput,
 				slashingPkScriptPath,
 				orderedCovenantPKs[i].MustToBTCPK(),
 				encKey,
@@ -217,8 +214,7 @@ func FuzzSlashingTxWithWitness(f *testing.F) {
 
 			covSchnorrSig := covSigsForFP[i].Decrypt(decKey)
 			err = slashingTx.VerifySignature(
-				testStakingInfo.StakingInfo.StakingOutput.PkScript,
-				testStakingInfo.StakingInfo.StakingOutput.Value,
+				testStakingInfo.StakingInfo.StakingOutput,
 				slashingPkScriptPath,
 				orderedCovenantPKs[i].MustToBTCPK(),
 				bbn.NewBIP340SignatureFromBTCSig(covSchnorrSig),

--- a/x/btcstaking/types/btc_undelegation_test.go
+++ b/x/btcstaking/types/btc_undelegation_test.go
@@ -87,8 +87,7 @@ func FuzzBTCUndelegation_SlashingTx(f *testing.F) {
 				continue
 			}
 			err := btcDel.BtcUndelegation.SlashingTx.EncVerifyAdaptorSignature(
-				unbondingInfo.UnbondingOutput.PkScript,
-				unbondingInfo.UnbondingOutput.Value,
+				unbondingInfo.UnbondingOutput,
 				slashingSpendInfo.GetPkScriptPath(),
 				orderedCovenantPKs[i].MustToBTCPK(),
 				encKey,
@@ -98,8 +97,7 @@ func FuzzBTCUndelegation_SlashingTx(f *testing.F) {
 
 			covSig := covSigsForFP[i].Decrypt(decKey)
 			err = btcDel.BtcUndelegation.SlashingTx.VerifySignature(
-				unbondingInfo.UnbondingOutput.PkScript,
-				unbondingInfo.UnbondingOutput.Value,
+				unbondingInfo.UnbondingOutput,
 				slashingSpendInfo.GetPkScriptPath(),
 				orderedCovenantPKs[i].MustToBTCPK(),
 				bbn.NewBIP340SignatureFromBTCSig(covSig),


### PR DESCRIPTION
This PR unifies the usage of verification functions for various txs in BTC staking, and cleans up some of the APIs.