### PR TITLE
chore: generalising datagen function for BTC delegation

### DIFF
--- a/cmd/babylond/cmd/genhelpers/set_btc_delegations_test.go
+++ b/cmd/babylond/cmd/genhelpers/set_btc_delegations_test.go
@@ -61,7 +61,7 @@ func FuzzCmdSetBtcDels(f *testing.F) {
 		require.NoError(t, err)
 
 		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
-		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.SimNetParams)
+		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.RegressionNetParams)
 		require.NoError(t, err)
 
 		startHeight := datagen.RandomInt(r, 100) + 1
@@ -76,6 +76,7 @@ func FuzzCmdSetBtcDels(f *testing.F) {
 			del, err := datagen.GenRandomBTCDelegation(
 				r,
 				t,
+				&chaincfg.RegressionNetParams,
 				[]bbn.BIP340PubKey{*fp.BtcPk},
 				delSK,
 				covenantSKs,
@@ -144,6 +145,7 @@ func FuzzCmdSetBtcDels(f *testing.F) {
 		delWithBadFp, err := datagen.GenRandomBTCDelegation(
 			r,
 			t,
+			&chaincfg.RegressionNetParams,
 			[]bbn.BIP340PubKey{*notInGenFp.BtcPk},
 			delSK,
 			covenantSKs,

--- a/testutil/datagen/btcstaking.go
+++ b/testutil/datagen/btcstaking.go
@@ -103,6 +103,7 @@ func GenRandomCustomFinalityProvider(r *rand.Rand, btcSK *btcec.PrivateKey, bbnS
 func GenRandomBTCDelegation(
 	r *rand.Rand,
 	t *testing.T,
+	btcNet *chaincfg.Params,
 	fpBTCPKs []bbn.BIP340PubKey,
 	delSK *btcec.PrivateKey,
 	covenantSKs []*btcec.PrivateKey,
@@ -113,7 +114,6 @@ func GenRandomBTCDelegation(
 	slashingRate sdkmath.LegacyDec,
 	slashingChangeLockTime uint16,
 ) (*bstypes.BTCDelegation, error) {
-	net := &chaincfg.SimNetParams
 	delPK := delSK.PubKey()
 	delBTCPK := bbn.NewBIP340PubKeyFromBTCPK(delPK)
 
@@ -141,7 +141,7 @@ func GenRandomBTCDelegation(
 	stakingSlashingInfo := GenBTCStakingSlashingInfo(
 		r,
 		t,
-		net,
+		btcNet,
 		delSK,
 		fpPKs,
 		covenantPks,
@@ -205,7 +205,7 @@ func GenRandomBTCDelegation(
 	unbondingSlashingInfo := GenBTCUnbondingSlashingInfo(
 		r,
 		t,
-		net,
+		btcNet,
 		delSK,
 		fpPKs,
 		covenantPks,

--- a/x/btcstaking/keeper/grpc_query_test.go
+++ b/x/btcstaking/keeper/grpc_query_test.go
@@ -7,7 +7,6 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 
-	"github.com/btcsuite/btcd/chaincfg"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/golang/mock/gomock"
@@ -178,7 +177,7 @@ func FuzzPendingBTCDelegations(f *testing.F) {
 
 		// covenant and slashing addr
 		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
-		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.SimNetParams)
+		slashingAddress, err := datagen.GenRandomBTCAddress(r, net)
 		require.NoError(t, err)
 		slashingChangeLockTime := uint16(101)
 
@@ -213,6 +212,7 @@ func FuzzPendingBTCDelegations(f *testing.F) {
 				btcDel, err := datagen.GenRandomBTCDelegation(
 					r,
 					t,
+					net,
 					[]bbn.BIP340PubKey{*fp.BtcPk},
 					delSK,
 					covenantSKs,
@@ -381,7 +381,7 @@ func FuzzActiveFinalityProvidersAtHeight(f *testing.F) {
 
 		// covenant and slashing addr
 		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
-		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.SimNetParams)
+		slashingAddress, err := datagen.GenRandomBTCAddress(r, net)
 		require.NoError(t, err)
 
 		slashingChangeLockTime := uint16(101)
@@ -419,6 +419,7 @@ func FuzzActiveFinalityProvidersAtHeight(f *testing.F) {
 				btcDel, err := datagen.GenRandomBTCDelegation(
 					r,
 					t,
+					net,
 					[]bbn.BIP340PubKey{*fpBTCPK},
 					delSK,
 					covenantSKs,
@@ -500,7 +501,7 @@ func FuzzFinalityProviderDelegations(f *testing.F) {
 
 		// covenant and slashing addr
 		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
-		slashingAddress, err := datagen.GenRandomBTCAddress(r, &chaincfg.SimNetParams)
+		slashingAddress, err := datagen.GenRandomBTCAddress(r, net)
 		require.NoError(t, err)
 		slashingChangeLockTime := uint16(101)
 
@@ -528,6 +529,7 @@ func FuzzFinalityProviderDelegations(f *testing.F) {
 			btcDel, err := datagen.GenRandomBTCDelegation(
 				r,
 				t,
+				net,
 				[]bbn.BIP340PubKey{*fp.BtcPk},
 				delSK,
 				covenantSKs,

--- a/x/btcstaking/keeper/keeper_test.go
+++ b/x/btcstaking/keeper/keeper_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	net = &chaincfg.SimNetParams
+)
+
 type Helper struct {
 	t testing.TB
 

--- a/x/btcstaking/keeper/msg_server_test.go
+++ b/x/btcstaking/keeper/msg_server_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/babylonchain/babylon/x/btcstaking/types"
 	etypes "github.com/babylonchain/babylon/x/epoching/types"
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -870,7 +869,6 @@ func createNDelegationsForFinalityProvider(
 		delSK, _, err := datagen.GenRandomBTCKeyPair(r)
 		require.NoError(t, err)
 
-		net := &chaincfg.SimNetParams
 		slashingAddress, err := datagen.GenRandomBTCAddress(r, net)
 		require.NoError(t, err)
 
@@ -879,6 +877,7 @@ func createNDelegationsForFinalityProvider(
 		del, err := datagen.GenRandomBTCDelegation(
 			r,
 			t,
+			net,
 			[]bbn.BIP340PubKey{*bbn.NewBIP340PubKeyFromBTCPK(fpPK)},
 			delSK,
 			covenatnSks,

--- a/x/btcstaking/types/btc_delegation_test.go
+++ b/x/btcstaking/types/btc_delegation_test.go
@@ -112,6 +112,7 @@ func FuzzBTCDelegation_SlashingTx(f *testing.F) {
 		btcDel, err := datagen.GenRandomBTCDelegation(
 			r,
 			t,
+			&chaincfg.SimNetParams,
 			fpBTCPKs,
 			delSK,
 			covenantSigners,

--- a/x/btcstaking/types/btc_undelegation_test.go
+++ b/x/btcstaking/types/btc_undelegation_test.go
@@ -61,6 +61,7 @@ func FuzzBTCUndelegation_SlashingTx(f *testing.F) {
 		btcDel, err := datagen.GenRandomBTCDelegation(
 			r,
 			t,
+			&chaincfg.SimNetParams,
 			fpBTCPKs,
 			delSK,
 			covenantSigners,


### PR DESCRIPTION
Needed by testing PoS integration. Rust Bitcoin library does not support simnet whereas many datagen functions in Babylon assume simnet.