### PR TITLE
refactor: moving keepers to a new struct

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -11,25 +11,20 @@ import (
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
 	"cosmossdk.io/client/v2/autocli"
 	"cosmossdk.io/core/appmodule"
-	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
-	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/circuit"
-	circuitkeeper "cosmossdk.io/x/circuit/keeper"
 	circuittypes "cosmossdk.io/x/circuit/types"
 	"cosmossdk.io/x/evidence"
-	evidencekeeper "cosmossdk.io/x/evidence/keeper"
 	evidencetypes "cosmossdk.io/x/evidence/types"
 	"cosmossdk.io/x/feegrant"
-	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	feegrantmodule "cosmossdk.io/x/feegrant/module"
 	"cosmossdk.io/x/upgrade"
-	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	wasmapp "github.com/CosmWasm/wasmd/app"
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	bbn "github.com/babylonchain/babylon/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtos "github.com/cometbft/cometbft/libs/os"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -49,99 +44,72 @@ import (
 	"github.com/cosmos/cosmos-sdk/std"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
-	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	authzmodule "github.com/cosmos/cosmos-sdk/x/authz/module"
 	"github.com/cosmos/cosmos-sdk/x/bank"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/consensus"
-	consensusparamkeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
-	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
-	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
-	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	"github.com/cosmos/cosmos-sdk/x/mint"
-	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
-	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
-	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/cosmos/ibc-go/modules/capability"
-	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 	ibcfee "github.com/cosmos/ibc-go/v8/modules/apps/29-fee"
-	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
 	ibcfeetypes "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/types"
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer"
-	ibctransferkeeper "github.com/cosmos/ibc-go/v8/modules/apps/transfer/keeper"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
-	ibc "github.com/cosmos/ibc-go/v8/modules/core"
-	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types" // ibc module puts types under `ibchost` rather than `ibctypes`
+	ibc "github.com/cosmos/ibc-go/v8/modules/core" // ibc module puts types under `ibchost` rather than `ibctypes`
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
-	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 	"github.com/spf13/cast"
 
+	appkeepers "github.com/babylonchain/babylon/app/keepers"
 	appparams "github.com/babylonchain/babylon/app/params"
 	"github.com/babylonchain/babylon/client/docs"
-	bbn "github.com/babylonchain/babylon/types"
-	owasm "github.com/babylonchain/babylon/wasmbinding"
 	"github.com/babylonchain/babylon/x/btccheckpoint"
-	btccheckpointkeeper "github.com/babylonchain/babylon/x/btccheckpoint/keeper"
 	btccheckpointtypes "github.com/babylonchain/babylon/x/btccheckpoint/types"
 	"github.com/babylonchain/babylon/x/btclightclient"
-	btclightclientkeeper "github.com/babylonchain/babylon/x/btclightclient/keeper"
 	btclightclienttypes "github.com/babylonchain/babylon/x/btclightclient/types"
 	"github.com/babylonchain/babylon/x/btcstaking"
-	btcstakingkeeper "github.com/babylonchain/babylon/x/btcstaking/keeper"
 	btcstakingtypes "github.com/babylonchain/babylon/x/btcstaking/types"
 	"github.com/babylonchain/babylon/x/checkpointing"
-	checkpointingkeeper "github.com/babylonchain/babylon/x/checkpointing/keeper"
 	checkpointingtypes "github.com/babylonchain/babylon/x/checkpointing/types"
 	"github.com/babylonchain/babylon/x/epoching"
 	epochingkeeper "github.com/babylonchain/babylon/x/epoching/keeper"
 	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
 	"github.com/babylonchain/babylon/x/finality"
-	finalitykeeper "github.com/babylonchain/babylon/x/finality/keeper"
 	finalitytypes "github.com/babylonchain/babylon/x/finality/types"
 	"github.com/babylonchain/babylon/x/incentive"
-	incentivekeeper "github.com/babylonchain/babylon/x/incentive/keeper"
 	incentivetypes "github.com/babylonchain/babylon/x/incentive/types"
 	"github.com/babylonchain/babylon/x/monitor"
-	monitorkeeper "github.com/babylonchain/babylon/x/monitor/keeper"
 	monitortypes "github.com/babylonchain/babylon/x/monitor/types"
 	"github.com/babylonchain/babylon/x/zoneconcierge"
 	zckeeper "github.com/babylonchain/babylon/x/zoneconcierge/keeper"
@@ -166,11 +134,8 @@ const (
 )
 
 var (
-	// TODO review possible capabilities
-	// The last arguments can contain custom message handlers, and custom query handlers,
-	// if we want to allow any custom callbacks
-	// See https://github.com/CosmWasm/cosmwasm/blob/main/docs/CAPABILITIES-BUILT-IN.md
-	wasmCapabilities = []string{"iterator", "stargate", "cosmwasm_1_1", "cosmwasm_1_2", "staking", "babylon"}
+	// EmptyWasmOpts defines a type alias for a list of wasm options.
+	EmptyWasmOpts []wasmkeeper.Option
 
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
@@ -188,11 +153,15 @@ var (
 	}
 )
 
-// Wasm related variables
-var (
-	// EmptyWasmOpts defines a type alias for a list of wasm options.
-	EmptyWasmOpts []wasmkeeper.Option
-)
+func init() {
+	// Note: If this changes, the home directory under x/checkpointing/client/cli/tx.go needs to change as well
+	userHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	DefaultNodeHome = filepath.Join(userHomeDir, ".babylond")
+}
 
 var (
 	_ runtime.AppI            = (*BabylonApp)(nil)
@@ -204,65 +173,14 @@ var (
 // capabilities aren't needed for testing.
 type BabylonApp struct {
 	*baseapp.BaseApp
+	*appkeepers.AppKeepers
+
 	legacyAmino *codec.LegacyAmino
 	appCodec    codec.Codec
 	txConfig    client.TxConfig
 
 	interfaceRegistry types.InterfaceRegistry
-
-	invCheckPeriod uint
-
-	// keys to access the substores
-	keys    map[string]*storetypes.KVStoreKey
-	tkeys   map[string]*storetypes.TransientStoreKey
-	memKeys map[string]*storetypes.MemoryStoreKey
-
-	// keepers
-	AccountKeeper         authkeeper.AccountKeeper
-	BankKeeper            bankkeeper.Keeper
-	CapabilityKeeper      *capabilitykeeper.Keeper
-	StakingKeeper         *stakingkeeper.Keeper
-	SlashingKeeper        slashingkeeper.Keeper
-	MintKeeper            mintkeeper.Keeper
-	DistrKeeper           distrkeeper.Keeper
-	GovKeeper             govkeeper.Keeper
-	CrisisKeeper          *crisiskeeper.Keeper
-	UpgradeKeeper         *upgradekeeper.Keeper
-	ParamsKeeper          paramskeeper.Keeper
-	AuthzKeeper           authzkeeper.Keeper
-	EvidenceKeeper        evidencekeeper.Keeper
-	FeeGrantKeeper        feegrantkeeper.Keeper
-	ConsensusParamsKeeper consensusparamkeeper.Keeper
-	CircuitKeeper         circuitkeeper.Keeper
-
-	// Babylon modules
-	EpochingKeeper       epochingkeeper.Keeper
-	BTCLightClientKeeper btclightclientkeeper.Keeper
-	BtcCheckpointKeeper  btccheckpointkeeper.Keeper
-	CheckpointingKeeper  checkpointingkeeper.Keeper
-	MonitorKeeper        monitorkeeper.Keeper
-
-	// IBC-related modules
-	IBCKeeper           *ibckeeper.Keeper        // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
-	IBCFeeKeeper        ibcfeekeeper.Keeper      // for relayer incentivization - https://github.com/cosmos/ibc/tree/main/spec/app/ics-029-fee-payment
-	TransferKeeper      ibctransferkeeper.Keeper // for cross-chain fungible token transfers
-	ZoneConciergeKeeper zckeeper.Keeper          // for cross-chain fungible token transfers
-
-	// BTC staking related modules
-	BTCStakingKeeper btcstakingkeeper.Keeper
-	FinalityKeeper   finalitykeeper.Keeper
-
-	// wasm smart contract module
-	WasmKeeper wasmkeeper.Keeper
-
-	// tokenomics-related modules
-	IncentiveKeeper incentivekeeper.Keeper
-
-	// make scoped keepers public for test purposes
-	ScopedIBCKeeper           capabilitykeeper.ScopedKeeper
-	ScopedTransferKeeper      capabilitykeeper.ScopedKeeper
-	ScopedZoneConciergeKeeper capabilitykeeper.ScopedKeeper
-	ScopedWasmKeeper          capabilitykeeper.ScopedKeeper
+	invCheckPeriod    uint
 
 	// the module manager
 	ModuleManager      *module.Manager
@@ -275,20 +193,15 @@ type BabylonApp struct {
 	configurator module.Configurator
 }
 
-func init() {
-	// Note: If this changes, the home directory under x/checkpointing/client/cli/tx.go needs to change as well
-	userHomeDir, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-
-	DefaultNodeHome = filepath.Join(userHomeDir, ".babylond")
-}
-
 // NewBabylonApp returns a reference to an initialized BabylonApp.
 func NewBabylonApp(
-	logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool, skipUpgradeHeights map[int64]bool,
-	invCheckPeriod uint, privSigner *PrivSigner,
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	loadLatest bool,
+	skipUpgradeHeights map[int64]bool,
+	invCheckPeriod uint,
+	privSigner *appkeepers.PrivSigner,
 	appOpts servertypes.AppOptions,
 	wasmOpts []wasmkeeper.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),
@@ -296,8 +209,6 @@ func NewBabylonApp(
 	// we could also take it from global object which should be initialised in rootCmd
 	// but this way it makes babylon app more testable
 	btcConfig := bbn.ParseBtcOptionsFromConfig(appOpts)
-	powLimit := btcConfig.PowLimit()
-	btcNetParams := btcConfig.NetParams()
 	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
 	if homePath == "" {
 		homePath = DefaultNodeHome
@@ -311,459 +222,43 @@ func NewBabylonApp(
 	std.RegisterLegacyAminoCodec(legacyAmino)
 	std.RegisterInterfaces(interfaceRegistry)
 
-	keys := storetypes.NewKVStoreKeys(
-		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey, crisistypes.StoreKey,
-		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
-		govtypes.StoreKey, paramstypes.StoreKey, consensusparamtypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
-		evidencetypes.StoreKey, circuittypes.StoreKey, capabilitytypes.StoreKey,
-		authzkeeper.StoreKey,
-		// Babylon modules
-		epochingtypes.StoreKey,
-		btclightclienttypes.StoreKey,
-		btccheckpointtypes.StoreKey,
-		checkpointingtypes.StoreKey,
-		monitortypes.StoreKey,
-		// IBC-related modules
-		ibcexported.StoreKey,
-		ibctransfertypes.StoreKey,
-		ibcfeetypes.StoreKey,
-		zctypes.StoreKey,
-		// BTC staking related modules
-		btcstakingtypes.StoreKey,
-		finalitytypes.StoreKey,
-		// WASM
-		wasmtypes.StoreKey,
-		// tokenomics-related modules
-		incentivetypes.StoreKey,
-	)
-	accountKeeper := authkeeper.NewAccountKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[authtypes.StoreKey]),
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(appparams.Bech32PrefixAccAddr),
-		appparams.Bech32PrefixAccAddr,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	bankKeeper := bankkeeper.NewBaseKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
-		accountKeeper,
-		BlockedAddresses(),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		logger,
-	)
-
-	stakingKeeper := stakingkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[stakingtypes.StoreKey]),
-		accountKeeper,
-		bankKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		authcodec.NewBech32Codec(appparams.Bech32PrefixValAddr),
-		authcodec.NewBech32Codec(appparams.Bech32PrefixConsAddr),
-	)
-
-	// NOTE: the epoching module has to be set before the chekpointing module, as the checkpointing module will have access to the epoching module
-	epochingKeeper := epochingkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[epochingtypes.StoreKey]),
-		bankKeeper,
-		stakingKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	checkpointingKeeper := checkpointingkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[checkpointingtypes.StoreKey]),
-		privSigner.WrappedPV,
-		epochingKeeper,
-	)
-
-	// set proposal extension
-	prepareOpt := func(bApp *baseapp.BaseApp) {
-		proposalHandler := checkpointing.NewProposalHandler(
-			logger, &checkpointingKeeper, bApp.Mempool(), bApp)
-		proposalHandler.SetHandlers(bApp)
-	}
-	baseAppOptions = append(baseAppOptions, prepareOpt)
-
-	// set vote extension
-	voteExtOp := func(bApp *baseapp.BaseApp) {
-		voteExtHandler := checkpointing.NewVoteExtensionHandler(logger, &checkpointingKeeper)
-		voteExtHandler.SetHandlers(bApp)
-	}
-	baseAppOptions = append(baseAppOptions, voteExtOp)
-
 	bApp := baseapp.NewBaseApp(appName, logger, db, txConfig.TxDecoder(), baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)
 	bApp.SetVersion(version.Version)
 	bApp.SetInterfaceRegistry(interfaceRegistry)
 	bApp.SetTxEncoder(txConfig.TxEncoder())
 
