### PR TITLE
fix typos in documentation files

### DIFF
--- a/docs/transaction-impl-spec.md
+++ b/docs/transaction-impl-spec.md
@@ -156,7 +156,7 @@ will be put in `unbonding_script` and `slashing_script`.
 - `covenant_committee_quorum` - it can be retrieved from
 `global_parameters.covenant_quorum`. It is quorum of covenant committee
 member required to authorize spending using `unbonding_script` or `slashing_script`
-- `staking_amout` - chosen by the user, it will be placed in `staking_output.value`
+- `staking_amount` - chosen by the user, it will be placed in `staking_output.value`
 - `btc_network` - btc network on which staking transactions will take place
 
 #### Building OP_RETRUN and staking output implementation

--- a/test/e2e/initialization/README.md
+++ b/test/e2e/initialization/README.md
@@ -5,4 +5,4 @@
 This package contains all logic necessary for initializing configuration
 data either for a new chain or a single node via Docker containers.
 
-Heavily based on Osmois init pacakage.
+Heavily based on Osmosis init package.

--- a/x/finality/README.md
+++ b/x/finality/README.md
@@ -293,7 +293,7 @@ Upon `MsgAddFinalitySig`, a Babylon node will execute as follows:
 ### MsgUpdateParams
 
 The `MsgUpdateParams` message is used for updating the module parameters for the
-Finality module. It can only be executed via a govenance proposal.
+Finality module. It can only be executed via a governance proposal.
 
 ```protobuf
 // MsgUpdateParams defines a message for updating finality module parameters.


### PR DESCRIPTION
![Image 1](https://github.com/user-attachments/assets/8fee0cb7-6bea-4dac-851b-295346dac9d7)

![Image 2](https://github.com/user-attachments/assets/b453811e-2db4-43d3-b86c-4590ff7e3465)

![Image 3](https://github.com/user-attachments/assets/84b6faea-d88a-45d9-9727-775e6e4969a0)
