### PR TITLE
Fix Typos in Staking Script Documentation 

### DIFF
--- a/docs/staking-script.md
+++ b/docs/staking-script.md
@@ -253,7 +253,7 @@ It is used in following way:
 The main difference between the unbonding and slashing paths is the existence of
 `FinalityProviderPk` in the slashing path.
 
-This leads to following system wide repercussions:
+This leads to following system-wide repercussions:
 
 - for staking request to become active, btc staker needs to provide valid
   unbonding transaction in this staking request. This staking request will become

--- a/docs/staking-script.md
+++ b/docs/staking-script.md
@@ -39,7 +39,7 @@ in staking scripts. Note that a staking transaction can be funded from
 arbitrary UTXO, including those owned by multisig/MPC/threshold accounts.
 Thus, `<StakerPk>` is not necessarily the address of the source of the fund.
 Rather, it is the controller and beneficiary of the stake after its creation.
-- **Finality Provider**: A Finality Provider is the an entity that votes
+- **Finality Provider**: A Finality Provider is an entity that votes
 in the finality round to provide security assurance to the PoS chain.
 
 The Bitcoin staker can choose a specific Finality Provider to delegate


### PR DESCRIPTION
This pull request corrects two grammatical issues in the `staking-script.md` file:  

1. Changed "the an" to "an" for proper article usage in the **Finality Provider** section.  
2. Updated "system wide" to "system-wide" for correct hyphenation when used as an adjective.  

### Motivation  
Ensuring clarity and grammatical correctness in the documentation enhances its readability and professionalism.  

### Changes  
- **File**: `docs/staking-script.md`  
  - Two additions and two deletions to fix grammar and hyphenation issues.  

### Testing  
No functional changes—only documentation updates.