-	tkeys := storetypes.NewTransientStoreKeys(
-		paramstypes.TStoreKey, btccheckpointtypes.TStoreKey)
-	// NOTE: The testingkey is just mounted for testing purposes. Actual applications should
-	// not include this key.
-	memKeys := storetypes.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, "testingkey")
-
-	// register streaming services
-	if err := bApp.RegisterStreamingServices(appOpts, keys); err != nil {
-		panic(err)
+	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
+	if err != nil {
+		panic(fmt.Sprintf("error while reading wasm config: %s", err))
 	}
 
 	app := &BabylonApp{
+		AppKeepers:        &appkeepers.AppKeepers{},
 		BaseApp:           bApp,
 		legacyAmino:       legacyAmino,
 		appCodec:          appCodec,
 		txConfig:          txConfig,
 		interfaceRegistry: interfaceRegistry,
 		invCheckPeriod:    invCheckPeriod,
-		keys:              keys,
-		tkeys:             tkeys,
-		memKeys:           memKeys,
 	}
 
-	app.ParamsKeeper = initParamsKeeper(
+	app.AppKeepers.InitKeepers(
+		logger,
 		appCodec,
-		legacyAmino,
-		keys[paramstypes.StoreKey],
-		tkeys[paramstypes.TStoreKey],
-	)
-
-	app.ConsensusParamsKeeper = consensusparamkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[consensusparamtypes.StoreKey]),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		runtime.EventService{},
-	)
-	bApp.SetParamStore(app.ConsensusParamsKeeper.ParamsStore)
-
-	app.CapabilityKeeper = capabilitykeeper.NewKeeper(
-		appCodec,
-		keys[capabilitytypes.StoreKey],
-		memKeys[capabilitytypes.MemStoreKey],
-	)
-
-	// grant capabilities for the ibc and ibc-transfer modules
-	scopedIBCKeeper := app.CapabilityKeeper.ScopeToModule(ibcexported.ModuleName)
-	scopedTransferKeeper := app.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
-	scopedZoneConciergeKeeper := app.CapabilityKeeper.ScopeToModule(zctypes.ModuleName)
-	scopedWasmKeeper := app.CapabilityKeeper.ScopeToModule(wasmtypes.ModuleName)
-
-	// Applications that wish to enforce statically created ScopedKeepers should call `Seal` after creating
-	// their scoped modules in `NewApp` with `ScopeToModule`
-	app.CapabilityKeeper.Seal()
-
-	// add keepers
-	app.AccountKeeper = accountKeeper
-
-	app.BankKeeper = bankKeeper
-
-	app.StakingKeeper = stakingKeeper
-
-	app.CircuitKeeper = circuitkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[circuittypes.StoreKey]),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		app.AccountKeeper.AddressCodec(),
-	)
-	app.BaseApp.SetCircuitBreaker(&app.CircuitKeeper)
-
-	app.MintKeeper = mintkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[minttypes.StoreKey]),
-		app.StakingKeeper,
-		app.AccountKeeper,
-		app.BankKeeper,
-		authtypes.FeeCollectorName,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	app.DistrKeeper = distrkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[distrtypes.StoreKey]),
-		app.AccountKeeper,
-		app.BankKeeper,
-		app.StakingKeeper,
-		authtypes.FeeCollectorName,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	// set up incentive keeper
-	app.IncentiveKeeper = incentivekeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[incentivetypes.StoreKey]),
-		app.BankKeeper,
-		app.AccountKeeper,
-		&epochingKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		authtypes.FeeCollectorName,
-	)
-
-	app.SlashingKeeper = slashingkeeper.NewKeeper(
-		appCodec,
-		legacyAmino,
-		runtime.NewKVStoreService(keys[slashingtypes.StoreKey]),
-		app.StakingKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	app.CrisisKeeper = crisiskeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[crisistypes.StoreKey]),
+		&btcConfig,
+		encCfg,
+		bApp,
+		maccPerms,
+		homePath,
 		invCheckPeriod,
