### PR TITLE
hotfix: Remove broadcasting btc timestamps

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -28,9 +28,10 @@ func TestBTCTimestampingTestSuite(t *testing.T) {
 
 // TestBTCTimestampingPhase2RlyTestSuite tests BTC timestamping phase 2 protocol end-to-end,
 // with the Go relayer
-func TestBTCTimestampingPhase2RlyTestSuite(t *testing.T) {
-	suite.Run(t, new(BTCTimestampingPhase2RlyTestSuite))
-}
+// TODO: Uncomment once we have fix broadcasting of timestamps
+// func TestBTCTimestampingPhase2RlyTestSuite(t *testing.T) {
+// 	suite.Run(t, new(BTCTimestampingPhase2RlyTestSuite))
+// }
 
 // TestBTCStakingTestSuite tests BTC staking protocol end-to-end
 func TestBTCStakingTestSuite(t *testing.T) {

--- a/x/zoneconcierge/keeper/hooks.go
+++ b/x/zoneconcierge/keeper/hooks.go
@@ -36,7 +36,10 @@ func (h Hooks) AfterRawCheckpointFinalized(ctx context.Context, epoch uint64) er
 	headersToBroadcast := h.k.getHeadersToBroadcast(ctx)
 
 	// send BTC timestamp to all open channels with ZoneConcierge
-	h.k.BroadcastBTCTimestamps(ctx, epoch, headersToBroadcast)
+	// TODO: BroadcastBTCTimestamps is non-deterministic due to generating proofs
+	// which are affected by pruning. Re-enable after improving BroadcastBTCTimestamps
+	// methods
+	// h.k.BroadcastBTCTimestamps(ctx, epoch, headersToBroadcast)
 
 	// Update the last broadcasted segment
 	h.k.setLastSentSegment(ctx, &types.BTCChainSegment{


### PR DESCRIPTION
- When we have a phase-2 IBC channel connection, we are forwarding Bitcoin timestamps and proofs for them
- To generate the proof, we are switching the context to a past block height in order to retrieve the data for a prior state
- Validators that have a high pruning policy (i.e. only keep very few recent blocks), can’t switch to the past state to generate the data, leading to non-determinism

The hotfix involves removing broadcasting of BTC timestamps. We are going to implement a longer term solution in which we do not get historical states for the generation of timestamps for the next testnet. While this is not consensus breaking, this happened only on a recent block, so if we roll back to that block and apply this it consensus won't break for new participants on the ledger.
