### PR TITLE
fix Twitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Unlocking 21 Million ₿ to Secure the Decentralized Economy
 
 [![Website](https://badgen.net/badge/icon/Website?label=)](https://babylonchain.io)
-[![Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label)](https://twitter.com/babylon_chain)
+[![Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label)](https://x.com/babylonlabs_io)
 [![Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.com/invite/babylonglobal)
 [![Medium](https://badgen.net/badge/icon/medium?icon=medium&label)](https://medium.com/babylonchain-io)
 


### PR DESCRIPTION
The current Twitter hyperlink goes to (https://x.com/babylon_chain) which incorrect.
The correct Babylon Twitter account link is (https://x.com/babylonlabs_io).