-		app.BankKeeper,
-		authtypes.FeeCollectorName,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		app.AccountKeeper.AddressCodec(),
-	)
-
-	app.FeeGrantKeeper = feegrantkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[feegrant.StoreKey]),
-		app.AccountKeeper,
-	)
-	// register the staking hooks
-	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
-	app.StakingKeeper.SetHooks(
-		stakingtypes.NewMultiStakingHooks(app.DistrKeeper.Hooks(), app.SlashingKeeper.Hooks(), epochingKeeper.Hooks()),
-	)
-
-	// set the governance module account as the authority for conducting upgrades
-	app.UpgradeKeeper = upgradekeeper.NewKeeper(
 		skipUpgradeHeights,
-		runtime.NewKVStoreService(keys[upgradetypes.StoreKey]),
-		appCodec,
-		homePath,
-		app.BaseApp,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	app.AuthzKeeper = authzkeeper.NewKeeper(
-		runtime.NewKVStoreService(keys[authzkeeper.StoreKey]),
-		appCodec,
-		app.MsgServiceRouter(),
-		app.AccountKeeper,
-	)
-
-	app.IBCKeeper = ibckeeper.NewKeeper(
-		appCodec,
-		keys[ibcexported.StoreKey],
-		app.GetSubspace(ibcexported.ModuleName),
-		app.StakingKeeper,
-		app.UpgradeKeeper,
-		scopedIBCKeeper,
-		// From 8.0.0 the IBC keeper requires an authority for the messages
-		// `MsgIBCSoftwareUpgrade` and `MsgRecoverClient`
-		// https://github.com/cosmos/ibc-go/releases/tag/v8.0.0
-		// Gov is the proper authority for those types of messages
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	// register the proposal types
-	// Deprecated: Avoid adding new handlers, instead use the new proposal flow
-	// by granting the governance module the right to execute the message.
-	// See: https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/x/gov/spec/01_concepts.md#proposal-messages
-	// TODO: investigate how to migrate to new proposal flow
-	govRouter := govv1beta1.NewRouter()
-	govRouter.AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
-		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper))
-
-	// TODO: this should be a function parameter
-	govConfig := govtypes.DefaultConfig()
-	/*
-		Example of setting gov params:
-		govConfig.MaxMetadataLen = 10000
-	*/
-	govKeeper := govkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[govtypes.StoreKey]),
-		app.AccountKeeper,
-		app.BankKeeper,
-		app.StakingKeeper,
-		app.DistrKeeper,
-		app.MsgServiceRouter(),
-		govConfig,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String())
-
-	app.GovKeeper = *govKeeper.SetHooks(
-		govtypes.NewMultiGovHooks(
-		// register the governance hooks
-		),
-	)
-
-	btclightclientKeeper := btclightclientkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[btclightclienttypes.StoreKey]),
-		btcConfig,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	btcCheckpointKeeper := btccheckpointkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[btccheckpointtypes.StoreKey]),
-		tkeys[btccheckpointtypes.TStoreKey],
-		&btclightclientKeeper,
-		&checkpointingKeeper,
-		&app.IncentiveKeeper,
-		&powLimit,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	// create querier for KVStore
-	storeQuerier, ok := app.CommitMultiStore().(storetypes.Queryable)
-	if !ok {
-		panic(errorsmod.Wrap(sdkerrors.ErrUnknownRequest, "multistore doesn't support queries"))
-	}
-
-	app.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
-		appCodec, keys[ibcfeetypes.StoreKey],
-		app.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
-		app.IBCKeeper.ChannelKeeper,
-		app.IBCKeeper.PortKeeper, app.AccountKeeper, app.BankKeeper,
-	)
-
-	zcKeeper := zckeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[zctypes.StoreKey]),
-		app.IBCFeeKeeper,
-		app.IBCKeeper.ClientKeeper,
-		app.IBCKeeper.ChannelKeeper,
-		app.IBCKeeper.PortKeeper,
-		app.AccountKeeper,
-		app.BankKeeper,
-		&btclightclientKeeper,
-		&checkpointingKeeper,
-		&btcCheckpointKeeper,
-		epochingKeeper,
-		storeQuerier,
-		scopedZoneConciergeKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-	app.ZoneConciergeKeeper = *zcKeeper
-
-	// Create Transfer Keepers
-	app.TransferKeeper = ibctransferkeeper.NewKeeper(
-		appCodec,
-		keys[ibctransfertypes.StoreKey],
-		app.GetSubspace(ibctransfertypes.ModuleName),
-		app.IBCFeeKeeper,
-		app.IBCKeeper.ChannelKeeper,
-		app.IBCKeeper.PortKeeper,
-		app.AccountKeeper,
-		app.BankKeeper,
-		scopedTransferKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	app.MonitorKeeper = monitorkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[monitortypes.StoreKey]),
-		&btclightclientKeeper,
-	)
-
-	// add msgServiceRouter so that the epoching module can forward unwrapped messages to the staking module
-	epochingKeeper.SetMsgServiceRouter(app.BaseApp.MsgServiceRouter())
-	// make ZoneConcierge and Monitor to subscribe to the epoching's hooks
-	app.EpochingKeeper = *epochingKeeper.SetHooks(
-		epochingtypes.NewMultiEpochingHooks(app.ZoneConciergeKeeper.Hooks(), app.MonitorKeeper.Hooks()),
-	)
-
-	// set up Checkpointing, BTCCheckpoint, and BTCLightclient keepers
-	app.CheckpointingKeeper = *checkpointingKeeper.SetHooks(
-		checkpointingtypes.NewMultiCheckpointingHooks(app.EpochingKeeper.Hooks(), app.ZoneConciergeKeeper.Hooks(), app.MonitorKeeper.Hooks()),
-	)
-	app.BtcCheckpointKeeper = btcCheckpointKeeper
-	app.BTCLightClientKeeper = *btclightclientKeeper.SetHooks(
-		btclightclienttypes.NewMultiBTCLightClientHooks(app.BtcCheckpointKeeper.Hooks()),
-	)
-
-	// set up BTC staking keeper
-	app.BTCStakingKeeper = btcstakingkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[btcstakingtypes.StoreKey]),
-		&btclightclientKeeper,
-		&btcCheckpointKeeper,
-		&checkpointingKeeper,
-		btcNetParams,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-	// set up finality keeper
-	app.FinalityKeeper = finalitykeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[finalitytypes.StoreKey]),
-		app.BTCStakingKeeper,
-		app.IncentiveKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-	)
-
-	// create evidence keeper with router
-	evidenceKeeper := evidencekeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[evidencetypes.StoreKey]),
-		app.StakingKeeper,
-		app.SlashingKeeper,
-		app.AccountKeeper.AddressCodec(),
-		runtime.ProvideCometInfoService(),
-	)
-	// If evidence needs to be handled for the app, set routes in router here and seal
-	app.EvidenceKeeper = *evidenceKeeper
-
-	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
-	if err != nil {
-		panic(fmt.Sprintf("error while reading wasm config: %s", err))
-	}
-
-	wasmOpts = append(owasm.RegisterCustomPlugins(&app.EpochingKeeper, &app.ZoneConciergeKeeper, &app.BTCLightClientKeeper), wasmOpts...)
-
-	app.WasmKeeper = wasmkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[wasmtypes.StoreKey]),
-		app.AccountKeeper,
-		app.BankKeeper,
-		app.StakingKeeper,
-		distrkeeper.NewQuerier(app.DistrKeeper),
-		app.IBCFeeKeeper,
-		app.IBCKeeper.ChannelKeeper,
-		app.IBCKeeper.PortKeeper,
-		scopedWasmKeeper,
-		app.TransferKeeper,
-		app.MsgServiceRouter(),
-		app.GRPCQueryRouter(),
-		homePath,
+		privSigner,
+		appOpts,
 		wasmConfig,
-		wasmCapabilities,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		wasmOpts...,
+		wasmOpts,
+		BlockedAddresses(),
 	)
