### PR TITLE
fix typo in method name in crypto/schnorr_adaptor_signature

### DIFF
--- a/crypto/schnorr-adaptor-signature/keys.go
+++ b/crypto/schnorr-adaptor-signature/keys.go
@@ -13,7 +13,7 @@ type DecryptionKey struct {
 	btcec.ModNScalar
 }
 
-func NewDecyptionKeyFromModNScalar(scalar *btcec.ModNScalar) (*DecryptionKey, error) {
+func NewDecryptionKeyFromModNScalar(scalar *btcec.ModNScalar) (*DecryptionKey, error) {
 	if scalar.IsZero() {
 		return nil, fmt.Errorf("the given scalar is zero")
 	}
@@ -29,11 +29,11 @@ func NewDecyptionKeyFromModNScalar(scalar *btcec.ModNScalar) (*DecryptionKey, er
 	return &DecryptionKey{*scalar}, nil
 }
 
-func NewDecyptionKeyFromBTCSK(btcSK *btcec.PrivateKey) (*DecryptionKey, error) {
-	return NewDecyptionKeyFromModNScalar(&btcSK.Key)
+func NewDecryptionKeyFromBTCSK(btcSK *btcec.PrivateKey) (*DecryptionKey, error) {
+	return NewDecryptionKeyFromModNScalar(&btcSK.Key)
 }
 
-func NewDecyptionKeyFromBytes(decKeyBytes []byte) (*DecryptionKey, error) {
+func NewDecryptionKeyFromBytes(decKeyBytes []byte) (*DecryptionKey, error) {
 	if len(decKeyBytes) != ModNScalarSize {
 		return nil, fmt.Errorf(
 			"the length of the given bytes for decryption key is incorrect (expected: %d, actual: %d)",
@@ -45,7 +45,7 @@ func NewDecyptionKeyFromBytes(decKeyBytes []byte) (*DecryptionKey, error) {
 	var decKeyScalar btcec.ModNScalar
 	decKeyScalar.SetByteSlice(decKeyBytes) //nolint:errcheck
 
-	return NewDecyptionKeyFromModNScalar(&decKeyScalar)
+	return NewDecryptionKeyFromModNScalar(&decKeyScalar)
 }
 
 func (dk *DecryptionKey) GetEncKey() *EncryptionKey {
@@ -119,7 +119,7 @@ func GenKeyPair() (*EncryptionKey, *DecryptionKey, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	dk, err := NewDecyptionKeyFromBTCSK(sk)
+	dk, err := NewDecryptionKeyFromBTCSK(sk)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/crypto/schnorr-adaptor-signature/keys_test.go
+++ b/crypto/schnorr-adaptor-signature/keys_test.go
@@ -35,7 +35,7 @@ func FuzzKeyGen(f *testing.F) {
 		actualEncKey, err = asig.NewEncryptionKeyFromBTCPK(btcPK)
 		require.NoError(t, err)
 		require.Equal(t, encKey, actualEncKey)
-		actualDecKey, err := asig.NewDecyptionKeyFromBTCSK(btcSK)
+		actualDecKey, err := asig.NewDecryptionKeyFromBTCSK(btcSK)
 		require.NoError(t, err)
 		require.Equal(t, decKey, actualDecKey)
 	})
@@ -61,7 +61,7 @@ func FuzzKeySerialization(f *testing.F) {
 
 		// roundtrip of serialising/deserialising decKey
 		decKeyBytes := decKey.ToBytes()
-		actualDecKey, err := asig.NewDecyptionKeyFromBytes(decKeyBytes)
+		actualDecKey, err := asig.NewDecryptionKeyFromBytes(decKeyBytes)
 		require.NoError(t, err)
 		require.Equal(t, decKey, actualDecKey)
 	})

--- a/x/btcstaking/keeper/msg_server_test.go
+++ b/x/btcstaking/keeper/msg_server_test.go
@@ -504,7 +504,7 @@ func FuzzSelectiveSlashing_StakingTx(f *testing.F) {
 		h.NoError(err)
 
 		// finality provider decrypts the covenant signature
-		decKey, err := asig.NewDecyptionKeyFromBTCSK(fpSK)
+		decKey, err := asig.NewDecryptionKeyFromBTCSK(fpSK)
 		h.NoError(err)
 		decryptedCovenantSig := bbn.NewBIP340SignatureFromBTCSig(covASig.Decrypt(decKey))
 

--- a/x/btcstaking/types/btc_slashing_tx.go
+++ b/x/btcstaking/types/btc_slashing_tx.go
@@ -277,7 +277,7 @@ func (tx *BTCSlashingTx) BuildSlashingTxWithWitness(
 	*/
 	// decrypt covenant adaptor signature to Schnorr signature using finality provider's SK,
 	// then marshal
-	decKey, err := asig.NewDecyptionKeyFromBTCSK(fpSK)
+	decKey, err := asig.NewDecryptionKeyFromBTCSK(fpSK)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get decryption key from BTC SK: %w", err)
 	}

--- a/x/btcstaking/types/btc_slashing_tx_test.go
+++ b/x/btcstaking/types/btc_slashing_tx_test.go
@@ -46,7 +46,7 @@ func FuzzSlashingTx_VerifySigAndASig(f *testing.F) {
 		// use a random fp SK/PK
 		fpIdx := int(datagen.RandomInt(r, numRestakedFPs))
 		fpSK, fpPK := fpSKs[fpIdx], fpPKs[fpIdx]
-		decKey, err := asig.NewDecyptionKeyFromBTCSK(fpSK)
+		decKey, err := asig.NewDecryptionKeyFromBTCSK(fpSK)
 		require.NoError(t, err)
 		encKey, err := asig.NewEncryptionKeyFromBTCPK(fpPK)
 		require.NoError(t, err)
@@ -144,7 +144,7 @@ func FuzzSlashingTxWithWitness(f *testing.F) {
 		fpSK, fpPK := fpSKs[fpIdx], fpPKs[fpIdx]
 		encKey, err := asig.NewEncryptionKeyFromBTCPK(fpPK)
 		require.NoError(t, err)
-		decKey, err := asig.NewDecyptionKeyFromBTCSK(fpSK)
+		decKey, err := asig.NewDecryptionKeyFromBTCSK(fpSK)
 		require.NoError(t, err)
 
 		delSK, _, err := datagen.GenRandomBTCKeyPair(r)

--- a/x/btcstaking/types/btc_undelegation_test.go
+++ b/x/btcstaking/types/btc_undelegation_test.go
@@ -33,7 +33,7 @@ func FuzzBTCUndelegation_SlashingTx(f *testing.F) {
 		// a random finality provider gets slashed
 		slashedFPIdx := int(datagen.RandomInt(r, numRestakedFPs))
 		fpSK, fpPK := fpSKs[slashedFPIdx], fpPKs[slashedFPIdx]
-		decKey, err := asig.NewDecyptionKeyFromBTCSK(fpSK)
+		decKey, err := asig.NewDecryptionKeyFromBTCSK(fpSK)
 		require.NoError(t, err)
 		encKey, err := asig.NewEncryptionKeyFromBTCPK(fpPK)
 		require.NoError(t, err)


### PR DESCRIPTION
Fixing a typo in `schnorr_adaptor_signature` package:
`NewDecyptionKeyFromModNScalar`
`NewDecyptionKeyFromBTCSK`
`NewDecyptionKeyFromModNScalar`