### PR TITLE
chore: e2e build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,7 +427,8 @@ dockerNetworkList=$($(DOCKER) network ls --filter name=bbn-testnet --format {{.I
 build-docker: ## Build babylond Docker image
 	$(MAKE) -C contrib/images babylond
 
-build-docker-e2e: build-docker
+build-docker-e2e:
+	$(MAKE) -C contrib/images babylond-e2e
 	$(MAKE) -C contrib/images babylond-before-upgrade
 	$(MAKE) -C contrib/images e2e-init-chain
 

--- a/app/app.go
+++ b/app/app.go
@@ -94,7 +94,6 @@ import (
 	"github.com/spf13/cast"
 
 	"github.com/babylonchain/babylon/app/upgrades"
-	"github.com/babylonchain/babylon/app/upgrades/vanilla"
 	bbn "github.com/babylonchain/babylon/types"
 
 	appkeepers "github.com/babylonchain/babylon/app/keepers"
@@ -159,11 +158,8 @@ var (
 	}
 
 	// software upgrades and forks
-	// TODO: REMOVE UPGRADE BEFORE MAINNET, used for e2e testing
-	Upgrades = []upgrades.Upgrade{
-		vanilla.Upgrade,
-	}
-	Forks = []upgrades.Fork{}
+	Upgrades = []upgrades.Upgrade{}
+	Forks    = []upgrades.Fork{}
 )
 
 func init() {

--- a/app/e2e_include_upgrades.go
+++ b/app/e2e_include_upgrades.go
@@ -1,0 +1,9 @@
+//go:build e2e
+
+package app
+
+import "github.com/babylonchain/babylon/app/upgrades/vanilla"
+
+func init() {
+	Upgrades = append(Upgrades, vanilla.Upgrade)
+}

--- a/contrib/images/Makefile
+++ b/contrib/images/Makefile
@@ -7,6 +7,10 @@ all: babylond cosmos-relayer
 babylond: babylond-rmi
 	docker build --tag babylonchain/babylond -f babylond/Dockerfile ${BABYLON_FULL_PATH}
 
+babylond-e2e: babylond-rmi
+	docker build --tag babylonchain/babylond -f babylond/Dockerfile ${BABYLON_FULL_PATH} \
+		--build-arg BUILD_TAGS="e2e"
+
 babylond-before-upgrade:
 	docker rmi babylonchain/babylond-before-upgrade 2>/dev/null; true && \
 	docker build --tag babylonchain/babylond-before-upgrade -f babylond/Dockerfile \

--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -6,6 +6,7 @@ ARG VERSION
 ARG LEDGER_ENABLED="false"
 # Cosmos build options
 ARG COSMOS_BUILD_OPTIONS=""
+ARG BUILD_TAGS=""
 
 # Install cli tools for building and final image
 RUN apt-get update && apt-get install -y make git bash gcc curl jq


### PR DESCRIPTION
- Removed vanilla upgrade from usual build
- Add new file `app/e2e_include_upgrades.go` that is included if there is a build tag e2e and adds the vanilla upgrade to the list of upgrades