-
-	// Set legacy router for backwards compatibility with gov v1beta1
-	app.GovKeeper.SetLegacyRouter(govRouter)
-
-	// Create all supported IBC routes
-	var transferStack porttypes.IBCModule
-	transferStack = transfer.NewIBCModule(app.TransferKeeper)
-	transferStack = ibcfee.NewIBCMiddleware(transferStack, app.IBCFeeKeeper)
-
-	var zoneConciergeStack porttypes.IBCModule
-	zoneConciergeStack = zoneconcierge.NewIBCModule(app.ZoneConciergeKeeper)
-	zoneConciergeStack = ibcfee.NewIBCMiddleware(zoneConciergeStack, app.IBCFeeKeeper)
-
-	var wasmStack porttypes.IBCModule
-	wasmStack = wasm.NewIBCHandler(app.WasmKeeper, app.IBCKeeper.ChannelKeeper, app.IBCFeeKeeper)
-	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, app.IBCFeeKeeper)
-
-	// Create static IBC router, add ibc-transfer module route, then set and seal it
-	ibcRouter := porttypes.NewRouter().
-		AddRoute(ibctransfertypes.ModuleName, transferStack).
-		AddRoute(zctypes.ModuleName, zoneConciergeStack).
-		AddRoute(wasmtypes.ModuleName, wasmStack)
-
-	// Setting Router will finalize all routes by sealing router
-	// No more routes can be added
-	app.IBCKeeper.SetRouter(ibcRouter)
 
 	/****  Module Options ****/
 
@@ -940,8 +435,7 @@ func NewBabylonApp(
 
 	app.ModuleManager.RegisterInvariants(app.CrisisKeeper)
 	app.configurator = module.NewConfigurator(app.appCodec, app.MsgServiceRouter(), app.GRPCQueryRouter())
-	err = app.ModuleManager.RegisterServices(app.configurator)
-	if err != nil {
+	if err := app.ModuleManager.RegisterServices(app.configurator); err != nil {
 		panic(err)
 	}
 
@@ -968,9 +462,9 @@ func NewBabylonApp(
 	app.sm.RegisterStoreDecoders()
 
 	// initialize stores
-	app.MountKVStores(keys)
-	app.MountTransientStores(tkeys)
-	app.MountMemoryStores(memKeys)
+	app.MountKVStores(app.GetKVStoreKeys())
+	app.MountTransientStores(app.GetTransientStoreKeys())
+	app.MountMemoryStores(app.GetMemoryStoreKeys())
 
 	// initialize AnteHandler, which includes
 	// - authAnteHandler
@@ -990,7 +484,7 @@ func NewBabylonApp(
 			},
 			IBCKeeper:             app.IBCKeeper,
 			WasmConfig:            &wasmConfig,
-			TXCounterStoreService: runtime.NewKVStoreService(keys[wasmtypes.StoreKey]),
+			TXCounterStoreService: runtime.NewKVStoreService(app.AppKeepers.GetKey(wasmtypes.StoreKey)),
 			WasmKeeper:            &app.WasmKeeper,
 			CircuitKeeper:         &app.CircuitKeeper,
 		},
@@ -1029,11 +523,6 @@ func NewBabylonApp(
 			panic(fmt.Errorf("failed to register snapshot extension: %s", err))
 		}
 	}
-
-	app.ScopedIBCKeeper = scopedIBCKeeper
-	app.ScopedZoneConciergeKeeper = scopedZoneConciergeKeeper
-	app.ScopedTransferKeeper = scopedTransferKeeper
-	app.ScopedWasmKeeper = scopedWasmKeeper
 
 	// At startup, after all modules have been registered, check that all proto
 	// annotations are correct.
@@ -1156,35 +645,6 @@ func (app *BabylonApp) EncodingConfig() *appparams.EncodingConfig {
 	}
 }
 
