### PR TITLE
Use NUMEQUAL op code in multisig scripts

### DIFF
--- a/btcstaking/btcstaking_test.go
+++ b/btcstaking/btcstaking_test.go
@@ -278,6 +278,10 @@ func TestSpendingUnbondingPathCovenant35MultiSig(t *testing.T) {
 		stakingInfo.StakingOutput,
 		si.RevealedLeaf,
 	)
+
+	covenantSigantures[1] = nil
+	covenantSigantures[3] = nil
+
 	witness, err := si.CreateUnbondingPathWitness(covenantSigantures, stakerSig)
 	require.NoError(t, err)
 	spendStakeTx.TxIn[0].Witness = witness
@@ -294,37 +298,6 @@ func TestSpendingUnbondingPathCovenant35MultiSig(t *testing.T) {
 	}
 	btctest.AssertEngineExecution(t, 0, true, newEngine)
 
-	numOfCovenantMembers := len(scenario.CovenantKeys)
-	// with each loop iteration we remove one key from the list of signatures
-	for i := 0; i < numOfCovenantMembers; i++ {
-		numOfRemovedSignatures := i + 1
-
-		covenantSigantures := GenerateSignatures(
-			t,
-			scenario.CovenantKeys,
-			spendStakeTx,
-			stakingInfo.StakingOutput,
-			si.RevealedLeaf,
-		)
-
-		for j := 0; j <= i; j++ {
-			// NOTE: Number provides signatures must match number of public keys in the script,
-			// if we are missing some signatures those must be set to empty signature in witness
-			covenantSigantures[j] = nil
-		}
-
-		witness, err := si.CreateUnbondingPathWitness(covenantSigantures, stakerSig)
-		require.NoError(t, err)
-		spendStakeTx.TxIn[0].Witness = witness
-
-		if numOfCovenantMembers-numOfRemovedSignatures >= int(scenario.RequiredCovenantSigs) {
-			// if we are above threshold execution should be successful
-			btctest.AssertEngineExecution(t, 0, true, newEngine)
-		} else {
-			// we are below threshold execution should be unsuccessful
-			btctest.AssertEngineExecution(t, 0, false, newEngine)
-		}
-	}
 }
 
 func TestSpendingUnbondingPathSingleKeyCovenant(t *testing.T) {
@@ -460,6 +433,9 @@ func TestSpendingSlashingPathCovenant35MultiSig(t *testing.T) {
 		si.RevealedLeaf,
 	)
 	require.NoError(t, err)
+
+	covenantSigantures[0] = nil
+	covenantSigantures[3] = nil
 
 	witness, err := si.CreateSlashingPathWitness(
 		covenantSigantures,

--- a/btcstaking/scripts_utils.go
+++ b/btcstaking/scripts_utils.go
@@ -29,9 +29,10 @@ func assembleMultiSigScript(
 	}
 
 	builder.AddInt64(int64(threshold))
-	builder.AddOp(txscript.OP_GREATERTHANOREQUAL)
 	if withVerify {
-		builder.AddOp(txscript.OP_VERIFY)
+		builder.AddOp(txscript.OP_NUMEQUALVERIFY)
+	} else {
+		builder.AddOp(txscript.OP_NUMEQUAL)
 	}
 
 	return builder.Script()

--- a/cmd/babylond/cmd/genhelpers/set_btc_delegations_test.go
+++ b/cmd/babylond/cmd/genhelpers/set_btc_delegations_test.go
@@ -60,7 +60,7 @@ func FuzzCmdSetBtcDels(f *testing.F) {
 		err = cmdSetFp.Execute()
 		require.NoError(t, err)
 
-		covenantSKs, _, covenantQuorum := datagen.GenCovenantCommittee(r)
+		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
 		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.SimNetParams)
 		require.NoError(t, err)
 
@@ -79,6 +79,7 @@ func FuzzCmdSetBtcDels(f *testing.F) {
 				[]bbn.BIP340PubKey{*fp.BtcPk},
 				delSK,
 				covenantSKs,
+				covenantPKs,
 				covenantQuorum,
 				slashingAddress.EncodeAddress(),
 				startHeight, endHeight, 10000,
@@ -146,6 +147,7 @@ func FuzzCmdSetBtcDels(f *testing.F) {
 			[]bbn.BIP340PubKey{*notInGenFp.BtcPk},
 			delSK,
 			covenantSKs,
+			covenantPKs,
 			covenantQuorum,
 			slashingAddress.EncodeAddress(),
 			startHeight, endHeight, 10000,

--- a/testutil/datagen/btcstaking.go
+++ b/testutil/datagen/btcstaking.go
@@ -106,6 +106,7 @@ func GenRandomBTCDelegation(
 	fpBTCPKs []bbn.BIP340PubKey,
 	delSK *btcec.PrivateKey,
 	covenantSKs []*btcec.PrivateKey,
+	covenantPks []*btcec.PublicKey,
 	covenantQuorum uint32,
 	slashingAddress string,
 	startHeight, endHeight, totalSat uint64,
@@ -115,11 +116,7 @@ func GenRandomBTCDelegation(
 	net := &chaincfg.SimNetParams
 	delPK := delSK.PubKey()
 	delBTCPK := bbn.NewBIP340PubKeyFromBTCPK(delPK)
-	// list of covenant PKs
-	covenantBTCPKs := []*btcec.PublicKey{}
-	for _, covenantSK := range covenantSKs {
-		covenantBTCPKs = append(covenantBTCPKs, covenantSK.PubKey())
-	}
+
 	// list of finality provider PKs
 	fpPKs, err := bbn.NewBTCPKsFromBIP340PKs(fpBTCPKs)
 	if err != nil {
@@ -147,7 +144,7 @@ func GenRandomBTCDelegation(
 		net,
 		delSK,
 		fpPKs,
-		covenantBTCPKs,
+		covenantPks,
 		covenantQuorum,
 		uint16(endHeight-startHeight),
 		int64(totalSat),
@@ -211,7 +208,7 @@ func GenRandomBTCDelegation(
 		net,
 		delSK,
 		fpPKs,
-		covenantBTCPKs,
+		covenantPks,
 		covenantQuorum,
 		wire.NewOutPoint(&stkTxHash, StakingOutIdx),
 		w+1,

--- a/x/btcstaking/keeper/grpc_query_test.go
+++ b/x/btcstaking/keeper/grpc_query_test.go
@@ -177,7 +177,7 @@ func FuzzPendingBTCDelegations(f *testing.F) {
 		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, ckptKeeper)
 
 		// covenant and slashing addr
-		covenantSKs, _, covenantQuorum := datagen.GenCovenantCommittee(r)
+		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
 		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.SimNetParams)
 		require.NoError(t, err)
 		slashingChangeLockTime := uint16(101)
@@ -216,6 +216,7 @@ func FuzzPendingBTCDelegations(f *testing.F) {
 					[]bbn.BIP340PubKey{*fp.BtcPk},
 					delSK,
 					covenantSKs,
+					covenantPKs,
 					covenantQuorum,
 					slashingAddress.EncodeAddress(),
 					startHeight, endHeight, 10000,
@@ -379,7 +380,7 @@ func FuzzActiveFinalityProvidersAtHeight(f *testing.F) {
 		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, ckptKeeper)
 
 		// covenant and slashing addr
-		covenantSKs, _, covenantQuorum := datagen.GenCovenantCommittee(r)
+		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
 		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.SimNetParams)
 		require.NoError(t, err)
 
@@ -421,6 +422,7 @@ func FuzzActiveFinalityProvidersAtHeight(f *testing.F) {
 					[]bbn.BIP340PubKey{*fpBTCPK},
 					delSK,
 					covenantSKs,
+					covenantPKs,
 					covenantQuorum,
 					slashingAddress.EncodeAddress(),
 					1, 1000, 10000,
@@ -497,7 +499,7 @@ func FuzzFinalityProviderDelegations(f *testing.F) {
 		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, ckptKeeper)
 
 		// covenant and slashing addr
-		covenantSKs, _, covenantQuorum := datagen.GenCovenantCommittee(r)
+		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
 		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.SimNetParams)
 		require.NoError(t, err)
 		slashingChangeLockTime := uint16(101)
@@ -529,6 +531,7 @@ func FuzzFinalityProviderDelegations(f *testing.F) {
 				[]bbn.BIP340PubKey{*fp.BtcPk},
 				delSK,
 				covenantSKs,
+				covenantPKs,
 				covenantQuorum,
 				slashingAddress.EncodeAddress(),
 				startHeight, endHeight, 10000,

--- a/x/btcstaking/keeper/msg_server_test.go
+++ b/x/btcstaking/keeper/msg_server_test.go
@@ -864,7 +864,7 @@ func createNDelegationsForFinalityProvider(
 ) []*types.BTCDelegation {
 	var delegations []*types.BTCDelegation
 	for i := 0; i < numDelegations; i++ {
-		covenatnSks, _, err := datagen.GenRandomBTCKeyPairs(r, int(quorum))
+		covenatnSks, covenantPks, err := datagen.GenRandomBTCKeyPairs(r, int(quorum))
 		require.NoError(t, err)
 
 		delSK, _, err := datagen.GenRandomBTCKeyPair(r)
@@ -882,6 +882,7 @@ func createNDelegationsForFinalityProvider(
 			[]bbn.BIP340PubKey{*bbn.NewBIP340PubKeyFromBTCPK(fpPK)},
 			delSK,
 			covenatnSks,
+			covenantPks,
 			quorum,
 			slashingAddress.EncodeAddress(),
 			0,

--- a/x/btcstaking/types/btc_delegation_test.go
+++ b/x/btcstaking/types/btc_delegation_test.go
@@ -105,13 +105,17 @@ func FuzzBTCDelegation_SlashingTx(f *testing.F) {
 		unbondingTime := uint16(100) + 1
 		slashingChangeLockTime := unbondingTime
 
+		// only the quorum of signers provided the signatures
+		covenantSigners := covenantSKs[:covenantQuorum]
+
 		// construct the BTC delegation with everything
 		btcDel, err := datagen.GenRandomBTCDelegation(
 			r,
 			t,
 			fpBTCPKs,
 			delSK,
-			covenantSKs,
+			covenantSigners,
+			covenantPKs,
 			covenantQuorum,
 			slashingAddress.EncodeAddress(),
 			1000,

--- a/x/btcstaking/types/btc_slashing_tx_test.go
+++ b/x/btcstaking/types/btc_slashing_tx_test.go
@@ -189,9 +189,10 @@ func FuzzSlashingTxWithWitness(f *testing.F) {
 		delSig, err := slashingTx.Sign(stakingMsgTx, 0, slashingPkScriptPath, delSK)
 		require.NoError(t, err)
 
+		covenantSigners := covenantSKs[:covenantQuorum]
 		// get covenant Schnorr signatures
 		covenantSigs, err := datagen.GenCovenantAdaptorSigs(
-			covenantSKs,
+			covenantSigners,
 			fpPKs,
 			stakingMsgTx,
 			slashingPkScriptPath,
@@ -205,6 +206,10 @@ func FuzzSlashingTxWithWitness(f *testing.F) {
 		// finality provider's PK are verified
 		orderedCovenantPKs := bbn.SortBIP340PKs(bsParams.CovenantPks)
 		for i := range covSigsForFP {
+			if covSigsForFP[i] == nil {
+				continue
+			}
+
 			err := slashingTx.EncVerifyAdaptorSignature(
 				testStakingInfo.StakingInfo.StakingOutput.PkScript,
 				testStakingInfo.StakingInfo.StakingOutput.Value,

--- a/x/btcstaking/types/btc_undelegation_test.go
+++ b/x/btcstaking/types/btc_undelegation_test.go
@@ -38,7 +38,7 @@ func FuzzBTCUndelegation_SlashingTx(f *testing.F) {
 		encKey, err := asig.NewEncryptionKeyFromBTCPK(fpPK)
 		require.NoError(t, err)
 
-		// (3, 5) covenant committee
+		// (5, 5) covenant committee
 		covenantSKs, covenantPKs, err := datagen.GenRandomBTCKeyPairs(r, 5)
 		require.NoError(t, err)
 		covenantQuorum := uint32(3)
@@ -46,6 +46,7 @@ func FuzzBTCUndelegation_SlashingTx(f *testing.F) {
 			CovenantPks:    bbn.NewBIP340PKsFromBTCPKs(covenantPKs),
 			CovenantQuorum: covenantQuorum,
 		}
+		covenantSigners := covenantSKs[:covenantQuorum]
 
 		stakingTimeBlocks := uint16(5)
 		stakingValue := int64(2 * 10e8)
@@ -62,7 +63,8 @@ func FuzzBTCUndelegation_SlashingTx(f *testing.F) {
 			t,
 			fpBTCPKs,
 			delSK,
-			covenantSKs,
+			covenantSigners,
+			covenantPKs,
 			covenantQuorum,
 			slashingAddress.EncodeAddress(),
 			1000,


### PR DESCRIPTION
Makes our mutlisig scripts non-malleable and minisciprt compliant