### PR TITLE
chore: fix the name of func calculateMinimumUnbondingValue

### DIFF
--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -147,9 +147,9 @@ func (ms msgServer) EditFinalityProvider(ctx context.Context, req *types.MsgEdit
 	return &types.MsgEditFinalityProviderResponse{}, nil
 }
 
-// caluculateMinimumUnbondingValue calculates minimum unbonding value basend on current staking output value
+// calculateMinimumUnbondingValue calculates minimum unbonding value basend on current staking output value
 // and params.MinUnbondingRate
-func caluculateMinimumUnbondingValue(
+func calculateMinimumUnbondingValue(
 	stakingOutput *wire.TxOut,
 	params *types.Params,
 ) btcutil.Amount {


### PR DESCRIPTION
Fixed the name for the function calculateMinimumUnbondingValue in the btc-staking