-// GetKey returns the KVStoreKey for the provided store key.
-//
-// NOTE: This is solely to be used for testing purposes.
-func (app *BabylonApp) GetKey(storeKey string) *storetypes.KVStoreKey {
-	return app.keys[storeKey]
-}
-
-// GetTKey returns the TransientStoreKey for the provided store key.
-//
-// NOTE: This is solely to be used for testing purposes.
-func (app *BabylonApp) GetTKey(storeKey string) *storetypes.TransientStoreKey {
-	return app.tkeys[storeKey]
-}
-
-// GetMemKey returns the MemStoreKey for the provided mem key.
-//
-// NOTE: This is solely used for testing purposes.
-func (app *BabylonApp) GetMemKey(storeKey string) *storetypes.MemoryStoreKey {
-	return app.memKeys[storeKey]
-}
-
-// GetSubspace returns a param subspace for a given module name.
-//
-// NOTE: This is solely to be used for testing purposes.
-func (app *BabylonApp) GetSubspace(moduleName string) paramstypes.Subspace {
-	subspace, _ := app.ParamsKeeper.GetSubspace(moduleName)
-	return subspace
-}
-
 // SimulationManager implements the SimulationApp interface
 func (app *BabylonApp) SimulationManager() *module.SimulationManager {
 	return app.sm
@@ -1281,18 +741,4 @@ func BlockedAddresses() map[string]bool {
 	delete(modAccAddrs, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 
 	return modAccAddrs
-}
-
-// initParamsKeeper init params keeper and its subspaces
-func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey storetypes.StoreKey) paramskeeper.Keeper {
-	paramsKeeper := paramskeeper.NewKeeper(appCodec, legacyAmino, key, tkey)
-
-	// TODO: Only modules which did not migrate yet to new way of hanldling params
-	// are the IBC-related modules. Once they are migrated, we can remove this and
-	// whole usage of params module
-	paramsKeeper.Subspace(ibcexported.ModuleName)
-	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
-	paramsKeeper.Subspace(zctypes.ModuleName)
-
-	return paramsKeeper
 }

--- a/app/export.go
+++ b/app/export.go
@@ -203,7 +203,7 @@ func (app *BabylonApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 
 	// Iterate through validators by power descending, reset bond heights, and
 	// update bond intra-tx counters.
-	store := ctx.KVStore(app.keys[stakingtypes.StoreKey])
+	store := ctx.KVStore(app.GetKey(stakingtypes.StoreKey))
 	iter := storetypes.KVStoreReversePrefixIterator(store, stakingtypes.ValidatorsKey)
 
 	for ; iter.Valid(); iter.Next() {

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -1,0 +1,609 @@
+package keepers
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
+	circuitkeeper "cosmossdk.io/x/circuit/keeper"
+	circuittypes "cosmossdk.io/x/circuit/types"
+	evidencekeeper "cosmossdk.io/x/evidence/keeper"
+	evidencetypes "cosmossdk.io/x/evidence/types"
+	"cosmossdk.io/x/feegrant"
+	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
+	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	consensusparamkeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
+	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
+	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
+	ibcfee "github.com/cosmos/ibc-go/v8/modules/apps/29-fee"
+	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
+	ibcfeetypes "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/types"
+	"github.com/cosmos/ibc-go/v8/modules/apps/transfer"
+	ibctransferkeeper "github.com/cosmos/ibc-go/v8/modules/apps/transfer/keeper"
+	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types" // ibc module puts types under `ibchost` rather than `ibctypes`
+	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
+	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
+
+	appparams "github.com/babylonchain/babylon/app/params"
+	bbn "github.com/babylonchain/babylon/types"
+	owasm "github.com/babylonchain/babylon/wasmbinding"
+	btccheckpointkeeper "github.com/babylonchain/babylon/x/btccheckpoint/keeper"
+	btccheckpointtypes "github.com/babylonchain/babylon/x/btccheckpoint/types"
+	btclightclientkeeper "github.com/babylonchain/babylon/x/btclightclient/keeper"
+	btclightclienttypes "github.com/babylonchain/babylon/x/btclightclient/types"
+	btcstakingkeeper "github.com/babylonchain/babylon/x/btcstaking/keeper"
+	btcstakingtypes "github.com/babylonchain/babylon/x/btcstaking/types"
+	"github.com/babylonchain/babylon/x/checkpointing"
+	checkpointingkeeper "github.com/babylonchain/babylon/x/checkpointing/keeper"
+	checkpointingtypes "github.com/babylonchain/babylon/x/checkpointing/types"
+	epochingkeeper "github.com/babylonchain/babylon/x/epoching/keeper"
+	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
+	finalitykeeper "github.com/babylonchain/babylon/x/finality/keeper"
+	finalitytypes "github.com/babylonchain/babylon/x/finality/types"
+	incentivekeeper "github.com/babylonchain/babylon/x/incentive/keeper"
+	incentivetypes "github.com/babylonchain/babylon/x/incentive/types"
+	monitorkeeper "github.com/babylonchain/babylon/x/monitor/keeper"
+	monitortypes "github.com/babylonchain/babylon/x/monitor/types"
+	"github.com/babylonchain/babylon/x/zoneconcierge"
+	zckeeper "github.com/babylonchain/babylon/x/zoneconcierge/keeper"
+	zctypes "github.com/babylonchain/babylon/x/zoneconcierge/types"
+)
+
+var (
+	// TODO review possible capabilities
+	// The last arguments can contain custom message handlers, and custom query handlers,
+	// if we want to allow any custom callbacks
+	// See https://github.com/CosmWasm/cosmwasm/blob/main/docs/CAPABILITIES-BUILT-IN.md
+	wasmCapabilities = []string{"iterator", "stargate", "cosmwasm_1_1", "cosmwasm_1_2", "staking", "babylon"}
+)
+
+type AppKeepers struct {
+	// keepers
+	AccountKeeper         authkeeper.AccountKeeper
+	BankKeeper            bankkeeper.Keeper
+	CapabilityKeeper      *capabilitykeeper.Keeper
+	StakingKeeper         *stakingkeeper.Keeper
+	SlashingKeeper        slashingkeeper.Keeper
+	MintKeeper            mintkeeper.Keeper
+	DistrKeeper           distrkeeper.Keeper
+	GovKeeper             govkeeper.Keeper
+	CrisisKeeper          *crisiskeeper.Keeper
+	UpgradeKeeper         *upgradekeeper.Keeper
+	ParamsKeeper          paramskeeper.Keeper
+	AuthzKeeper           authzkeeper.Keeper
+	EvidenceKeeper        evidencekeeper.Keeper
+	FeeGrantKeeper        feegrantkeeper.Keeper
+	ConsensusParamsKeeper consensusparamkeeper.Keeper
+	CircuitKeeper         circuitkeeper.Keeper
+
+	// Babylon modules
+	EpochingKeeper       epochingkeeper.Keeper
+	BTCLightClientKeeper btclightclientkeeper.Keeper
+	BtcCheckpointKeeper  btccheckpointkeeper.Keeper
+	CheckpointingKeeper  checkpointingkeeper.Keeper
+	MonitorKeeper        monitorkeeper.Keeper
+
+	// IBC-related modules
+	IBCKeeper           *ibckeeper.Keeper        // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	IBCFeeKeeper        ibcfeekeeper.Keeper      // for relayer incentivization - https://github.com/cosmos/ibc/tree/main/spec/app/ics-029-fee-payment
+	TransferKeeper      ibctransferkeeper.Keeper // for cross-chain fungible token transfers
+	ZoneConciergeKeeper zckeeper.Keeper          // for cross-chain fungible token transfers
+
+	// BTC staking related modules
+	BTCStakingKeeper btcstakingkeeper.Keeper
+	FinalityKeeper   finalitykeeper.Keeper
+
+	// wasm smart contract module
+	WasmKeeper wasmkeeper.Keeper
+
+	// tokenomics-related modules
+	IncentiveKeeper incentivekeeper.Keeper
+
+	// make scoped keepers public for test purposes
+	ScopedIBCKeeper           capabilitykeeper.ScopedKeeper
+	ScopedTransferKeeper      capabilitykeeper.ScopedKeeper
+	ScopedZoneConciergeKeeper capabilitykeeper.ScopedKeeper
+	ScopedWasmKeeper          capabilitykeeper.ScopedKeeper
+
+	// keys to access the substores
+	keys    map[string]*storetypes.KVStoreKey
+	tkeys   map[string]*storetypes.TransientStoreKey
+	memKeys map[string]*storetypes.MemoryStoreKey
+}
+
+func (ak *AppKeepers) InitKeepers(
+	logger log.Logger,
+	appCodec codec.Codec,
+	btcConfig *bbn.BtcConfig,
+	encodingConfig *appparams.EncodingConfig,
+	bApp *baseapp.BaseApp,
+	maccPerms map[string][]string,
+	homePath string,
+	invCheckPeriod uint,
+	skipUpgradeHeights map[int64]bool,
+	privSigner *PrivSigner,
+	appOpts servertypes.AppOptions,
+	wasmConfig wasmtypes.WasmConfig,
+	wasmOpts []wasmkeeper.Option,
+	blockedAddress map[string]bool,
+) {
+	powLimit := btcConfig.PowLimit()
+	btcNetParams := btcConfig.NetParams()
+
+	// set persistent store keys
+	keys := storetypes.NewKVStoreKeys(
+		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey, crisistypes.StoreKey,
+		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
+		govtypes.StoreKey, paramstypes.StoreKey, consensusparamtypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
+		evidencetypes.StoreKey, circuittypes.StoreKey, capabilitytypes.StoreKey,
+		authzkeeper.StoreKey,
+		// Babylon modules
+		epochingtypes.StoreKey,
+		btclightclienttypes.StoreKey,
+		btccheckpointtypes.StoreKey,
+		checkpointingtypes.StoreKey,
+		monitortypes.StoreKey,
+		// IBC-related modules
+		ibcexported.StoreKey,
+		ibctransfertypes.StoreKey,
+		ibcfeetypes.StoreKey,
+		zctypes.StoreKey,
+		// BTC staking related modules
+		btcstakingtypes.StoreKey,
+		finalitytypes.StoreKey,
+		// WASM
+		wasmtypes.StoreKey,
+		// tokenomics-related modules
+		incentivetypes.StoreKey,
+	)
+	ak.keys = keys
+
+	// set transient store keys
+	ak.tkeys = storetypes.NewTransientStoreKeys(paramstypes.TStoreKey, btccheckpointtypes.TStoreKey)
+
+	// set memory store keys
+	// NOTE: The testingkey is just mounted for testing purposes. Actual applications should
+	// not include this key.
+	ak.memKeys = storetypes.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, "testingkey")
+
+	accountKeeper := authkeeper.NewAccountKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[authtypes.StoreKey]),
+		authtypes.ProtoBaseAccount,
+		maccPerms,
+		authcodec.NewBech32Codec(appparams.Bech32PrefixAccAddr),
+		appparams.Bech32PrefixAccAddr,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	bankKeeper := bankkeeper.NewBaseKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
+		accountKeeper,
+		blockedAddress,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		logger,
+	)
+
+	stakingKeeper := stakingkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[stakingtypes.StoreKey]),
+		accountKeeper,
+		bankKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		authcodec.NewBech32Codec(appparams.Bech32PrefixValAddr),
+		authcodec.NewBech32Codec(appparams.Bech32PrefixConsAddr),
+	)
+
+	// NOTE: the epoching module has to be set before the chekpointing module, as the checkpointing module will have access to the epoching module
+	epochingKeeper := epochingkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[epochingtypes.StoreKey]),
+		bankKeeper,
+		stakingKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	checkpointingKeeper := checkpointingkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[checkpointingtypes.StoreKey]),
+		privSigner.WrappedPV,
+		epochingKeeper,
+	)
+
+	// set proposal extension
+	proposalHandler := checkpointing.NewProposalHandler(
+		logger, &checkpointingKeeper, bApp.Mempool(), bApp)
+	proposalHandler.SetHandlers(bApp)
+
+	// set vote extension
+	voteExtHandler := checkpointing.NewVoteExtensionHandler(logger, &checkpointingKeeper)
+	voteExtHandler.SetHandlers(bApp)
+
+	// register streaming services
+	if err := bApp.RegisterStreamingServices(appOpts, keys); err != nil {
+		panic(err)
+	}
+
+	ak.ParamsKeeper = initParamsKeeper(
+		appCodec,
+		encodingConfig.Amino,
+		keys[paramstypes.StoreKey],
+		ak.tkeys[paramstypes.TStoreKey],
+	)
+
+	ak.ConsensusParamsKeeper = consensusparamkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[consensusparamtypes.StoreKey]),
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		runtime.EventService{},
+	)
+	bApp.SetParamStore(ak.ConsensusParamsKeeper.ParamsStore)
+
+	ak.CapabilityKeeper = capabilitykeeper.NewKeeper(
+		appCodec,
+		keys[capabilitytypes.StoreKey],
+		ak.memKeys[capabilitytypes.MemStoreKey],
+	)
+
+	// grant capabilities for the ibc and ibc-transfer modules
+	scopedIBCKeeper := ak.CapabilityKeeper.ScopeToModule(ibcexported.ModuleName)
+	scopedTransferKeeper := ak.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
+	scopedZoneConciergeKeeper := ak.CapabilityKeeper.ScopeToModule(zctypes.ModuleName)
+	scopedWasmKeeper := ak.CapabilityKeeper.ScopeToModule(wasmtypes.ModuleName)
+
+	// Applications that wish to enforce statically created ScopedKeepers should call `Seal` after creating
+	// their scoped modules in `NewApp` with `ScopeToModule`
+	ak.CapabilityKeeper.Seal()
+
+	// add keepers
+	ak.AccountKeeper = accountKeeper
+
+	ak.BankKeeper = bankKeeper
+
+	ak.StakingKeeper = stakingKeeper
+
+	ak.CircuitKeeper = circuitkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[circuittypes.StoreKey]),
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		ak.AccountKeeper.AddressCodec(),
+	)
+	bApp.SetCircuitBreaker(&ak.CircuitKeeper)
+
+	ak.MintKeeper = mintkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[minttypes.StoreKey]),
+		ak.StakingKeeper,
+		ak.AccountKeeper,
+		ak.BankKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	ak.DistrKeeper = distrkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[distrtypes.StoreKey]),
+		ak.AccountKeeper,
+		ak.BankKeeper,
+		ak.StakingKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	// set up incentive keeper
+	ak.IncentiveKeeper = incentivekeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[incentivetypes.StoreKey]),
+		ak.BankKeeper,
+		ak.AccountKeeper,
+		&epochingKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		authtypes.FeeCollectorName,
+	)
+
+	ak.SlashingKeeper = slashingkeeper.NewKeeper(
+		appCodec,
+		encodingConfig.Amino,
+		runtime.NewKVStoreService(keys[slashingtypes.StoreKey]),
+		ak.StakingKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	ak.CrisisKeeper = crisiskeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[crisistypes.StoreKey]),
+		invCheckPeriod,
+		ak.BankKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		ak.AccountKeeper.AddressCodec(),
+	)
+
+	ak.FeeGrantKeeper = feegrantkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[feegrant.StoreKey]),
+		ak.AccountKeeper,
+	)
+	// register the staking hooks
+	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
+	ak.StakingKeeper.SetHooks(
+		stakingtypes.NewMultiStakingHooks(ak.DistrKeeper.Hooks(), ak.SlashingKeeper.Hooks(), epochingKeeper.Hooks()),
+	)
+
+	// set the governance module account as the authority for conducting upgrades
+	ak.UpgradeKeeper = upgradekeeper.NewKeeper(
+		skipUpgradeHeights,
+		runtime.NewKVStoreService(keys[upgradetypes.StoreKey]),
+		appCodec,
+		homePath,
+		bApp,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	ak.AuthzKeeper = authzkeeper.NewKeeper(
+		runtime.NewKVStoreService(keys[authzkeeper.StoreKey]),
+		appCodec,
+		bApp.MsgServiceRouter(),
+		ak.AccountKeeper,
+	)
+
+	ak.IBCKeeper = ibckeeper.NewKeeper(
+		appCodec,
+		keys[ibcexported.StoreKey],
+		ak.GetSubspace(ibcexported.ModuleName),
+		ak.StakingKeeper,
+		ak.UpgradeKeeper,
+		scopedIBCKeeper,
+		// From 8.0.0 the IBC keeper requires an authority for the messages
+		// `MsgIBCSoftwareUpgrade` and `MsgRecoverClient`
+		// https://github.com/cosmos/ibc-go/releases/tag/v8.0.0
+		// Gov is the proper authority for those types of messages
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	// register the proposal types
+	// Deprecated: Avoid adding new handlers, instead use the new proposal flow
+	// by granting the governance module the right to execute the message.
+	// See: https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/x/gov/spec/01_concepts.md#proposal-messages
+	// TODO: investigate how to migrate to new proposal flow
+	govRouter := govv1beta1.NewRouter()
+	govRouter.AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
+		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(ak.ParamsKeeper))
+
+	// TODO: this should be a function parameter
+	govConfig := govtypes.DefaultConfig()
+	/*
+		Example of setting gov params:
+		govConfig.MaxMetadataLen = 10000
+	*/
+	govKeeper := govkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[govtypes.StoreKey]),
+		ak.AccountKeeper,
+		ak.BankKeeper,
+		ak.StakingKeeper,
+		ak.DistrKeeper,
+		bApp.MsgServiceRouter(),
+		govConfig,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String())
+
+	ak.GovKeeper = *govKeeper.SetHooks(
+		govtypes.NewMultiGovHooks(
+		// register the governance hooks
+		),
+	)
+
+	btclightclientKeeper := btclightclientkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[btclightclienttypes.StoreKey]),
+		*btcConfig,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	btcCheckpointKeeper := btccheckpointkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[btccheckpointtypes.StoreKey]),
+		ak.tkeys[btccheckpointtypes.TStoreKey],
+		&btclightclientKeeper,
+		&checkpointingKeeper,
+		&ak.IncentiveKeeper,
+		&powLimit,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	// create querier for KVStore
+	storeQuerier, ok := bApp.CommitMultiStore().(storetypes.Queryable)
+	if !ok {
+		panic(errorsmod.Wrap(sdkerrors.ErrUnknownRequest, "multistore doesn't support queries"))
+	}
+
+	ak.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
+		appCodec, keys[ibcfeetypes.StoreKey],
+		ak.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
+		ak.IBCKeeper.ChannelKeeper,
+		ak.IBCKeeper.PortKeeper, ak.AccountKeeper, ak.BankKeeper,
+	)
+
+	zcKeeper := zckeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[zctypes.StoreKey]),
+		ak.IBCFeeKeeper,
+		ak.IBCKeeper.ClientKeeper,
+		ak.IBCKeeper.ChannelKeeper,
+		ak.IBCKeeper.PortKeeper,
+		ak.AccountKeeper,
+		ak.BankKeeper,
+		&btclightclientKeeper,
+		&checkpointingKeeper,
+		&btcCheckpointKeeper,
+		epochingKeeper,
+		storeQuerier,
+		scopedZoneConciergeKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	ak.ZoneConciergeKeeper = *zcKeeper
+
+	// Create Transfer Keepers
+	ak.TransferKeeper = ibctransferkeeper.NewKeeper(
+		appCodec,
+		keys[ibctransfertypes.StoreKey],
+		ak.GetSubspace(ibctransfertypes.ModuleName),
+		ak.IBCFeeKeeper,
+		ak.IBCKeeper.ChannelKeeper,
+		ak.IBCKeeper.PortKeeper,
+		ak.AccountKeeper,
+		ak.BankKeeper,
+		scopedTransferKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	ak.MonitorKeeper = monitorkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[monitortypes.StoreKey]),
+		&btclightclientKeeper,
+	)
+
+	// add msgServiceRouter so that the epoching module can forward unwrapped messages to the staking module
+	epochingKeeper.SetMsgServiceRouter(bApp.MsgServiceRouter())
+	// make ZoneConcierge and Monitor to subscribe to the epoching's hooks
+	ak.EpochingKeeper = *epochingKeeper.SetHooks(
+		epochingtypes.NewMultiEpochingHooks(ak.ZoneConciergeKeeper.Hooks(), ak.MonitorKeeper.Hooks()),
+	)
+
+	// set up Checkpointing, BTCCheckpoint, and BTCLightclient keepers
+	ak.CheckpointingKeeper = *checkpointingKeeper.SetHooks(
+		checkpointingtypes.NewMultiCheckpointingHooks(ak.EpochingKeeper.Hooks(), ak.ZoneConciergeKeeper.Hooks(), ak.MonitorKeeper.Hooks()),
+	)
+	ak.BtcCheckpointKeeper = btcCheckpointKeeper
+	ak.BTCLightClientKeeper = *btclightclientKeeper.SetHooks(
+		btclightclienttypes.NewMultiBTCLightClientHooks(ak.BtcCheckpointKeeper.Hooks()),
+	)
+
+	// set up BTC staking keeper
+	ak.BTCStakingKeeper = btcstakingkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[btcstakingtypes.StoreKey]),
+		&btclightclientKeeper,
+		&btcCheckpointKeeper,
+		&checkpointingKeeper,
+		btcNetParams,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	// set up finality keeper
+	ak.FinalityKeeper = finalitykeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[finalitytypes.StoreKey]),
+		ak.BTCStakingKeeper,
+		ak.IncentiveKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	// create evidence keeper with router
+	evidenceKeeper := evidencekeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[evidencetypes.StoreKey]),
+		ak.StakingKeeper,
+		ak.SlashingKeeper,
+		ak.AccountKeeper.AddressCodec(),
+		runtime.ProvideCometInfoService(),
+	)
+	// If evidence needs to be handled for the app, set routes in router here and seal
+	ak.EvidenceKeeper = *evidenceKeeper
+
+	wasmOpts = append(owasm.RegisterCustomPlugins(&ak.EpochingKeeper, &ak.ZoneConciergeKeeper, &ak.BTCLightClientKeeper), wasmOpts...)
+
+	ak.WasmKeeper = wasmkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[wasmtypes.StoreKey]),
+		ak.AccountKeeper,
+		ak.BankKeeper,
+		ak.StakingKeeper,
+		distrkeeper.NewQuerier(ak.DistrKeeper),
+		ak.IBCFeeKeeper,
+		ak.IBCKeeper.ChannelKeeper,
+		ak.IBCKeeper.PortKeeper,
+		scopedWasmKeeper,
+		ak.TransferKeeper,
+		bApp.MsgServiceRouter(),
+		bApp.GRPCQueryRouter(),
+		homePath,
+		wasmConfig,
+		wasmCapabilities,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		wasmOpts...,
+	)
+
+	// Set legacy router for backwards compatibility with gov v1beta1
+	ak.GovKeeper.SetLegacyRouter(govRouter)
+
+	// Create all supported IBC routes
+	var transferStack porttypes.IBCModule
+	transferStack = transfer.NewIBCModule(ak.TransferKeeper)
+	transferStack = ibcfee.NewIBCMiddleware(transferStack, ak.IBCFeeKeeper)
+
+	var zoneConciergeStack porttypes.IBCModule
+	zoneConciergeStack = zoneconcierge.NewIBCModule(ak.ZoneConciergeKeeper)
+	zoneConciergeStack = ibcfee.NewIBCMiddleware(zoneConciergeStack, ak.IBCFeeKeeper)
+
+	var wasmStack porttypes.IBCModule
+	wasmStack = wasm.NewIBCHandler(ak.WasmKeeper, ak.IBCKeeper.ChannelKeeper, ak.IBCFeeKeeper)
+	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, ak.IBCFeeKeeper)
+
+	// Create static IBC router, add ibc-transfer module route, then set and seal it
+	ibcRouter := porttypes.NewRouter().
+		AddRoute(ibctransfertypes.ModuleName, transferStack).
+		AddRoute(zctypes.ModuleName, zoneConciergeStack).
+		AddRoute(wasmtypes.ModuleName, wasmStack)
+
+	// Setting Router will finalize all routes by sealing router
+	// No more routes can be added
+	ak.IBCKeeper.SetRouter(ibcRouter)
+}
+
+// initParamsKeeper init params keeper and its subspaces
+func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey storetypes.StoreKey) paramskeeper.Keeper {
+	paramsKeeper := paramskeeper.NewKeeper(appCodec, legacyAmino, key, tkey)
+
+	// TODO: Only modules which did not migrate yet to new way of hanldling params
+	// are the IBC-related modules. Once they are migrated, we can remove this and
+	// whole usage of params module
+	paramsKeeper.Subspace(ibcexported.ModuleName)
+	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
+	paramsKeeper.Subspace(zctypes.ModuleName)
+
+	return paramsKeeper
+}

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -1,0 +1,48 @@
+package keepers
+
+import (
+	storetypes "cosmossdk.io/store/types"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+)
+
+// GetSubspace gets existing substore from keeper.
+func (appKeepers *AppKeepers) GetSubspace(moduleName string) paramstypes.Subspace {
+	subspace, _ := appKeepers.ParamsKeeper.GetSubspace(moduleName)
+	return subspace
+}
+
+// GetKVStoreKey gets KV Store keys.
+func (appKeepers *AppKeepers) GetKVStoreKeys() map[string]*storetypes.KVStoreKey {
+	return appKeepers.keys
+}
+
+// GetTransientStoreKey gets Transient Store keys.
+func (appKeepers *AppKeepers) GetTransientStoreKeys() map[string]*storetypes.TransientStoreKey {
+	return appKeepers.tkeys
+}
+
+// GetMemoryStoreKey get memory Store keys.
+func (appKeepers *AppKeepers) GetMemoryStoreKeys() map[string]*storetypes.MemoryStoreKey {
+	return appKeepers.memKeys
+}
+
+// GetKey returns the KVStoreKey for the provided store key.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (appKeepers *AppKeepers) GetKey(storeKey string) *storetypes.KVStoreKey {
+	return appKeepers.keys[storeKey]
+}
+
+// GetTKey returns the TransientStoreKey for the provided store key.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (appKeepers *AppKeepers) GetTKey(storeKey string) *storetypes.TransientStoreKey {
+	return appKeepers.tkeys[storeKey]
+}
+
+// GetMemKey returns the MemStoreKey for the provided mem key.
+//
+// NOTE: This is solely used for testing purposes.
+func (appKeepers *AppKeepers) GetMemKey(storeKey string) *storetypes.MemoryStoreKey {
+	return appKeepers.memKeys[storeKey]
+}

