### PR TITLE
Tighten checks in CheckTransactions function

### DIFF
--- a/btcstaking/staking.go
+++ b/btcstaking/staking.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	sdkmath "cosmossdk.io/math"
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
@@ -214,7 +215,7 @@ func IsSimpleTransfer(tx *wire.MsgTx) error {
 	return nil
 }
 
-// ValidateSlashingTx performs basic checks on a slashing transaction:
+// validateSlashingTx performs basic checks on a slashing transaction:
 // - the slashing transaction is not nil.
 // - the slashing transaction has exactly one input.
 // - the slashing transaction is non-replaceable.
@@ -225,7 +226,7 @@ func IsSimpleTransfer(tx *wire.MsgTx) error {
 //   - neither of the outputs are considered dust.
 //
 // - the min fee for slashing tx is preserved
-func ValidateSlashingTx(
+func validateSlashingTx(
 	slashingTx *wire.MsgTx,
 	slashingAddress btcutil.Address,
 	slashingRate sdkmath.LegacyDec,
@@ -329,6 +330,7 @@ func ValidateSlashingTx(
 }
 
 // CheckTransactions validates all relevant data of slashing and funding transaction.
+// - both transactions are valid from pov of BTC rules
 // - funding transaction has output committing to the provided script
 // - slashing transaction is valid
 // - slashing transaction input hash is pointing to funding transaction hash
@@ -344,6 +346,18 @@ func CheckTransactions(
 	slashingChangeLockTime uint16,
 	net *chaincfg.Params,
 ) error {
+	if slashingTx == nil || fundingTransaction == nil {
+		return fmt.Errorf("slashing and funding transactions must not be nil")
+	}
+
+	if blockchain.CheckTransactionSanity(btcutil.NewTx(slashingTx)) != nil {
+		return fmt.Errorf("slashing transaction does not obey BTC rules")
+	}
+
+	if blockchain.CheckTransactionSanity(btcutil.NewTx(fundingTransaction)) != nil {
+		return fmt.Errorf("funding transaction does not obey BTC rules")
+	}
+
 	// Check if slashing tx min fee is valid
 	if slashingTxMinFee <= 0 {
 		return fmt.Errorf("slashing transaction min fee must be larger than 0")
@@ -360,7 +374,7 @@ func CheckTransactions(
 
 	stakingOutput := fundingTransaction.TxOut[fundingOutputIdx]
 	// 3. Check if slashing transaction is valid
-	if err := ValidateSlashingTx(
+	if err := validateSlashingTx(
 		slashingTx,
 		slashingAddress,
 		slashingRate,

--- a/btcstaking/staking.go
+++ b/btcstaking/staking.go
@@ -350,12 +350,12 @@ func CheckTransactions(
 		return fmt.Errorf("slashing and funding transactions must not be nil")
 	}
 
-	if blockchain.CheckTransactionSanity(btcutil.NewTx(slashingTx)) != nil {
-		return fmt.Errorf("slashing transaction does not obey BTC rules")
+	if err := blockchain.CheckTransactionSanity(btcutil.NewTx(slashingTx)); err != nil {
+		return fmt.Errorf("slashing transaction does not obey BTC rules: %w", err)
 	}
 
-	if blockchain.CheckTransactionSanity(btcutil.NewTx(fundingTransaction)) != nil {
-		return fmt.Errorf("funding transaction does not obey BTC rules")
+	if err := blockchain.CheckTransactionSanity(btcutil.NewTx(fundingTransaction)); err != nil {
+		return fmt.Errorf("funding transaction does not obey BTC rules: %w", err)
 	}
 
 	// Check if slashing tx min fee is valid

--- a/btcstaking/staking_test.go
+++ b/btcstaking/staking_test.go
@@ -67,6 +67,12 @@ func FuzzGeneratingValidStakingSlashingTx(f *testing.F) {
 		r := rand.New(rand.NewSource(seed))
 		// we do not care for inputs in staking tx
 		stakingTx := wire.NewMsgTx(2)
+		bogusInputHashBytes := [32]byte{}
+		bogusInputHash, _ := chainhash.NewHash(bogusInputHashBytes[:])
+		stakingTx.AddTxIn(
+			wire.NewTxIn(wire.NewOutPoint(bogusInputHash, 0), nil, nil),
+		)
+
 		stakingOutputIdx := r.Intn(5)
 		// always more outputs than stakingOutputIdx
 		stakingTxNumOutputs := r.Intn(5) + 10
@@ -302,5 +308,5 @@ func TestSlashingTxWithOverflowMustNotAccepted(t *testing.T) {
 		&chaincfg.MainNetParams,
 	)
 	require.Error(t, err)
-	require.EqualError(t, err, "slashing transaction does not obey BTC rules")
+	require.EqualError(t, err, "slashing transaction does not obey BTC rules: transaction output value of 1152921504606846975 is higher than max allowed value of 2.1e+15")
 }

--- a/btcstaking/staking_test.go
+++ b/btcstaking/staking_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/babylonchain/babylon/btcstaking"
@@ -239,4 +240,67 @@ func FuzzGeneratingSignatureValidation(f *testing.F) {
 
 		require.NoError(t, err)
 	})
+}
+
+func TestSlashingTxWithOverflowMustNotAccepted(t *testing.T) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	// we do not care for inputs in staking tx
+	stakingTx := wire.NewMsgTx(2)
+	slashingLockTime := uint16(100)
+	minStakingValue := 10000
+	minFee := 2000
+	slashingRate := sdkmath.LegacyNewDecWithPrec(1000, 4)
+	sd := genValidStakingScriptData(t, r)
+
+	info, err := btcstaking.BuildStakingInfo(
+		sd.StakerKey,
+		[]*btcec.PublicKey{sd.FinalityProviderKey},
+		[]*btcec.PublicKey{sd.CovenantKey},
+		1,
+		sd.StakingTime,
+		btcutil.Amount(r.Intn(5000)+minStakingValue),
+		&chaincfg.MainNetParams,
+	)
+
+	require.NoError(t, err)
+	stakingTx.AddTxOut(info.StakingOutput)
+	bogusInputHashBytes := [32]byte{}
+	bogusInputHash, _ := chainhash.NewHash(bogusInputHashBytes[:])
+	stakingTx.AddTxIn(
+		wire.NewTxIn(wire.NewOutPoint(bogusInputHash, 0), nil, nil),
+	)
+
+	slashingAddress, err := genRandomBTCAddress(r)
+	require.NoError(t, err)
+
+	// Construct slashing transaction using the provided parameters
+	slashingTx, err := btcstaking.BuildSlashingTxFromStakingTxStrict(
+		stakingTx,
+		uint32(0),
+		slashingAddress,
+		sd.StakerKey,
+		slashingLockTime,
+		int64(minFee),
+		slashingRate,
+		&chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, slashingTx)
+
+	slashingTx.TxOut[0].Value = math.MaxInt64 / 8
+	slashingTx.TxOut[1].Value = math.MaxInt64 / 8
+
+	err = btcstaking.CheckTransactions(
+		slashingTx,
+		stakingTx,
+		uint32(0),
+		int64(minFee),
+		slashingRate,
+		slashingAddress,
+		sd.StakerKey,
+		slashingLockTime,
+		&chaincfg.MainNetParams,
+	)
+	require.Error(t, err)
+	require.EqualError(t, err, "slashing transaction does not obey BTC rules")
 }


### PR DESCRIPTION
- make `validateSlashingTx` private as it should not be part of the public api, the validation of slashing tx only have point in context of validation of funding/slashing transactions pair
- add check for slashing and funding transaction -  `blockchain.CheckTransactionSanity` which check transactions against BTC rules which are relevant to overlfows and transactions limits.