### PR TITLE
chore: Rename magic bytes to tag

### DIFF
--- a/btcstaking/staking_testvectors_test.go
+++ b/btcstaking/staking_testvectors_test.go
@@ -8,13 +8,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/babylonchain/babylon/btcstaking"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
+
+	"github.com/babylonchain/babylon/btcstaking"
 )
 
 func getBtcNetworkParams(network string) (*chaincfg.Params, error) {
@@ -86,7 +87,7 @@ type Parameters struct {
 	UnbondingTxVersion         int      `json:"unbonding_tx_version"`
 	UnbondingTime              int      `json:"unbonding_time"`
 	UnbondingFee               int      `json:"unbonding_fee"`
-	MagicBytes                 string   `json:"magic_bytes"`
+	Tag                        string   `json:"tag"`
 	Network                    string   `json:"network"`
 }
 
@@ -124,7 +125,7 @@ type ParsedParams struct {
 	UnbondingTxVersion         uint32
 	UnbondingTime              uint16
 	UnbondingFee               btcutil.Amount
-	MagicBytes                 []byte
+	Tag                        []byte
 	Network                    *chaincfg.Params
 }
 
@@ -139,7 +140,7 @@ func parseTestParams(t *testing.T, p *Parameters) (*ParsedParams, error) {
 		return nil, err
 	}
 
-	magicBytes, err := hex.DecodeString(p.MagicBytes)
+	tag, err := hex.DecodeString(p.Tag)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func parseTestParams(t *testing.T, p *Parameters) (*ParsedParams, error) {
 		UnbondingTxVersion:         uint32(p.UnbondingTxVersion),
 		UnbondingTime:              uint16(p.UnbondingTime),
 		UnbondingFee:               btcutil.Amount(p.UnbondingFee),
-		MagicBytes:                 magicBytes,
+		Tag:                        tag,
 		Network:                    network,
 	}, nil
 }
@@ -260,7 +261,7 @@ func TestVectorsCompatiblity(t *testing.T) {
 
 		if tc.Expected.OpReturnScript != "" {
 			data, err := btcstaking.NewV0OpReturnDataFromParsed(
-				parsedParams.MagicBytes,
+				parsedParams.Tag,
 				parsedParams.StakerPublicKey,
 				parsedParams.FinalityProviderPublicKeys[0],
 				parsedParams.StakingTime,
@@ -320,7 +321,7 @@ func GenerateTestCase(
 	stakingTime int,
 	unbondingTime int,
 	unbondingFee int,
-	magicBytes []byte,
+	tag []byte,
 ) string {
 	emptyHash := [32]byte{}
 	eh, err := chainhash.NewHash(emptyHash[:])
@@ -379,7 +380,7 @@ func GenerateTestCase(
 	// if there is more build op_return output
 	if len(finalityKeys) == 1 {
 		opInfo, err := btcstaking.BuildV0IdentifiableStakingOutputs(
-			magicBytes,
+			tag,
 			keysToPubKeys(t, stakerKeys)[0],
 			keysToPubKeys(t, finalityKeys)[0],
 			keysToPubKeys(t, covenantKeys),
@@ -404,7 +405,7 @@ func GenerateTestCase(
 		UnbondingTxVersion:         2,
 		UnbondingTime:              unbondingTime,
 		UnbondingFee:               unbondingFee,
-		MagicBytes:                 hex.EncodeToString(magicBytes),
+		Tag:                        hex.EncodeToString(tag),
 		Network:                    "mainnet",
 	}
 

--- a/btcstaking/testvectors/vectors.json
+++ b/btcstaking/testvectors/vectors.json
@@ -18,7 +18,7 @@
         "unbonding_tx_version": 2,
         "unbonding_time": 100,
         "unbonding_fee": 2000,
-        "magic_bytes": "01020304",
+        "tag": "01020304",
         "network": "mainnet"
       },
       "expected": {
@@ -55,7 +55,7 @@
         "unbonding_tx_version": 2,
         "unbonding_time": 50,
         "unbonding_fee": 20000,
-        "magic_bytes": "01020304",
+        "tag": "01020304",
         "network": "mainnet"
       },
       "expected": {
@@ -94,7 +94,7 @@
         "unbonding_tx_version": 2,
         "unbonding_time": 50,
         "unbonding_fee": 20000,
-        "magic_bytes": "01020304",
+        "tag": "01020304",
         "network": "mainnet"
       },
       "expected": {
@@ -135,7 +135,7 @@
         "unbonding_tx_version": 2,
         "unbonding_time": 201,
         "unbonding_fee": 50000,
-        "magic_bytes": "01020304",
+        "tag": "01020304",
         "network": "mainnet"
       },
       "expected": {
@@ -196,7 +196,7 @@
         "unbonding_tx_version": 2,
         "unbonding_time": 201,
         "unbonding_fee": 100000,
-        "magic_bytes": "01020304",
+        "tag": "01020304",
         "network": "mainnet"
       },
       "expected": {

--- a/docs/transaction-impl-spec.md
+++ b/docs/transaction-impl-spec.md
@@ -81,7 +81,7 @@ Data in the OP_RETURN output is described by the following struct:
 
 ```go
 type V0OpReturnData struct {
-	MagicBytes                []byte
+	Tag                       []byte
 	Version                   byte
 	StakerPublicKey           []byte
 	FinalityProviderPublicKey []byte
@@ -91,7 +91,7 @@ type V0OpReturnData struct {
 The implementation of the struct can be found [here](../btcstaking/identifiable_staking.go?pain=1#L52)
 
 Fields description:
-- `MagicBytes` - 4 bytes, tag which is used to identify the staking transaction
+- `Tag` - 4 bytes, tag which is used to identify the staking transaction
 among other transactions in the Bitcoin ledger.
 It is specified in the `global_parameters.Tag` field.
 - `Version` - 1 byte, current version of the OP_RETURN output
@@ -107,7 +107,7 @@ output in the staking transaction.
 
 This data is serialized as follows:
 ```
-SerializedStakingData = MagicBytes || Version || StakerPublicKey || FinalityProviderPublicKey || StakingTime
+SerializedStakingData = Tag || Version || StakerPublicKey || FinalityProviderPublicKey || StakingTime
 ```
 
 To transform this data into OP_RETURN data:
@@ -166,7 +166,7 @@ function with the following signature:
 
 ```go
 func BuildV0IdentifiableStakingOutputsAndTx(
-	magicBytes []byte,
+	tag []byte,
 	stakerKey *btcec.PublicKey,
 	fpKey *btcec.PublicKey,
 	covenantKeys []*btcec.PublicKey,


### PR DESCRIPTION
This PR renamed `magicBytes` to `tag` to be consistent with the `tag` field in the global parameters.