--- a/app/keepers/utils.go
+++ b/app/keepers/utils.go
@@ -1,4 +1,4 @@
-package app
+package keepers
 
 import (
 	"bytes"

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/stretchr/testify/require"
 
+	appkeepers "github.com/babylonchain/babylon/app/keepers"
 	appparams "github.com/babylonchain/babylon/app/params"
 	"github.com/babylonchain/babylon/crypto/bls12381"
 	"github.com/babylonchain/babylon/privval"
@@ -46,7 +47,7 @@ type SetupOptions struct {
 	AppOpts            types.AppOptions
 }
 
-func setup(t *testing.T, ps *PrivSigner, withGenesis bool, invCheckPeriod uint) (*BabylonApp, GenesisState) {
+func setup(t *testing.T, ps *appkeepers.PrivSigner, withGenesis bool, invCheckPeriod uint) (*BabylonApp, GenesisState) {
 	db := dbm.NewMemDB()
 	nodeHome := t.TempDir()
 
@@ -80,7 +81,7 @@ func setup(t *testing.T, ps *PrivSigner, withGenesis bool, invCheckPeriod uint) 
 // Created Babylon application will have one validator with hardcoed amount of tokens.
 // This is necessary as from cosmos-sdk 0.46 it is required that there is at least
 // one validator in validator set during InitGenesis abci call - https://github.com/cosmos/cosmos-sdk/pull/9697
-func NewBabylonAppWithCustomOptions(t *testing.T, isCheckTx bool, privSigner *PrivSigner, options SetupOptions) *BabylonApp {
+func NewBabylonAppWithCustomOptions(t *testing.T, isCheckTx bool, privSigner *appkeepers.PrivSigner, options SetupOptions) *BabylonApp {
 	t.Helper()
 	// create validator set with single validator
 	valKeys, err := privval.NewValidatorKeys(ed25519.GenPrivKey(), bls12381.GenPrivKey())
@@ -245,7 +246,7 @@ func Setup(t *testing.T, isCheckTx bool) *BabylonApp {
 }
 
 // SetupTestPrivSigner sets up a PrivSigner for testing
-func SetupTestPrivSigner() (*PrivSigner, error) {
+func SetupTestPrivSigner() (*appkeepers.PrivSigner, error) {
 	// Create a temporary node directory
 	nodeDir, err := ioutils.TempDir("", "tmp-signer")
 	if err != nil {
@@ -254,7 +255,7 @@ func SetupTestPrivSigner() (*PrivSigner, error) {
 	defer func() {
 		_ = os.RemoveAll(nodeDir)
 	}()
-	privSigner, _ := InitPrivSigner(nodeDir)
+	privSigner, _ := appkeepers.InitPrivSigner(nodeDir)
 	return privSigner, nil
 }
 
@@ -263,7 +264,7 @@ func SetupTestPrivSigner() (*PrivSigner, error) {
 // of one consensus engine unit (10^6) in the default token of the babylon app from first genesis
 // account. A Nop logger is set in BabylonApp.
 // Note that the privSigner should be the 0th item of valSet
-func SetupWithGenesisValSet(t *testing.T, valSet []*checkpointingtypes.GenesisKey, privSigner *PrivSigner, genAccs []authtypes.GenesisAccount, balances ...banktypes.Balance) *BabylonApp {
+func SetupWithGenesisValSet(t *testing.T, valSet []*checkpointingtypes.GenesisKey, privSigner *appkeepers.PrivSigner, genAccs []authtypes.GenesisAccount, balances ...banktypes.Balance) *BabylonApp {
 	t.Helper()
 	app, genesisState := setup(t, privSigner, true, 5)
 	genesisState = genesisStateWithValSet(t, app, genesisState, valSet, genAccs, balances...)
@@ -296,7 +297,7 @@ func SetupWithGenesisValSet(t *testing.T, valSet []*checkpointingtypes.GenesisKe
 	return app
 }
 
-func GenesisKeyFromPrivSigner(ps *PrivSigner) (*checkpointingtypes.GenesisKey, error) {
+func GenesisKeyFromPrivSigner(ps *appkeepers.PrivSigner) (*checkpointingtypes.GenesisKey, error) {
 	valKeys, err := privval.NewValidatorKeys(ps.WrappedPV.GetValPrivKey(), ps.WrappedPV.GetBlsPrivKey())
 	if err != nil {
 		return nil, err

--- a/cmd/babylond/cmd/root.go
+++ b/cmd/babylond/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	confixcmd "cosmossdk.io/tools/confix/cmd"
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	appkeepers "github.com/babylonchain/babylon/app/keepers"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	cmtcli "github.com/cometbft/cometbft/libs/cli"
 	dbm "github.com/cosmos/cosmos-db"
@@ -274,7 +275,7 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts serverty
 	}
 
 	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
-	privSigner, err := app.InitPrivSigner(homeDir)
+	privSigner, err := appkeepers.InitPrivSigner(homeDir)
 	if err != nil {
 		panic(err)
 	}
@@ -313,7 +314,7 @@ func appExport(
 		return servertypes.ExportedApp{}, errors.New("application home not set")
 	}
 
-	privSigner, err := app.InitPrivSigner(homePath)
+	privSigner, err := appkeepers.InitPrivSigner(homePath)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/babylond/cmd/testnet.go
+++ b/cmd/babylond/cmd/testnet.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	appkeepers "github.com/babylonchain/babylon/app/keepers"
 	cmtconfig "github.com/cometbft/cometbft/config"
 	cmtos "github.com/cometbft/cometbft/libs/os"
 	cmttime "github.com/cometbft/cometbft/types/time"
@@ -35,7 +36,6 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/spf13/cobra"
 
-	"github.com/babylonchain/babylon/app"
 	appparams "github.com/babylonchain/babylon/app/params"
 	"github.com/babylonchain/babylon/privval"
 	"github.com/babylonchain/babylon/testutil/datagen"
@@ -321,7 +321,7 @@ func InitTestnet(
 		srvconfig.WriteConfigFile(filepath.Join(nodeDir, "config/app.toml"), babylonConfig)
 
 		// create and save client config
-		if _, err = app.CreateClientConfig(chainID, keyringBackend, nodeDir); err != nil {
+		if _, err = appkeepers.CreateClientConfig(chainID, keyringBackend, nodeDir); err != nil {
 			return err
 		}
 	}

--- a/test/e2e/initialization/init.go
+++ b/test/e2e/initialization/init.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/babylonchain/babylon/app"
+	appkeepers "github.com/babylonchain/babylon/app/keepers"
 	"github.com/babylonchain/babylon/test/e2e/util"
 )
 
@@ -42,7 +42,7 @@ func InitChain(id, dataDir string, nodeConfigs []*NodeConfig, votingPeriod, expe
 	}
 
 	for _, node := range chain.nodes {
-		_, _ = app.CreateClientConfig(node.chain.chainMeta.Id, "test", node.configDir())
+		_, _ = appkeepers.CreateClientConfig(node.chain.chainMeta.Id, "test", node.configDir())
 	}
 
 	return chain.export(), nil

--- a/testutil/datagen/genesiskey.go
+++ b/testutil/datagen/genesiskey.go
@@ -1,6 +1,11 @@
 package datagen
 
 import (
+	"github.com/babylonchain/babylon/app"
+	appkeepers "github.com/babylonchain/babylon/app/keepers"
+	"github.com/babylonchain/babylon/crypto/bls12381"
+	"github.com/babylonchain/babylon/privval"
+	checkpointingtypes "github.com/babylonchain/babylon/x/checkpointing/types"
 	cmtcrypto "github.com/cometbft/cometbft/crypto"
 	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -8,11 +13,6 @@ import (
 	cosmosed "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/babylonchain/babylon/app"
-	"github.com/babylonchain/babylon/crypto/bls12381"
-	"github.com/babylonchain/babylon/privval"
-	checkpointingtypes "github.com/babylonchain/babylon/x/checkpointing/types"
 )
 
 type GenesisValidators struct {
@@ -88,7 +88,7 @@ func GenesisValidatorSet(numVals int) (*GenesisValidators, error) {
 
 // GenesisValidatorSetWithPrivSigner generates a set with `numVals` genesis validators
 // along with the privSigner, which will be in the 0th position of the return validator set
-func GenesisValidatorSetWithPrivSigner(numVals int) (*GenesisValidators, *app.PrivSigner, error) {
+func GenesisValidatorSetWithPrivSigner(numVals int) (*GenesisValidators, *appkeepers.PrivSigner, error) {
 	ps, err := app.SetupTestPrivSigner()
 	if err != nil {
 		return nil, nil, err

--- a/testutil/helper/helper.go
+++ b/testutil/helper/helper.go
@@ -7,15 +7,15 @@ import (
 	"testing"
 
 	"cosmossdk.io/core/header"
+	appkeepers "github.com/babylonchain/babylon/app/keepers"
+	"github.com/babylonchain/babylon/crypto/bls12381"
+	"github.com/babylonchain/babylon/testutil/datagen"
+	checkpointingtypes "github.com/babylonchain/babylon/x/checkpointing/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	cosmosed "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	protoio "github.com/cosmos/gogoproto/io"
-
-	"github.com/babylonchain/babylon/crypto/bls12381"
-	"github.com/babylonchain/babylon/testutil/datagen"
-	checkpointingtypes "github.com/babylonchain/babylon/x/checkpointing/types"
 
 	"cosmossdk.io/math"
 	"github.com/cosmos/gogoproto/proto"
@@ -56,7 +56,7 @@ func NewHelper(t *testing.T) *Helper {
 
 // NewHelperWithValSet is same as NewHelper, except that it creates a set of validators
 // the privSigner is the 0th validator in valSet
-func NewHelperWithValSet(t *testing.T, valSet *datagen.GenesisValidators, privSigner *app.PrivSigner) *Helper {
+func NewHelperWithValSet(t *testing.T, valSet *datagen.GenesisValidators, privSigner *appkeepers.PrivSigner) *Helper {
 	// generate the genesis account
 	signerPubKey := privSigner.WrappedPV.Key.PubKey
 	acc := authtypes.NewBaseAccount(signerPubKey.Address().Bytes(), &cosmosed.PubKey{Key: signerPubKey.Bytes()}, 0, 0)
@@ -94,7 +94,7 @@ func NewHelperWithValSet(t *testing.T, valSet *datagen.GenesisValidators, privSi
 
 // NewHelperWithValSetNoSigner is same as NewHelperWithValSet, except that the privSigner is not
 // included in the validator set
-func NewHelperWithValSetNoSigner(t *testing.T, valSet *datagen.GenesisValidators, privSigner *app.PrivSigner) *Helper {
+func NewHelperWithValSetNoSigner(t *testing.T, valSet *datagen.GenesisValidators, privSigner *appkeepers.PrivSigner) *Helper {
 	// generate the genesis account
 	signerPubKey := privSigner.WrappedPV.Key.PubKey
 	acc := authtypes.NewBaseAccount(signerPubKey.Address().Bytes(), &cosmosed.PubKey{Key: signerPubKey.Bytes()}, 0, 0)


### PR DESCRIPTION
Closes #609 , step 1 of #698 

This PR refactors the `BabylonApp` to move all keepers into a new struct, including

- Creating a new struct `AppKeepers` that includes all keepers, under `app/keepers`. `BabylonApp` comprises `AppKeepers` such that no interface is changed.
- Moving keeper initialisation into `AppKeepers.InitKeepers` function. The function is parameterised such that all config entries remain in `app/` folder.

This is in line with Osmosis' [approach](https://github.com/osmosis-labs/osmosis/blob/5b92bcb75ca8f9caae83a2a928d2426afa822f82/app/keepers), for formalising [software upgrading](https://github.com/osmosis-labs/osmosis/blob/5796a3faf0411953163511e5635dd9a1c7a46613/app/upgrades) and for modularity. See #698 for more details.