### PR TITLE
epoching: test updating epoch interval

### DIFF
--- a/x/epoching/keeper/epochs.go
+++ b/x/epoching/keeper/epochs.go
@@ -120,13 +120,16 @@ func (k Keeper) RecordSealerBlockHashForEpoch(ctx context.Context) *types.Epoch 
 // IncEpoch adds epoch number by 1
 // CONTRACT: can only be invoked at the first block of an epoch
 func (k Keeper) IncEpoch(ctx context.Context) types.Epoch {
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	epochNumber := k.GetEpoch(ctx).EpochNumber
-	incrementedEpochNumber := epochNumber + 1
 
-	epochInterval := k.GetParams(ctx).EpochInterval
-	newEpoch := types.NewEpoch(incrementedEpochNumber, epochInterval, uint64(sdkCtx.HeaderInfo().Height), nil)
-	k.setEpochInfo(ctx, incrementedEpochNumber, &newEpoch)
+	params := k.GetParams(ctx)
+	epoch := k.GetEpoch(ctx)
+
+	newEpochNumber := epoch.EpochNumber + 1
+	epochInterval := params.EpochInterval
+	firstHeight := epoch.GetLastBlockHeight() + 1
+
+	newEpoch := types.NewEpoch(newEpochNumber, epochInterval, firstHeight, nil)
+	k.setEpochInfo(ctx, newEpochNumber, &newEpoch)
 
 	return newEpoch
 }

--- a/x/epoching/keeper/epochs_test.go
+++ b/x/epoching/keeper/epochs_test.go
@@ -89,8 +89,7 @@ func FuzzEpochs_UpdateEpochInterval(f *testing.F) {
 			h.Ctx, err = h.ApplyEmptyBlockWithVoteExtension(r)
 			require.NoError(t, err)
 		}
-		h.Ctx, err = h.ApplyEmptyBlockWithVoteExtension(r)
-		require.NoError(t, err)
+		keeper.IncEpoch(h.Ctx)
 
 		// ensure
 		// - the epoch has incremented
@@ -99,7 +98,7 @@ func FuzzEpochs_UpdateEpochInterval(f *testing.F) {
 		newEpoch := keeper.GetEpoch(h.Ctx)
 		require.Equal(t, epoch.EpochNumber+1, newEpoch.EpochNumber)
 		require.Equal(t, newEpochInterval, newEpoch.CurrentEpochInterval)
-		require.Equal(t, uint64(h.Ctx.HeaderInfo().Height), newEpoch.FirstBlockHeight)
-		require.Equal(t, uint64(h.Ctx.HeaderInfo().Height)+newEpochInterval-1, newEpoch.GetLastBlockHeight())
+		require.Equal(t, epoch.GetLastBlockHeight()+1, newEpoch.FirstBlockHeight)
+		require.Equal(t, epoch.GetLastBlockHeight()+newEpochInterval, newEpoch.GetLastBlockHeight())
 	})
 }

--- a/x/epoching/keeper/epochs_test.go
+++ b/x/epoching/keeper/epochs_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/babylonchain/babylon/testutil/datagen"
 	testhelper "github.com/babylonchain/babylon/testutil/helper"
+	"github.com/babylonchain/babylon/x/epoching/types"
 )
 
 func FuzzEpochs(f *testing.F) {
@@ -23,11 +24,10 @@ func FuzzEpochs(f *testing.F) {
 		require.Equal(t, epoch.EpochNumber, uint64(1))
 		require.Equal(t, epoch.FirstBlockHeight, uint64(1))
 
-		// set a random epoch interval
 		epochInterval := keeper.GetParams(ctx).EpochInterval
 
 		// increment a random number of new blocks
-		numIncBlocks := r.Uint64()%1000 + 1
+		numIncBlocks := r.Uint64()%100 + 1
 		var err error
 		for i := uint64(0); i < numIncBlocks-1; i++ {
 			// TODO: Figure out why when ctx height is 1, ApplyEmptyBlockWithVoteExtension
@@ -45,5 +45,57 @@ func FuzzEpochs(f *testing.F) {
 		require.Equal(t, expectedEpochNumber, actualNewEpoch.EpochNumber)
 		require.Equal(t, epochInterval, actualNewEpoch.CurrentEpochInterval)
 		require.Equal(t, (expectedEpochNumber-1)*epochInterval+1, actualNewEpoch.FirstBlockHeight)
+	})
+}
+
+func FuzzEpochs_UpdateEpochInterval(f *testing.F) {
+	datagen.AddRandomSeedsToFuzzer(f, 10)
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+
+		h := testhelper.NewHelper(t)
+		keeper := h.App.EpochingKeeper
+
+		// increment a random number of new blocks
+		numIncBlocks := r.Uint64()%100 + 1
+		var err error
+		for i := uint64(0); i < numIncBlocks-1; i++ {
+			// When ctx height is 1, ApplyEmptyBlockWithVoteExtension
+			// will still give ctx height 1 once, then start to increment
+			_, err = h.ApplyEmptyBlockWithVoteExtension(r)
+			require.NoError(t, err)
+		}
+		// get current epoch metadata
+		epoch := keeper.GetEpoch(h.Ctx)
+
+		// update the epoch interval in params
+		newEpochInterval := datagen.RandomInt(r, 20) + 2
+		newParams := types.Params{EpochInterval: newEpochInterval}
+		err = keeper.SetParams(h.Ctx, newParams)
+		require.NoError(t, err)
+
+		// ensure the current epoch metadata is not affected
+		epoch2 := keeper.GetEpoch(h.Ctx)
+		require.Equal(t, epoch, epoch2)
+
+		// enter the last block of the current epoch
+		lastHeightOfEpoch := epoch.GetLastBlockHeight()
+		for uint64(h.Ctx.HeaderInfo().Height) < lastHeightOfEpoch {
+			_, err = h.ApplyEmptyBlockWithVoteExtension(r)
+			require.NoError(t, err)
+		}
+		// enter the next block and thus 1st block of the next epoch
+		_, err = h.ApplyEmptyBlockWithVoteExtension(r)
+		require.NoError(t, err)
+		// ensure
+		// - the epoch has incremented
+		// - epoch interval is updated
+		// - first/last height of the epoch is correct
+		newEpoch := keeper.GetEpoch(h.Ctx)
+		require.Equal(t, epoch.EpochNumber+1, newEpoch.EpochNumber)
+		require.Equal(t, newEpochInterval, newEpoch.CurrentEpochInterval)
+		require.Equal(t, uint64(h.Ctx.HeaderInfo().Height), newEpoch.FirstBlockHeight)
+		require.Equal(t, uint64(h.Ctx.HeaderInfo().Height)+newEpochInterval-1, newEpoch.GetLastBlockHeight())
 	})
 }


### PR DESCRIPTION
This PR adds a test case to test updating the epoch interval in the middle of execution. In particular, it lets the chain run for a random number of blocks, update the epoch interval, ensure the current epoch metadata is not affected, and ensure the next epoch metadata is updated.

NOTE: Will try to do an e2e test for this as well.